### PR TITLE
Implement core engine types and state machine

### DIFF
--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -1,0 +1,102 @@
+// --- Content Types ---
+// Represents generated learning content: explanations and questions.
+// Question types match OpenQuizzer's proven set.
+
+// --- Explanations ---
+
+export type Explanation = {
+  type: 'explanation';
+  topicId: string;
+  title: string;
+  content: string; // markdown text, 2-3 paragraphs
+};
+
+// --- Question Types ---
+// These mirror OpenQuizzer's 5 question types.
+
+export type MultipleChoiceQuestion = {
+  type: 'multiple-choice';
+  id: string;
+  topicId: string;
+  question: string;
+  options: string[];
+  correctIndex: number;
+};
+
+export type NumericInputQuestion = {
+  type: 'numeric-input';
+  id: string;
+  topicId: string;
+  question: string;
+  correctValue: number;
+  tolerance?: number; // absolute tolerance, default 0
+  unit?: string;
+};
+
+export type OrderingQuestion = {
+  type: 'ordering';
+  id: string;
+  topicId: string;
+  question: string;
+  items: string[];
+  correctOrder: number[]; // indices into items[] in correct sequence
+};
+
+export type MultiSelectQuestion = {
+  type: 'multi-select';
+  id: string;
+  topicId: string;
+  question: string;
+  options: string[];
+  correctIndices: number[];
+};
+
+export type TwoStageQuestion = {
+  type: 'two-stage';
+  id: string;
+  topicId: string;
+  question: string;
+  options: string[];
+  correctIndex: number;
+  followUp: string;
+  followUpOptions: string[];
+  followUpCorrectIndex: number;
+};
+
+export type Question =
+  | MultipleChoiceQuestion
+  | NumericInputQuestion
+  | OrderingQuestion
+  | MultiSelectQuestion
+  | TwoStageQuestion;
+
+export type QuestionType = Question['type'];
+
+// --- Content Items ---
+// A content item is either an explanation or a question.
+// The engine emits these in the content/quiz loop order.
+
+export type ContentItem = Explanation | Question;
+
+// --- Answers ---
+
+export type StudentAnswer =
+  | { type: 'multiple-choice'; selectedIndex: number }
+  | { type: 'numeric-input'; value: number }
+  | { type: 'ordering'; order: number[] }
+  | { type: 'multi-select'; selectedIndices: number[] }
+  | {
+      type: 'two-stage';
+      selectedIndex: number;
+      followUpSelectedIndex: number;
+    };
+
+export type AnswerResult = {
+  correct: boolean;
+  questionId: string;
+  topicId: string;
+  userAnswer: StudentAnswer;
+  // Additional context the UI needs to render the result
+  correctAnswer: string; // human-readable description of the correct answer
+  explanation?: string; // optional explanation of why
+};

--- a/packages/engine/src/curriculum/types.ts
+++ b/packages/engine/src/curriculum/types.ts
@@ -1,0 +1,21 @@
+// --- Curriculum Types ---
+// Represents the structured plan produced by analyzing a syllabus.
+
+export type Topic = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+export type Section = {
+  id: string;
+  title: string;
+  topics: Topic[];
+  order: number;
+};
+
+export type CurriculumPlan = {
+  title: string;
+  description: string;
+  sections: Section[];
+};

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -5,17 +5,36 @@
 // the UI consumes these events and never reaches back into the engine.
 
 import { EventEmitter } from './events.js';
-import type { CourseEngineConfig, EngineSnapshot, EngineState } from './types.js';
+import { InvalidTransitionError } from './errors.js';
+import type {
+  CourseEngineConfig,
+  EngineSnapshot,
+  EngineState,
+  CurriculumPlan,
+  ContentItem,
+  AnswerResult,
+  StudentState,
+  SessionProgress,
+} from './types.js';
+import type { StudentAnswer, Question } from '../content/types.js';
+import type { Section } from '../curriculum/types.js';
 
