### PR TITLE
Implement StudentModel: mastery tracking and gap detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 — 2026-04-05
+
+### Phase 1: Engine Core
+
+- `StudentModel`: dedicated class for per-topic mastery tracking and gap detection, extracted from inline logic in `CourseEngine`
+- Mastery scores: correct answers increase by 0.15, incorrect decrease by 0.10, clamped to [0, 1]
+- Gap detection: topics below 0.5 mastery threshold are tracked as gaps
+- `SessionProgress` computation with overall mastery average
+- Full serialize/restore round-trip support
+- `CourseEngine` now delegates all mastery logic to `StudentModel`
+- Snapshot version bumped to 3
+- 22 new tests covering mastery calculations, gap detection, bounds, serialization, and defensive copies
+
 ## 0.1.0 — 2026-04-05
 
 ### Phase 0: Scaffolding

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from './events.js';
 import { InvalidTransitionError } from './errors.js';
+import { StudentModel } from '../student/StudentModel.js';
 import type {
   CourseEngineConfig,
   EngineSnapshot,
@@ -19,8 +20,7 @@ import type {
 import type { StudentAnswer, Question } from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
-const SNAPSHOT_VERSION = 2;
-const GAP_THRESHOLD = 0.5; // topics below this mastery score are "gaps"
+const SNAPSHOT_VERSION = 3;
 
 export class CourseEngine extends EventEmitter {
   #state: EngineState = 'idle';
@@ -29,7 +29,7 @@ export class CourseEngine extends EventEmitter {
   #currentSectionIndex = -1;
   #currentItemIndex = -1;
   #sectionItems: ContentItem[] = [];
-  #studentState: StudentState = { masteryByTopic: {}, gaps: [] };
+  #studentModel: StudentModel = new StudentModel();
   #lastAnswerResult: AnswerResult | null = null;
 
   constructor(config: CourseEngineConfig) {
@@ -58,28 +58,16 @@ export class CourseEngine extends EventEmitter {
   }
 
   get studentState(): StudentState {
-    // Return a defensive copy so callers can't mutate internal state
-    return {
-      masteryByTopic: { ...this.#studentState.masteryByTopic },
-      gaps: [...this.#studentState.gaps],
-    };
+    return this.#studentModel.getState();
   }
 
   get sessionProgress(): SessionProgress {
-    const totalSections = this.#curriculum?.sections.length ?? 0;
-    const masteries = Object.values(this.#studentState.masteryByTopic);
-    const overallMastery =
-      masteries.length > 0
-        ? masteries.reduce((sum, m) => sum + m.score, 0) / masteries.length
-        : 0;
-
-    return {
+    return this.#studentModel.computeProgress({
       currentSectionIndex: this.#currentSectionIndex,
-      totalSections,
+      totalSections: this.#curriculum?.sections.length ?? 0,
       currentItemIndex: this.#currentItemIndex,
       totalItemsInSection: this.#sectionItems.length,
-      overallMastery,
-    };
+    });
   }
 
   // --- State Transitions ---
@@ -114,12 +102,7 @@ export class CourseEngine extends EventEmitter {
     // Initialize mastery for all topics
     for (const section of this.#curriculum.sections) {
       for (const topic of section.topics) {
-        this.#studentState.masteryByTopic[topic.id] = {
-          topicId: topic.id,
-          score: 0,
-          questionsAnswered: 0,
-          questionsCorrect: 0,
-        };
+        this.#studentModel.initializeTopic(topic.id);
       }
     }
 
@@ -294,22 +277,10 @@ export class CourseEngine extends EventEmitter {
   }
 
   #updateMastery(result: AnswerResult): void {
-    const topicId = result.topicId;
-    const mastery = this.#studentState.masteryByTopic[topicId];
-    if (!mastery) return;
-
-    mastery.questionsAnswered++;
-    if (result.correct) {
-      mastery.questionsCorrect++;
-      mastery.score = Math.min(1, mastery.score + 0.15);
-    } else {
-      mastery.score = Math.max(0, mastery.score - 0.1);
-    }
-
-    // Update gaps list
-    this.#studentState.gaps = Object.values(this.#studentState.masteryByTopic)
-      .filter((m) => m.score < GAP_THRESHOLD)
-      .map((m) => m.topicId);
+    this.#studentModel.recordAnswer({
+      topicId: result.topicId,
+      correct: result.correct,
+    });
   }
 
   // --- Grading ---
@@ -409,7 +380,7 @@ export class CourseEngine extends EventEmitter {
       currentSectionIndex: this.#currentSectionIndex,
       currentItemIndex: this.#currentItemIndex,
       sectionItems: this.#sectionItems,
-      studentState: this.#studentState,
+      studentState: this.#studentModel.getState(),
       lastAnswerResult: this.#lastAnswerResult,
     };
   }
@@ -430,7 +401,7 @@ export class CourseEngine extends EventEmitter {
     engine.#currentSectionIndex = snapshot.currentSectionIndex;
     engine.#currentItemIndex = snapshot.currentItemIndex;
     engine.#sectionItems = snapshot.sectionItems;
-    engine.#studentState = snapshot.studentState;
+    engine.#studentModel = new StudentModel(snapshot.studentState);
     engine.#lastAnswerResult = snapshot.lastAnswerResult;
     return engine;
   }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,6 @@
 export { CourseEngine } from './engine/CourseEngine.js';
 export { InvalidTransitionError, EngineError } from './engine/errors.js';
+export { StudentModel } from './student/StudentModel.js';
 
 export type {
   CourseEngineConfig,
@@ -19,6 +20,7 @@ export type {
 export type { EngineEvent, EngineEventMap, Listener } from './engine/events.js';
 
 export type { Topic } from './curriculum/types.js';
+export type { MasteryUpdate } from './student/StudentModel.js';
 
 export type {
   StudentAnswer,

--- a/packages/engine/src/student/StudentModel.ts
+++ b/packages/engine/src/student/StudentModel.ts
@@ -1,0 +1,155 @@
+// --- StudentModel ---
+// Tracks per-topic mastery and identifies knowledge gaps.
+// The engine delegates all mastery tracking to this class.
+// It owns the StudentState and provides SessionProgress computation.
+//
+// Mastery update rules:
+//   - Correct answer: score += BASE_GAIN (0.15), clamped to [0, 1]
+//   - Incorrect answer: score -= BASE_LOSS (0.10), clamped to [0, 1]
+//   - Topics with score < GAP_THRESHOLD (0.5) are tracked as gaps
+//
+// The model is serializable: getState() returns a snapshot,
+// and the constructor can restore from a prior StudentState.
+
+import type { StudentState, TopicMastery, SessionProgress } from './types.js';
+
+const GAP_THRESHOLD = 0.5;
+const BASE_GAIN = 0.15;
+const BASE_LOSS = 0.1;
+
+export type MasteryUpdate = {
+  topicId: string;
+  correct: boolean;
+};
+
+export class StudentModel {
+  #masteryByTopic: Map<string, TopicMastery>;
+  #gaps: Set<string>;
+
+  constructor(state?: StudentState) {
+    if (state) {
+      this.#masteryByTopic = new Map(
+        Object.entries(state.masteryByTopic).map(([id, mastery]) => [id, { ...mastery }])
+      );
+      this.#gaps = new Set(state.gaps);
+    } else {
+      this.#masteryByTopic = new Map();
+      this.#gaps = new Set();
+    }
+  }
+
+  // --- Topic Initialization ---
+
+  /**
+   * Register a topic for tracking. Sets initial mastery to 0.
+   * Skips topics that are already registered (e.g., from a restored state).
+   */
+  initializeTopic(topicId: string): void {
+    if (this.#masteryByTopic.has(topicId)) return;
+
+    this.#masteryByTopic.set(topicId, {
+      topicId,
+      score: 0,
+      questionsAnswered: 0,
+      questionsCorrect: 0,
+    });
+    // New topics start at 0, which is below the gap threshold
+    this.#gaps.add(topicId);
+  }
+
+  // --- Mastery Updates ---
+
+  /**
+   * Record an answer result and update the topic's mastery score.
+   * Returns the updated TopicMastery for the topic.
+   */
+  recordAnswer(update: MasteryUpdate): TopicMastery {
+    const mastery = this.#masteryByTopic.get(update.topicId);
+    if (!mastery) {
+      throw new Error(`Topic "${update.topicId}" is not tracked by the student model`);
+    }
+
+    mastery.questionsAnswered++;
+
+    if (update.correct) {
+      mastery.questionsCorrect++;
+      mastery.score = Math.min(1, mastery.score + BASE_GAIN);
+    } else {
+      mastery.score = Math.max(0, mastery.score - BASE_LOSS);
+    }
+
+    // Update gaps
+    if (mastery.score < GAP_THRESHOLD) {
+      this.#gaps.add(update.topicId);
+    } else {
+      this.#gaps.delete(update.topicId);
+    }
+
+    return { ...mastery };
+  }
+
+  // --- Queries ---
+
+  /** Get mastery for a specific topic, or undefined if not tracked. */
+  getTopicMastery(topicId: string): TopicMastery | undefined {
+    const mastery = this.#masteryByTopic.get(topicId);
+    return mastery ? { ...mastery } : undefined;
+  }
+
+  /** Topic IDs where mastery is below the gap threshold. */
+  get gaps(): string[] {
+    return [...this.#gaps];
+  }
+
+  /** Average mastery across all tracked topics. 0 if no topics. */
+  get overallMastery(): number {
+    if (this.#masteryByTopic.size === 0) return 0;
+
+    let total = 0;
+    for (const mastery of this.#masteryByTopic.values()) {
+      total += mastery.score;
+    }
+    return total / this.#masteryByTopic.size;
+  }
+
+  /** Number of topics currently tracked. */
+  get topicCount(): number {
+    return this.#masteryByTopic.size;
+  }
+
+  // --- Session Progress ---
+
+  /**
+   * Compute session progress given the current section/item position.
+   * The StudentModel owns the mastery calculation; the engine provides
+   * the positional data (section index, item index, totals).
+   */
+  computeProgress(position: {
+    currentSectionIndex: number;
+    totalSections: number;
+    currentItemIndex: number;
+    totalItemsInSection: number;
+  }): SessionProgress {
+    return {
+      currentSectionIndex: position.currentSectionIndex,
+      totalSections: position.totalSections,
+      currentItemIndex: position.currentItemIndex,
+      totalItemsInSection: position.totalItemsInSection,
+      overallMastery: this.overallMastery,
+    };
+  }
+
+  // --- Serialization ---
+
+  /** Returns a snapshot of the current student state. */
+  getState(): StudentState {
+    const masteryByTopic: Record<string, TopicMastery> = {};
+    for (const [id, mastery] of this.#masteryByTopic) {
+      masteryByTopic[id] = { ...mastery };
+    }
+    return {
+      masteryByTopic,
+      gaps: [...this.#gaps],
+    };
+  }
+}

--- a/packages/engine/tests/student-model.test.ts
+++ b/packages/engine/tests/student-model.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest';
+import { StudentModel } from '../src/index.js';
+import type { StudentState } from '../src/index.js';
+
+// --- Helpers ---
+
+function modelWithTopics(...topicIds: string[]): StudentModel {
+  const model = new StudentModel();
+  for (const id of topicIds) {
+    model.initializeTopic(id);
+  }
+  return model;
+}
+
+// --- Initialization ---
+
+describe('StudentModel initialization', () => {
+  it('starts with no topics', () => {
+    const model = new StudentModel();
+    expect(model.topicCount).toBe(0);
+    expect(model.overallMastery).toBe(0);
+    expect(model.gaps).toEqual([]);
+  });
+
+  it('initializes topics with zero mastery', () => {
+    const model = modelWithTopics('topic-1', 'topic-2');
+
+    expect(model.topicCount).toBe(2);
+    const mastery = model.getTopicMastery('topic-1');
+    expect(mastery).toBeDefined();
+    expect(mastery!.score).toBe(0);
+    expect(mastery!.questionsAnswered).toBe(0);
+    expect(mastery!.questionsCorrect).toBe(0);
+  });
+
+  it('skips duplicate topic initialization', () => {
+    const model = new StudentModel();
+    model.initializeTopic('topic-1');
+    // Answer a question to change the mastery
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    // Re-initialize should not reset
+    model.initializeTopic('topic-1');
+    expect(model.getTopicMastery('topic-1')!.score).toBeGreaterThan(0);
+    expect(model.topicCount).toBe(1);
+  });
+
+  it('marks new topics as gaps (score 0 < threshold)', () => {
+    const model = modelWithTopics('topic-1');
+    expect(model.gaps).toContain('topic-1');
+  });
+});
+
+// --- Mastery Updates ---
+
+describe('mastery calculations', () => {
+  it('increases mastery on correct answer', () => {
+    const model = modelWithTopics('topic-1');
+
+    const updated = model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    expect(updated.score).toBe(0.15);
+    expect(updated.questionsAnswered).toBe(1);
+    expect(updated.questionsCorrect).toBe(1);
+  });
+
+  it('decreases mastery on incorrect answer', () => {
+    const model = modelWithTopics('topic-1');
+    // First get some mastery
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+    const before = model.getTopicMastery('topic-1')!.score;
+
+    const updated = model.recordAnswer({ topicId: 'topic-1', correct: false });
+
+    expect(updated.score).toBe(before - 0.1);
+    expect(updated.questionsAnswered).toBe(3);
+    expect(updated.questionsCorrect).toBe(2);
+  });
+
+  it('mastery does not go below 0', () => {
+    const model = modelWithTopics('topic-1');
+
+    // Multiple incorrect answers from 0
+    model.recordAnswer({ topicId: 'topic-1', correct: false });
+    model.recordAnswer({ topicId: 'topic-1', correct: false });
+    model.recordAnswer({ topicId: 'topic-1', correct: false });
+
+    expect(model.getTopicMastery('topic-1')!.score).toBe(0);
+  });
+
+  it('mastery does not exceed 1', () => {
+    const model = modelWithTopics('topic-1');
+
+    // 10 correct answers: 10 * 0.15 = 1.5, but clamped to 1
+    for (let i = 0; i < 10; i++) {
+      model.recordAnswer({ topicId: 'topic-1', correct: true });
+    }
+
+    expect(model.getTopicMastery('topic-1')!.score).toBe(1);
+  });
+
+  it('throws for untracked topic', () => {
+    const model = new StudentModel();
+
+    expect(() => model.recordAnswer({ topicId: 'nonexistent', correct: true })).toThrow(
+      'not tracked'
+    );
+  });
+
+  it('returns a defensive copy from recordAnswer', () => {
+    const model = modelWithTopics('topic-1');
+
+    const result = model.recordAnswer({ topicId: 'topic-1', correct: true });
+    result.score = 999;
+
+    expect(model.getTopicMastery('topic-1')!.score).toBe(0.15);
+  });
+});
+
+// --- Gap Detection ---
+
+describe('gap detection', () => {
+  it('tracks topics below threshold as gaps', () => {
+    const model = modelWithTopics('topic-1', 'topic-2');
+    // Both start at 0, both are gaps
+    expect(model.gaps).toContain('topic-1');
+    expect(model.gaps).toContain('topic-2');
+  });
+
+  it('removes topic from gaps when mastery reaches threshold', () => {
+    const model = modelWithTopics('topic-1');
+
+    // 4 correct answers: 4 * 0.15 = 0.60, above 0.5 threshold
+    for (let i = 0; i < 4; i++) {
+      model.recordAnswer({ topicId: 'topic-1', correct: true });
+    }
+
+    expect(model.gaps).not.toContain('topic-1');
+  });
+
+  it('re-adds topic to gaps when mastery drops below threshold', () => {
+    const model = modelWithTopics('topic-1');
+
+    // Get above threshold
+    for (let i = 0; i < 4; i++) {
+      model.recordAnswer({ topicId: 'topic-1', correct: true });
+    }
+    expect(model.gaps).not.toContain('topic-1');
+
+    // Drop back below: 0.60 - 0.10 = 0.50 — at threshold, not below
+    model.recordAnswer({ topicId: 'topic-1', correct: false });
+    expect(model.gaps).not.toContain('topic-1');
+
+    // One more: 0.50 - 0.10 = 0.40 — below threshold
+    model.recordAnswer({ topicId: 'topic-1', correct: false });
+    expect(model.gaps).toContain('topic-1');
+  });
+});
+
+// --- Overall Mastery ---
+
+describe('overall mastery', () => {
+  it('computes average across all topics', () => {
+    const model = modelWithTopics('topic-1', 'topic-2');
+
+    // topic-1: 1 correct = 0.15
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+    // topic-2: stays at 0
+
+    expect(model.overallMastery).toBeCloseTo(0.075, 5);
+  });
+
+  it('returns 0 with no topics', () => {
+    const model = new StudentModel();
+    expect(model.overallMastery).toBe(0);
+  });
+});
+
+// --- Session Progress ---
+
+describe('session progress', () => {
+  it('computes progress with position data', () => {
+    const model = modelWithTopics('topic-1');
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    const progress = model.computeProgress({
+      currentSectionIndex: 1,
+      totalSections: 5,
+      currentItemIndex: 3,
+      totalItemsInSection: 10,
+    });
+
+    expect(progress.currentSectionIndex).toBe(1);
+    expect(progress.totalSections).toBe(5);
+    expect(progress.currentItemIndex).toBe(3);
+    expect(progress.totalItemsInSection).toBe(10);
+    expect(progress.overallMastery).toBe(0.15);
+  });
+});
+
+// --- Serialization ---
+
+describe('serialize / restore', () => {
+  it('round-trips student state', () => {
+    const model = modelWithTopics('topic-1', 'topic-2');
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+    model.recordAnswer({ topicId: 'topic-2', correct: false });
+
+    const state = model.getState();
+    const restored = new StudentModel(state);
+
+    expect(restored.getTopicMastery('topic-1')!.score).toBe(0.15);
+    expect(restored.getTopicMastery('topic-2')!.score).toBe(0);
+    expect(restored.gaps).toContain('topic-2');
+    expect(restored.topicCount).toBe(2);
+  });
+
+  it('restored model can continue recording answers', () => {
+    const model = modelWithTopics('topic-1');
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    const state = model.getState();
+    const restored = new StudentModel(state);
+    restored.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    expect(restored.getTopicMastery('topic-1')!.score).toBe(0.3);
+    expect(restored.getTopicMastery('topic-1')!.questionsAnswered).toBe(2);
+  });
+
+  it('getState returns defensive copies', () => {
+    const model = modelWithTopics('topic-1');
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    const state1 = model.getState();
+    state1.gaps.push('fake-gap');
+    state1.masteryByTopic['topic-1'].score = 999;
+
+    const state2 = model.getState();
+    expect(state2.gaps).not.toContain('fake-gap');
+    expect(state2.masteryByTopic['topic-1'].score).toBe(0.15);
+  });
+
+  it('constructor does not mutate the input state', () => {
+    const state: StudentState = {
+      masteryByTopic: {
+        'topic-1': {
+          topicId: 'topic-1',
+          score: 0.5,
+          questionsAnswered: 3,
+          questionsCorrect: 2,
+        },
+      },
+      gaps: [],
+    };
+
+    const model = new StudentModel(state);
+    model.recordAnswer({ topicId: 'topic-1', correct: true });
+
+    // Original state should be unmodified
+    expect(state.masteryByTopic['topic-1'].score).toBe(0.5);
+  });
+});
+
+// --- getTopicMastery ---
+
+describe('getTopicMastery', () => {
+  it('returns undefined for untracked topic', () => {
+    const model = new StudentModel();
+    expect(model.getTopicMastery('nonexistent')).toBeUndefined();
+  });
+
+  it('returns a defensive copy', () => {
+    const model = modelWithTopics('topic-1');
+
+    const mastery = model.getTopicMastery('topic-1')!;
+    mastery.score = 999;
+
+    expect(model.getTopicMastery('topic-1')!.score).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #6

## Summary

- **StudentModel** — Dedicated class for per-topic mastery tracking, extracted from inline logic in `CourseEngine`. Owns all mastery state and gap detection.
- **Mastery calculation** — Correct answers increase score by 0.15, incorrect decrease by 0.10, clamped to [0, 1]. Topics below 0.5 threshold are tracked as knowledge gaps.
- **SessionProgress** — `computeProgress()` method combines positional data (from engine) with overall mastery average (from student model).
- **Serialize/restore** — `StudentModel` can be constructed from a `StudentState` snapshot. `CourseEngine.serialize()` uses `StudentModel.getState()`, and `restore()` creates a new `StudentModel` from the snapshot. Snapshot version bumped 2 → 3.
- **CourseEngine refactor** — Engine now delegates all mastery logic to `StudentModel`. `#updateMastery` calls `studentModel.recordAnswer()`, `loadCurriculum` calls `studentModel.initializeTopic()`.
- **22 new tests** covering mastery calculations, gap detection, bounds clamping, serialization round-trips, defensive copies, and error cases.

## Architecture compliance

- No browser APIs (Rule #3)
- Student state is the engine's responsibility (Rule #6) — delegated to `StudentModel`
- Private `#fields` throughout, no `any` types
- Defensive copies on all public getters and state snapshots

## Test plan

- [x] Mastery increases on correct, decreases on incorrect
- [x] Score clamped to [0, 1]
- [x] Gaps track topics below 0.5 threshold
- [x] Topics removed from gaps when mastery recovers
- [x] Duplicate `initializeTopic` is a no-op (doesn't reset)
- [x] Throws on untracked topic
- [x] Serialize/restore round-trip preserves full state
- [x] Restored model can continue recording answers
- [x] Defensive copies prevent external mutation
- [x] Constructor doesn't mutate input state
- [x] All 69 tests pass (`pnpm -r test`)
- [x] `pnpm -r build` — clean
- [x] `pnpm format` — clean