-const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_VERSION = 2;
+const GAP_THRESHOLD = 0.5; // topics below this mastery score are "gaps"
 
 export class CourseEngine extends EventEmitter {
   #state: EngineState = 'idle';
   #config: CourseEngineConfig;
+  #curriculum: CurriculumPlan | null = null;
+  #currentSectionIndex = -1;
+  #currentItemIndex = -1;
+  #sectionItems: ContentItem[] = [];
+  #studentState: StudentState = { masteryByTopic: {}, gaps: [] };
+  #lastAnswerResult: AnswerResult | null = null;
+
   constructor(config: CourseEngineConfig) {
     super();
     this.#config = { ...config };
-    this.#setState('ready');
   }
 
   // --- State ---
@@ -24,13 +43,359 @@ export class CourseEngine extends EventEmitter {
     return this.#state;
   }
 
+  get curriculum(): CurriculumPlan | null {
+    return this.#curriculum;
+  }
+
+  get currentSection(): Section | null {
+    if (!this.#curriculum || this.#currentSectionIndex < 0) return null;
+    return this.#curriculum.sections[this.#currentSectionIndex] ?? null;
+  }
+
+  get currentItem(): ContentItem | null {
+    if (this.#currentItemIndex < 0) return null;
+    return this.#sectionItems[this.#currentItemIndex] ?? null;
+  }
+
+  get studentState(): StudentState {
+    // Return a defensive copy so callers can't mutate internal state
+    return {
+      masteryByTopic: { ...this.#studentState.masteryByTopic },
+      gaps: [...this.#studentState.gaps],
+    };
+  }
+
+  get sessionProgress(): SessionProgress {
+    const totalSections = this.#curriculum?.sections.length ?? 0;
+    const masteries = Object.values(this.#studentState.masteryByTopic);
+    const overallMastery =
+      masteries.length > 0
+        ? masteries.reduce((sum, m) => sum + m.score, 0) / masteries.length
+        : 0;
+
+    return {
+      currentSectionIndex: this.#currentSectionIndex,
+      totalSections,
+      currentItemIndex: this.#currentItemIndex,
+      totalItemsInSection: this.#sectionItems.length,
+      overallMastery,
+    };
+  }
+
+  // --- State Transitions ---
+
   #setState(newState: EngineState): void {
     const from = this.#state;
     this.#state = newState;
     this.emit('stateChange', { from, to: newState });
+  }
 
-    if (newState === 'ready') {
-      this.emit('ready', { state: newState });
+  #requireState(action: string, ...validStates: EngineState[]): void {
+    if (!validStates.includes(this.#state)) {
+      throw new InvalidTransitionError(action, this.#state);
+    }
+  }
+
+  // --- Syllabus Loading ---
+  // In the full implementation, this calls the LLM to analyze the syllabus.
+  // For now, it accepts a pre-built CurriculumPlan directly.
+
+  loadCurriculum(curriculum: CurriculumPlan): void {
+    this.#requireState('loadCurriculum', 'idle');
+
+    this.#curriculum = {
+      ...curriculum,
+      sections: curriculum.sections.map((s) => ({
+        ...s,
+        topics: [...s.topics],
+      })),
+    };
+
+    // Initialize mastery for all topics
+    for (const section of this.#curriculum.sections) {
+      for (const topic of section.topics) {
+        this.#studentState.masteryByTopic[topic.id] = {
+          topicId: topic.id,
+          score: 0,
+          questionsAnswered: 0,
+          questionsCorrect: 0,
+        };
+      }
+    }
+
+    this.#setState('ready');
+    this.emit('syllabusLoaded', { curriculum: this.#curriculum });
+  }
+
+  // --- Section Lifecycle ---
+
+  startSection(sectionId: string): void {
+    this.#requireState('startSection', 'ready', 'sectionComplete');
+
+    if (!this.#curriculum) {
+      throw new InvalidTransitionError('startSection', 'no curriculum loaded');
+    }
+
+    const sectionIndex = this.#curriculum.sections.findIndex((s) => s.id === sectionId);
+    if (sectionIndex === -1) {
+      throw new InvalidTransitionError(
+        'startSection',
+        `section "${sectionId}" not found`
+      );
+    }
+
+    this.#currentSectionIndex = sectionIndex;
+    this.#currentItemIndex = -1;
+    this.#sectionItems = [];
+    this.#lastAnswerResult = null;
+
+    const section = this.#curriculum.sections[sectionIndex];
+    this.#setState('loading');
+    this.emit('sectionStart', {
+      section,
+      sectionIndex,
+      totalSections: this.#curriculum.sections.length,
+    });
+  }
+
+  // --- Content Loading ---
+  // Called by the content generator after it produces items for the section.
+  // This is the bridge between the async LLM call and the engine state machine.
+
+  setSectionContent(items: ContentItem[]): void {
+    this.#requireState('setSectionContent', 'loading');
+
+    this.#sectionItems = items.map((item) => ({ ...item }));
+    this.#currentItemIndex = 0;
+
+    const section = this.currentSection!;
+    this.emit('contentReady', { items: this.#sectionItems, section });
+
+    this.#setState('practicing');
+    this.#emitCurrentItem();
+  }
+
+  // --- Student Interaction ---
+
+  submitAnswer(answer: StudentAnswer): AnswerResult {
+    this.#requireState('submitAnswer', 'practicing');
+
+    const item = this.currentItem;
+    if (!item || item.type === 'explanation') {
+      throw new InvalidTransitionError('submitAnswer', 'current item is not a question');
+    }
+
+    const result = this.#gradeAnswer(item, answer);
+    this.#lastAnswerResult = result;
+
+    // Update mastery
+    this.#updateMastery(result);
+
+    this.#setState('answered');
+    this.emit('answerResult', {
+      result,
+      studentState: this.studentState,
+      progress: this.sessionProgress,
+    });
+
+    return result;
+  }
+
+  nextItem(): void {
+    this.#requireState('nextItem', 'answered', 'practicing');
+
+    // In 'practicing' state, nextItem is only valid if current item is an explanation
+    if (this.#state === 'practicing') {
+      const item = this.currentItem;
+      if (item && item.type !== 'explanation') {
+        throw new InvalidTransitionError(
+          'nextItem',
+          'must answer the current question before advancing'
+        );
+      }
+    }
+
+    this.#currentItemIndex++;
+    this.#lastAnswerResult = null;
+
+    // Check if section is complete
+    if (this.#currentItemIndex >= this.#sectionItems.length) {
+      this.#completeSection();
+      return;
+    }
+
+    this.#setState('practicing');
+    this.#emitCurrentItem();
+  }
+
+  skipQuestion(): void {
+    this.#requireState('skipQuestion', 'practicing');
+
+    const item = this.currentItem;
+    if (!item || item.type === 'explanation') {
+      throw new InvalidTransitionError('skipQuestion', 'current item is not a question');
+    }
+
+    this.#currentItemIndex++;
+    this.#lastAnswerResult = null;
+
+    if (this.#currentItemIndex >= this.#sectionItems.length) {
+      this.#completeSection();
+      return;
+    }
+
+    // Stay in practicing, show next item
+    this.#emitCurrentItem();
+  }
+
+  nextSection(): void {
+    this.#requireState('nextSection', 'sectionComplete');
+
+    if (!this.#curriculum) {
+      throw new InvalidTransitionError('nextSection', 'no curriculum loaded');
+    }
+
+    const nextIndex = this.#currentSectionIndex + 1;
+    if (nextIndex >= this.#curriculum.sections.length) {
+      // Course is complete
+      this.#setState('complete');
+      this.emit('courseComplete', {
+        studentState: this.studentState,
+        progress: this.sessionProgress,
+      });
+      return;
+    }
+
+    const nextSection = this.#curriculum.sections[nextIndex];
+    this.startSection(nextSection.id);
+  }
+
+  // --- Internal Helpers ---
+
+  #emitCurrentItem(): void {
+    const item = this.currentItem;
+    if (!item) return;
+
+    this.emit('itemShow', {
+      item,
+      itemIndex: this.#currentItemIndex,
+      totalItems: this.#sectionItems.length,
+    });
+  }
+
+  #completeSection(): void {
+    const section = this.currentSection!;
+    this.#setState('sectionComplete');
+    this.emit('sectionComplete', {
+      section,
+      studentState: this.studentState,
+      progress: this.sessionProgress,
+    });
+  }
+
+  #updateMastery(result: AnswerResult): void {
+    const topicId = result.topicId;
+    const mastery = this.#studentState.masteryByTopic[topicId];
+    if (!mastery) return;
+
+    mastery.questionsAnswered++;
+    if (result.correct) {
+      mastery.questionsCorrect++;
+      mastery.score = Math.min(1, mastery.score + 0.15);
+    } else {
+      mastery.score = Math.max(0, mastery.score - 0.1);
+    }
+
+    // Update gaps list
+    this.#studentState.gaps = Object.values(this.#studentState.masteryByTopic)
+      .filter((m) => m.score < GAP_THRESHOLD)
+      .map((m) => m.topicId);
+  }
+
+  // --- Grading ---
+
+  #gradeAnswer(question: Question, answer: StudentAnswer): AnswerResult {
+    if (question.type !== answer.type) {
+      return {
+        correct: false,
+        questionId: question.id,
+        topicId: question.topicId,
+        userAnswer: answer,
+        correctAnswer: this.#describeCorrectAnswer(question),
+        explanation: 'Answer type does not match question type.',
+      };
+    }
+
+    const correct = this.#checkCorrectness(question, answer);
+
+    return {
+      correct,
+      questionId: question.id,
+      topicId: question.topicId,
+      userAnswer: answer,
+      correctAnswer: this.#describeCorrectAnswer(question),
+    };
+  }
+
+  #checkCorrectness(question: Question, answer: StudentAnswer): boolean {
+    switch (question.type) {
+      case 'multiple-choice': {
+        const a = answer as { type: 'multiple-choice'; selectedIndex: number };
+        return a.selectedIndex === question.correctIndex;
+      }
+      case 'numeric-input': {
+        const a = answer as { type: 'numeric-input'; value: number };
+        const tolerance = question.tolerance ?? 0;
+        // Guard against division by zero when correctValue is 0
+        if (question.correctValue === 0) {
+          return Math.abs(a.value) <= tolerance;
+        }
+        return Math.abs(a.value - question.correctValue) <= tolerance;
+      }
+      case 'ordering': {
+        const a = answer as { type: 'ordering'; order: number[] };
+        return (
+          a.order.length === question.correctOrder.length &&
+          a.order.every((val, idx) => val === question.correctOrder[idx])
+        );
+      }
+      case 'multi-select': {
+        const a = answer as { type: 'multi-select'; selectedIndices: number[] };
+        const correct = [...question.correctIndices].sort();
+        const selected = [...a.selectedIndices].sort();
+        return (
+          correct.length === selected.length &&
+          correct.every((val, idx) => val === selected[idx])
+        );
+      }
+      case 'two-stage': {
+        const a = answer as {
+          type: 'two-stage';
+          selectedIndex: number;
+          followUpSelectedIndex: number;
+        };
+        return (
+          a.selectedIndex === question.correctIndex &&
+          a.followUpSelectedIndex === question.followUpCorrectIndex
+        );
+      }
+    }
+  }
+
+  #describeCorrectAnswer(question: Question): string {
+    switch (question.type) {
+      case 'multiple-choice':
+        return question.options[question.correctIndex];
+      case 'numeric-input': {
+        const unit = question.unit ? ` ${question.unit}` : '';
+        return `${question.correctValue}${unit}`;
+      }
+      case 'ordering':
+        return question.correctOrder.map((i) => question.items[i]).join(' → ');
+      case 'multi-select':
+        return question.correctIndices.map((i) => question.options[i]).join(', ');
+      case 'two-stage':
+        return `${question.options[question.correctIndex]}, then ${question.followUpOptions[question.followUpCorrectIndex]}`;
     }
   }
 
@@ -40,6 +405,12 @@ export class CourseEngine extends EventEmitter {
     return {
       version: SNAPSHOT_VERSION,
       state: this.#state,
+      curriculum: this.#curriculum,
+      currentSectionIndex: this.#currentSectionIndex,
+      currentItemIndex: this.#currentItemIndex,
+      sectionItems: this.#sectionItems,
+      studentState: this.#studentState,
+      lastAnswerResult: this.#lastAnswerResult,
     };
   }
 
@@ -50,11 +421,17 @@ export class CourseEngine extends EventEmitter {
       );
     }
 
-    // Constructor fires events, but no listeners are registered yet,
-    // so they go nowhere. We overwrite state to match the snapshot.
+    // Constructor does not emit events for idle state.
+    // We overwrite all state from the snapshot.
     // Restore does NOT emit events — the consumer must resync explicitly.
     const engine = new CourseEngine(config);
     engine.#state = snapshot.state;
+    engine.#curriculum = snapshot.curriculum;
+    engine.#currentSectionIndex = snapshot.currentSectionIndex;
+    engine.#currentItemIndex = snapshot.currentItemIndex;
+    engine.#sectionItems = snapshot.sectionItems;
+    engine.#studentState = snapshot.studentState;
+    engine.#lastAnswerResult = snapshot.lastAnswerResult;
     return engine;
   }
 }

--- a/packages/engine/src/engine/errors.ts
+++ b/packages/engine/src/engine/errors.ts
@@ -1,0 +1,15 @@
+// --- Engine Errors ---
+
+export class InvalidTransitionError extends Error {
+  constructor(action: string, currentState: string) {
+    super(`Cannot ${action} in state "${currentState}"`);
+    this.name = 'InvalidTransitionError';
+  }
+}
+
+export class EngineError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EngineError';
+  }
+}

--- a/packages/engine/src/engine/events.ts
+++ b/packages/engine/src/engine/events.ts
@@ -3,10 +3,49 @@
 // The engine emits events with all data the UI needs to render.
 // The UI never reaches back into the engine for display info.
 
+import type { CurriculumPlan, Section } from '../curriculum/types.js';
+import type {
+  ContentItem,
+  Explanation,
+  Question,
+  AnswerResult,
+} from '../content/types.js';
+import type { StudentState, SessionProgress } from '../student/types.js';
+import type { EngineState } from './types.js';
+
 export type EngineEventMap = {
-  ready: { state: string };
-  stateChange: { from: string; to: string };
-  error: { message: string };
+  stateChange: { from: EngineState; to: EngineState };
+  error: { message: string; recoverable: boolean };
+
+  // --- Syllabus lifecycle ---
+  syllabusLoaded: { curriculum: CurriculumPlan };
+
+  // --- Section lifecycle ---
+  sectionStart: { section: Section; sectionIndex: number; totalSections: number };
+  contentReady: { items: ContentItem[]; section: Section };
+
+  // --- Content/quiz loop ---
+  itemShow: { item: ContentItem; itemIndex: number; totalItems: number };
+  answerResult: {
+    result: AnswerResult;
+    studentState: StudentState;
+    progress: SessionProgress;
+  };
+
+  // --- Section/course completion ---
+  sectionComplete: {
+    section: Section;
+    studentState: StudentState;
+    progress: SessionProgress;
+  };
+  courseComplete: {
+    studentState: StudentState;
+    progress: SessionProgress;
+  };
+
+  // --- API activity (for loading indicators) ---
+  apiCallStart: { purpose: string };
+  apiCallComplete: { purpose: string };
 };
 
 export type EngineEvent = keyof EngineEventMap;

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -1,13 +1,49 @@
 // --- Engine Types ---
 
-export type EngineState = 'idle' | 'ready';
+import type { CurriculumPlan, Section } from '../curriculum/types.js';
+import type {
+  AnswerResult,
+  ContentItem,
+  Question,
+  Explanation,
+} from '../content/types.js';
+import type { StudentState, SessionProgress, TopicMastery } from '../student/types.js';
 
-export type EngineSnapshot = {
-  version: number;
-  state: EngineState;
-};
+export type EngineState =
+  | 'idle' // no syllabus loaded
+  | 'planning' // analyzing syllabus via LLM
+  | 'ready' // curriculum plan available, no section started
+  | 'loading' // generating content for a section
+  | 'practicing' // student is viewing content or answering a question
+  | 'answered' // student submitted an answer, viewing result
+  | 'sectionComplete' // all items in the current section are done
+  | 'complete'; // all sections done
 
 export type CourseEngineConfig = {
   apiKey: string;
   model?: string;
+};
+
+export type EngineSnapshot = {
+  version: number;
+  state: EngineState;
+  curriculum: CurriculumPlan | null;
+  currentSectionIndex: number;
+  currentItemIndex: number;
+  sectionItems: ContentItem[];
+  studentState: StudentState;
+  lastAnswerResult: AnswerResult | null;
+};
+
+// Re-export types that consumers need
+export type {
+  CurriculumPlan,
+  Section,
+  ContentItem,
+  Question,
+  Explanation,
+  AnswerResult,
+  StudentState,
+  SessionProgress,
+  TopicMastery,
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,3 +1,31 @@
 export { CourseEngine } from './engine/CourseEngine.js';
-export type { CourseEngineConfig, EngineSnapshot, EngineState } from './engine/types.js';
+export { InvalidTransitionError, EngineError } from './engine/errors.js';
+
+export type {
+  CourseEngineConfig,
+  EngineSnapshot,
+  EngineState,
+  CurriculumPlan,
+  Section,
+  ContentItem,
+  Question,
+  Explanation,
+  AnswerResult,
+  StudentState,
+  SessionProgress,
+  TopicMastery,
+} from './engine/types.js';
+
 export type { EngineEvent, EngineEventMap, Listener } from './engine/events.js';
+
+export type { Topic } from './curriculum/types.js';
+
+export type {
+  StudentAnswer,
+  QuestionType,
+  MultipleChoiceQuestion,
+  NumericInputQuestion,
+  OrderingQuestion,
+  MultiSelectQuestion,
+  TwoStageQuestion,
+} from './content/types.js';

--- a/packages/engine/src/student/types.ts
+++ b/packages/engine/src/student/types.ts
@@ -1,0 +1,22 @@
+// --- Student Types ---
+// Tracks what the student knows and where they're struggling.
+
+export type TopicMastery = {
+  topicId: string;
+  score: number; // 0.0 to 1.0
+  questionsAnswered: number;
+  questionsCorrect: number;
+};
+
+export type StudentState = {
+  masteryByTopic: Record<string, TopicMastery>;
+  gaps: string[]; // topic IDs where mastery is below threshold
+};
+
+export type SessionProgress = {
+  currentSectionIndex: number;
+  totalSections: number;
+  currentItemIndex: number;
+  totalItemsInSection: number;
+  overallMastery: number; // 0.0 to 1.0, average across all topics
+};

--- a/packages/engine/tests/engine.test.ts
+++ b/packages/engine/tests/engine.test.ts
@@ -1,11 +1,90 @@
 import { describe, it, expect } from 'vitest';
-import { CourseEngine } from '../src/index.js';
-import type { EngineEventMap } from '../src/index.js';
+import { CourseEngine, InvalidTransitionError } from '../src/index.js';
+import type {
+  EngineEventMap,
+  CurriculumPlan,
+  ContentItem,
+  StudentAnswer,
+} from '../src/index.js';
 
-// --- Test Helpers ---
+// --- Test Data Factories ---
 
-function createEngine() {
-  return new CourseEngine({ apiKey: 'test-key' });
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Intro to Testing',
+    description: 'A course about testing',
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Unit Testing',
+        order: 0,
+        topics: [
+          { id: 'topic-1', title: 'Assertions', description: 'How to assert' },
+          { id: 'topic-2', title: 'Mocking', description: 'How to mock' },
+        ],
+      },
+      {
+        id: 'section-2',
+        title: 'Integration Testing',
+        order: 1,
+        topics: [{ id: 'topic-3', title: 'Setup', description: 'Test setup' }],
+      },
+    ],
+  };
+}
+
+function mockSectionContent(): ContentItem[] {
+  return [
+    {
+      type: 'explanation',
+      topicId: 'topic-1',
+      title: 'Understanding Assertions',
+      content: 'Assertions verify expected behavior.',
+    },
+    {
+      type: 'multiple-choice',
+      id: 'q1',
+      topicId: 'topic-1',
+      question: 'What does assertEquals do?',
+      options: ['Compares values', 'Logs output', 'Throws always', 'Does nothing'],
+      correctIndex: 0,
+    },
+    {
+      type: 'numeric-input',
+      id: 'q2',
+      topicId: 'topic-1',
+      question: 'What is 2 + 2?',
+      correctValue: 4,
+      tolerance: 0,
+    },
+    {
+      type: 'ordering',
+      id: 'q3',
+      topicId: 'topic-2',
+      question: 'Order the test phases:',
+      items: ['Assert', 'Arrange', 'Act'],
+      correctOrder: [1, 2, 0], // Arrange, Act, Assert
+    },
+    {
+      type: 'multi-select',
+      id: 'q4',
+      topicId: 'topic-2',
+      question: 'Select all testing frameworks:',
+      options: ['Vitest', 'Photoshop', 'Jest', 'Excel'],
+      correctIndices: [0, 2],
+    },
+    {
+      type: 'two-stage',
+      id: 'q5',
+      topicId: 'topic-2',
+      question: 'What is a mock?',
+      options: ['A fake object', 'A real database', 'A CSS file'],
+      correctIndex: 0,
+      followUp: 'Why use mocks?',
+      followUpOptions: ['Isolation', 'Performance', 'Styling'],
+      followUpCorrectIndex: 0,
+    },
+  ];
 }
 
 function collectEvents<E extends keyof EngineEventMap>(
@@ -17,96 +96,652 @@ function collectEvents<E extends keyof EngineEventMap>(
   return events;
 }
 
+function engineAtPracticing(): {
+  engine: CourseEngine;
+  items: ContentItem[];
+} {
+  const engine = new CourseEngine({ apiKey: 'test-key' });
+  engine.loadCurriculum(mockCurriculum());
+  engine.startSection('section-1');
+  const items = mockSectionContent();
+  engine.setSectionContent(items);
+  return { engine, items };
+}
+
 // --- Constructor ---
 
 describe('CourseEngine', () => {
-  it('starts in ready state after construction', () => {
-    const engine = createEngine();
+  it('starts in idle state', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    expect(engine.state).toBe('idle');
+  });
+
+  it('has no curriculum initially', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    expect(engine.curriculum).toBeNull();
+    expect(engine.currentSection).toBeNull();
+    expect(engine.currentItem).toBeNull();
+  });
+});
+
+// --- State Transitions ---
+
+describe('state machine transitions', () => {
+  it('idle → ready on loadCurriculum', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    const stateChanges = collectEvents(engine, 'stateChange');
+
+    engine.loadCurriculum(mockCurriculum());
+
     expect(engine.state).toBe('ready');
+    expect(stateChanges).toEqual([{ from: 'idle', to: 'ready' }]);
   });
 
-  it('emits stateChange and ready events on construction', () => {
-    const stateChanges: EngineEventMap['stateChange'][] = [];
-    const readyEvents: EngineEventMap['ready'][] = [];
+  it('ready → loading on startSection', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    const stateChanges = collectEvents(engine, 'stateChange');
 
-    // Need to listen before construction completes —
-    // construct manually to capture events
-    const engine = createEngine();
+    engine.startSection('section-1');
 
-    // Constructor already fired events, so we test via serialize
-    // that the state is correct. For event testing, we'll use
-    // a fresh engine with pre-registered listeners.
-    expect(engine.state).toBe('ready');
+    expect(engine.state).toBe('loading');
+    expect(stateChanges).toEqual([{ from: 'ready', to: 'loading' }]);
   });
 
-  it('emits events to registered listeners', () => {
-    const engine = createEngine();
-    const errors = collectEvents(engine, 'error');
+  it('loading → practicing on setSectionContent', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    const stateChanges = collectEvents(engine, 'stateChange');
 
-    // Trigger an error event manually isn't possible from public API yet,
-    // but we can verify the listener registration works via state events
-    expect(errors).toHaveLength(0);
+    engine.setSectionContent(mockSectionContent());
+
+    expect(engine.state).toBe('practicing');
+    expect(stateChanges).toEqual([{ from: 'loading', to: 'practicing' }]);
   });
 
-  it('removes listeners with off()', () => {
-    const engine = createEngine();
-    const events: EngineEventMap['stateChange'][] = [];
-    const listener = (payload: EngineEventMap['stateChange']) => events.push(payload);
+  it('practicing → answered on submitAnswer', () => {
+    const { engine } = engineAtPracticing();
+    // Skip explanation first
+    engine.nextItem();
+    const stateChanges = collectEvents(engine, 'stateChange');
 
-    engine.on('stateChange', listener);
-    engine.off('stateChange', listener);
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
 
-    // No public way to trigger stateChange yet, but listener is removed
-    expect(events).toHaveLength(0);
+    expect(engine.state).toBe('answered');
+    expect(stateChanges).toEqual([{ from: 'practicing', to: 'answered' }]);
+  });
+
+  it('answered → practicing on nextItem', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    const stateChanges = collectEvents(engine, 'stateChange');
+
+    engine.nextItem();
+
+    expect(engine.state).toBe('practicing');
+    expect(stateChanges).toEqual([{ from: 'answered', to: 'practicing' }]);
+  });
+
+  it('practicing → sectionComplete when all items done', () => {
+    const { engine } = engineAtPracticing();
+    const sectionCompleteEvents = collectEvents(engine, 'sectionComplete');
+
+    // Walk through all items
+    engine.nextItem(); // explanation → q1
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem(); // q1 → q2
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem(); // q2 → q3
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem(); // q3 → q4
+    engine.submitAnswer({ type: 'multi-select', selectedIndices: [0, 2] });
+    engine.nextItem(); // q4 → q5
+    engine.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 0,
+    });
+    engine.nextItem(); // q5 → complete
+
+    expect(engine.state).toBe('sectionComplete');
+    expect(sectionCompleteEvents).toHaveLength(1);
+    expect(sectionCompleteEvents[0].section.id).toBe('section-1');
+  });
+
+  it('sectionComplete → loading on nextSection', () => {
+    const { engine } = engineAtPracticing();
+    // Complete section 1
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multi-select', selectedIndices: [0, 2] });
+    engine.nextItem();
+    engine.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 0,
+    });
+    engine.nextItem();
+
+    expect(engine.state).toBe('sectionComplete');
+    const stateChanges = collectEvents(engine, 'stateChange');
+    engine.nextSection();
+
+    // Should transition through sectionComplete → loading
+    expect(engine.state).toBe('loading');
+  });
+
+  it('sectionComplete → complete when last section finishes', () => {
+    const { engine } = engineAtPracticing();
+    // Complete section 1
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multi-select', selectedIndices: [0, 2] });
+    engine.nextItem();
+    engine.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 0,
+    });
+    engine.nextItem();
+
+    // Start and complete section 2
+    engine.nextSection();
+    engine.setSectionContent([
+      {
+        type: 'multiple-choice',
+        id: 'q6',
+        topicId: 'topic-3',
+        question: 'What is integration testing?',
+        options: ['Testing components together', 'Unit testing', 'Manual testing'],
+        correctIndex: 0,
+      },
+    ]);
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    expect(engine.state).toBe('sectionComplete');
+
+    const courseCompleteEvents = collectEvents(engine, 'courseComplete');
+    engine.nextSection();
+
+    expect(engine.state).toBe('complete');
+    expect(courseCompleteEvents).toHaveLength(1);
+  });
+});
+
+// --- Invalid Transitions ---
+
+describe('invalid transitions', () => {
+  it('throws on loadCurriculum when not idle', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+
+    expect(() => engine.loadCurriculum(mockCurriculum())).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on startSection when idle', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    expect(() => engine.startSection('section-1')).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on startSection with unknown section id', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    expect(() => engine.startSection('nonexistent')).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on submitAnswer when not practicing', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    expect(() =>
+      engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 })
+    ).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on submitAnswer when current item is an explanation', () => {
+    const { engine } = engineAtPracticing();
+    // Current item is an explanation
+    expect(() =>
+      engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 })
+    ).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on nextItem for unanswered question', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation, now on q1
+    // Try to skip the question without answering
+    expect(() => engine.nextItem()).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on setSectionContent when not loading', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    expect(() => engine.setSectionContent([])).toThrow(InvalidTransitionError);
+  });
+
+  it('throws on nextSection when not sectionComplete', () => {
+    const { engine } = engineAtPracticing();
+    expect(() => engine.nextSection()).toThrow(InvalidTransitionError);
+  });
+});
+
+// --- Grading ---
+
+describe('answer grading', () => {
+  it('grades multiple-choice correctly', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation
+    const result = engine.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 0,
+    });
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Compares values');
+  });
+
+  it('grades multiple-choice incorrectly', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    const result = engine.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 2,
+    });
+    expect(result.correct).toBe(false);
+  });
+
+  it('grades numeric-input correctly', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // explanation
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem(); // q1 → q2
+    const result = engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    expect(result.correct).toBe(true);
+  });
+
+  it('grades numeric-input with tolerance', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    engine.setSectionContent([
+      {
+        type: 'numeric-input',
+        id: 'q-tol',
+        topicId: 'topic-1',
+        question: 'What is pi?',
+        correctValue: 3.14,
+        tolerance: 0.01,
+      },
+    ]);
+    const result = engine.submitAnswer({ type: 'numeric-input', value: 3.14159 });
+    // 3.14159 is within 0.01 of 3.14? |3.14159 - 3.14| = 0.00159 < 0.01
+    expect(result.correct).toBe(true);
+  });
+
+  it('handles numeric-input with correctValue of 0', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    engine.setSectionContent([
+      {
+        type: 'numeric-input',
+        id: 'q-zero',
+        topicId: 'topic-1',
+        question: 'What is 0?',
+        correctValue: 0,
+        tolerance: 0.1,
+      },
+    ]);
+    const result = engine.submitAnswer({ type: 'numeric-input', value: 0.05 });
+    expect(result.correct).toBe(true);
+  });
+
+  it('grades ordering correctly', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // explanation
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem(); // q1
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem(); // q2 → q3
+    const result = engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Arrange → Act → Assert');
+  });
+
+  it('grades multi-select correctly regardless of order', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem(); // q3 → q4
+    // Correct indices are [0, 2], submit in reverse order
+    const result = engine.submitAnswer({
+      type: 'multi-select',
+      selectedIndices: [2, 0],
+    });
+    expect(result.correct).toBe(true);
+  });
+
+  it('grades two-stage correctly', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multi-select', selectedIndices: [0, 2] });
+    engine.nextItem(); // q4 → q5
+    const result = engine.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 0,
+    });
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('A fake object, then Isolation');
+  });
+
+  it('grades two-stage incorrect when follow-up is wrong', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'numeric-input', value: 4 });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'ordering', order: [1, 2, 0] });
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multi-select', selectedIndices: [0, 2] });
+    engine.nextItem();
+    const result = engine.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 1, // wrong follow-up
+    });
+    expect(result.correct).toBe(false);
+  });
+
+  it('handles mismatched answer type', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation, now on MCQ
+    const result = engine.submitAnswer({ type: 'numeric-input', value: 42 });
+    expect(result.correct).toBe(false);
+    expect(result.explanation).toContain('type does not match');
+  });
+});
+
+// --- Skip ---
+
+describe('skipQuestion', () => {
+  it('advances to the next item without answering', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // explanation → q1
+    const itemEvents = collectEvents(engine, 'itemShow');
+
+    engine.skipQuestion();
+
+    expect(engine.state).toBe('practicing');
+    expect(itemEvents).toHaveLength(1);
+    expect(itemEvents[0].itemIndex).toBe(2); // q2
+  });
+
+  it('throws when current item is an explanation', () => {
+    const { engine } = engineAtPracticing();
+    expect(() => engine.skipQuestion()).toThrow(InvalidTransitionError);
+  });
+});
+
+// --- Event Payloads ---
+
+describe('event payloads', () => {
+  it('syllabusLoaded contains the full curriculum', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    const events = collectEvents(engine, 'syllabusLoaded');
+
+    engine.loadCurriculum(mockCurriculum());
+
+    expect(events).toHaveLength(1);
+    expect(events[0].curriculum.title).toBe('Intro to Testing');
+    expect(events[0].curriculum.sections).toHaveLength(2);
+  });
+
+  it('sectionStart contains section info and position', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    const events = collectEvents(engine, 'sectionStart');
+
+    engine.startSection('section-1');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].section.id).toBe('section-1');
+    expect(events[0].sectionIndex).toBe(0);
+    expect(events[0].totalSections).toBe(2);
+  });
+
+  it('contentReady contains all items and section', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    const events = collectEvents(engine, 'contentReady');
+    const items = mockSectionContent();
+
+    engine.setSectionContent(items);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].items).toHaveLength(items.length);
+    expect(events[0].section.id).toBe('section-1');
+  });
+
+  it('itemShow contains item and position', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    const events = collectEvents(engine, 'itemShow');
+
+    engine.setSectionContent(mockSectionContent());
+
+    expect(events).toHaveLength(1);
+    expect(events[0].item.type).toBe('explanation');
+    expect(events[0].itemIndex).toBe(0);
+    expect(events[0].totalItems).toBe(6);
+  });
+
+  it('answerResult contains result, studentState, and progress', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation
+    const events = collectEvents(engine, 'answerResult');
+
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].result.correct).toBe(true);
+    expect(events[0].studentState.masteryByTopic).toBeDefined();
+    expect(events[0].progress.currentItemIndex).toBe(1);
+  });
+});
+
+// --- Student State ---
+
+describe('mastery tracking', () => {
+  it('increases mastery on correct answer', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+
+    const state = engine.studentState;
+    expect(state.masteryByTopic['topic-1'].score).toBeGreaterThan(0);
+    expect(state.masteryByTopic['topic-1'].questionsCorrect).toBe(1);
+  });
+
+  it('decreases mastery on incorrect answer', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 3 }); // wrong
+
+    const state = engine.studentState;
+    // Started at 0, decreased — but clamped to 0
+    expect(state.masteryByTopic['topic-1'].score).toBe(0);
+    expect(state.masteryByTopic['topic-1'].questionsCorrect).toBe(0);
+    expect(state.masteryByTopic['topic-1'].questionsAnswered).toBe(1);
+  });
+
+  it('mastery stays within 0-1 bounds', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+
+    // Create 10 correct answers to push mastery high
+    const items: ContentItem[] = Array.from({ length: 10 }, (_, i) => ({
+      type: 'multiple-choice' as const,
+      id: `q-${i}`,
+      topicId: 'topic-1',
+      question: `Question ${i}`,
+      options: ['A', 'B'],
+      correctIndex: 0,
+    }));
+    engine.setSectionContent(items);
+
+    for (let i = 0; i < 10; i++) {
+      engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+      if (i < 9) engine.nextItem();
+    }
+
+    expect(engine.studentState.masteryByTopic['topic-1'].score).toBeLessThanOrEqual(1);
+  });
+
+  it('identifies gaps when mastery is below threshold', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem();
+    // Wrong answer — mastery stays at 0, which is below gap threshold
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 3 });
+
+    const state = engine.studentState;
+    // All topics start at 0 mastery, so all should be gaps initially
+    expect(state.gaps).toContain('topic-1');
+  });
+
+  it('returns defensive copies of student state', () => {
+    const { engine } = engineAtPracticing();
+    const state1 = engine.studentState;
+    state1.gaps.push('fake-gap');
+    const state2 = engine.studentState;
+    expect(state2.gaps).not.toContain('fake-gap');
+  });
+});
+
+// --- Session Progress ---
+
+describe('session progress', () => {
+  it('tracks section and item position', () => {
+    const { engine } = engineAtPracticing();
+    const progress = engine.sessionProgress;
+
+    expect(progress.currentSectionIndex).toBe(0);
+    expect(progress.totalSections).toBe(2);
+    expect(progress.currentItemIndex).toBe(0);
+    expect(progress.totalItemsInSection).toBe(6);
   });
 });
 
 // --- Serialization ---
 
 describe('serialize / restore', () => {
-  it('round-trips engine state', () => {
-    const engine = createEngine();
+  it('round-trips engine in idle state', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
     const snapshot = engine.serialize();
-
     const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
-    expect(restored.state).toBe(engine.state);
+    expect(restored.state).toBe('idle');
   });
 
-  it('produces a snapshot with version and state', () => {
-    const engine = createEngine();
+  it('round-trips engine in practicing state with full context', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // skip explanation
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem(); // advance to q2
+
     const snapshot = engine.serialize();
+    const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
 
-    expect(snapshot).toEqual({
-      version: 1,
-      state: 'ready',
-    });
-  });
-
-  it('rejects snapshots with wrong version', () => {
-    expect(() =>
-      CourseEngine.restore({ version: 999, state: 'ready' }, { apiKey: 'test-key' })
-    ).toThrow('Unsupported snapshot version');
+    expect(restored.state).toBe('practicing');
+    expect(restored.curriculum?.title).toBe('Intro to Testing');
+    expect(restored.currentSection?.id).toBe('section-1');
+    expect(restored.currentItem?.type).toBe('numeric-input');
+    expect(restored.studentState.masteryByTopic['topic-1'].questionsCorrect).toBe(1);
   });
 
   it('restore does not emit events', () => {
-    const engine = createEngine();
+    const { engine } = engineAtPracticing();
     const snapshot = engine.serialize();
 
-    const stateChanges: EngineEventMap['stateChange'][] = [];
+    const events: EngineEventMap['stateChange'][] = [];
     const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
-    restored.on('stateChange', (p) => stateChanges.push(p));
+    restored.on('stateChange', (p) => events.push(p));
 
-    // No events should have been emitted during restore
-    expect(stateChanges).toHaveLength(0);
+    expect(events).toHaveLength(0);
   });
 
-  it('stores a defensive copy of config', () => {
-    const config = { apiKey: 'original-key' };
-    const engine = createEngine();
-    config.apiKey = 'mutated-key';
+  it('rejects snapshots with wrong version', () => {
+    const snapshot = {
+      version: 999,
+      state: 'idle' as const,
+      curriculum: null,
+      currentSectionIndex: -1,
+      currentItemIndex: -1,
+      sectionItems: [],
+      studentState: { masteryByTopic: {}, gaps: [] },
+      lastAnswerResult: null,
+    };
+    expect(() => CourseEngine.restore(snapshot, { apiKey: 'test-key' })).toThrow(
+      'Unsupported snapshot version'
+    );
+  });
 
-    // Engine should not be affected by external mutation
+  it('restored engine can continue operating', () => {
+    const { engine } = engineAtPracticing();
+    engine.nextItem(); // explanation → q1
+
     const snapshot = engine.serialize();
-    expect(snapshot.state).toBe('ready');
+    const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
+
+    // Should be able to answer the current question
+    const result = restored.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 0,
+    });
+    expect(result.correct).toBe(true);
+    expect(restored.state).toBe('answered');
+  });
+});
+
+// --- Defensive Copies ---
+
+describe('defensive copies', () => {
+  it('loadCurriculum stores a copy, not the original', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key' });
+    const curriculum = mockCurriculum();
+    engine.loadCurriculum(curriculum);
+
+    // Mutate the original
+    curriculum.title = 'Mutated';
+    curriculum.sections.push({
+      id: 'extra',
+      title: 'Extra',
+      order: 2,
+      topics: [],
+    });
+
+    expect(engine.curriculum?.title).toBe('Intro to Testing');
+    expect(engine.curriculum?.sections).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2

- Full state machine: `idle → ready → loading → practicing → answered → sectionComplete → complete`
- Curriculum types: `CurriculumPlan`, `Section`, `Topic`
- Content types: 5 question types (MCQ, numeric, ordering, multi-select, two-stage), `Explanation`, `ContentItem`
- Student types: `TopicMastery`, `StudentState`, `SessionProgress`
- Answer grading for all 5 question types with human-readable correct answer descriptions
- Mastery tracking: 0.0–1.0 per topic, gap detection below threshold
- Full serialize/restore with all state (snapshot version bumped to 2)
- Transition guards: invalid transitions throw `InvalidTransitionError`
- 47 tests covering valid transitions, invalid transitions, grading correctness for all types, mastery bounds, event payloads, serialization round-trips, and defensive copies

## Test plan

- [x] `pnpm --filter quizzer-engine test` — 47 tests passing
- [x] `pnpm --filter quizzer-engine build` — clean TypeScript build
- [x] `pnpm -r build` — app still builds with expanded engine API
- [x] `pnpm format:check` — all formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)