### PR TITLE
Implement ContentGenerator with prompts and quality filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
 - `validateCurriculumPlan`: runtime shape validation with duplicate ID detection
 - 3 recorded fixtures (MIT algorithms, Coursera ML, informal cooking) for deterministic testing
 - 29 new tests (prompt builder, validation, parser with fixtures, curriculum manager)
+- `ContentGenerator`: core content/quiz loop — generates explanation + quiz burst per topic in a section
+- Explanation prompt (`src/prompts/explanation.ts`): versioned (v1.0), tool_use-based, topic context in user message
+- Quiz generation prompt (`src/prompts/quiz-generation.ts`): versioned (v1.0), supports all 5 question types (MCQ, numeric-input, ordering, multi-select, two-stage)
+- Quality filters (`src/content/quality-filters.ts`): length outlier detection, front-matter question detection, duplicate option detection — inherited from PageQuizzer
+- Retry-once on malformed LLM responses for both explanations and quiz bursts
+- Runtime shape validation and parsing for all 5 question types
+- 22 new tests (prompt builders, quality filters, content generator with fixtures)
 
 ## 0.1.0 — 2026-04-05
 

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -1,0 +1,379 @@
+// --- ContentGenerator ---
+// Produces the content/quiz loop for a single section:
+// For each topic in the section, generates a brief explanation
+// followed by a burst of quiz questions.
+//
+// The output is a flat ContentItem[] array that the CourseEngine
+// feeds through its state machine. The generator doesn't know
+// about engine state — it just produces content.
+//
+// Flow per topic:
+//   1. Generate explanation via Claude → Explanation item
+//   2. Generate quiz burst via Claude → Question items
+//   3. Validate and filter questions
+// Repeat for each topic in the section.
+
+import { buildExplanationPrompt } from '../prompts/explanation.js';
+import { buildQuizGenerationPrompt } from '../prompts/quiz-generation.js';
+import { checkQuestionQuality } from './quality-filters.js';
+import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
+import type { ToolUseBlock } from '../provider/types.js';
+import type { Section, Topic } from '../curriculum/types.js';
+import type { ContentItem, Explanation, Question, QuestionType } from './types.js';
+
+const EXPLANATION_MAX_TOKENS = 1024;
+const QUIZ_MAX_TOKENS = 4096;
+
+export class ContentGenerator {
+  #provider: ClaudeProvider;
+
+  constructor(provider: ClaudeProvider) {
+    this.#provider = provider;
+  }
+
+  // --- Public API ---
+
+  /**
+   * Generate content items for an entire section.
+   * Returns a flat array: [explanation, questions..., explanation, questions..., ...]
+   * following the content/quiz loop from the Learning Model.
+   */
+  async generateSection(section: Section, courseTitle: string): Promise<ContentItem[]> {
+    const items: ContentItem[] = [];
+
+    for (const topic of section.topics) {
+      const explanation = await this.#generateExplanation(
+        topic,
+        courseTitle,
+        section.title
+      );
+      items.push(explanation);
+
+      const questions = await this.#generateQuizBurst(
+        topic,
+        courseTitle,
+        section.title,
+        explanation.content
+      );
+      items.push(...questions);
+    }
+
+    return items;
+  }
+
+  // --- Explanation Generation ---
+
+  async #generateExplanation(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string
+  ): Promise<Explanation> {
+    const prompt = buildExplanationPrompt({
+      topicTitle: topic.title,
+      topicDescription: topic.description,
+      courseTitle,
+      sectionTitle,
+    });
+
+    const response = await this.#provider.sendMessage({
+      ...prompt,
+      maxTokens: EXPLANATION_MAX_TOKENS,
+    });
+
+    const toolBlock = response.content.find(
+      (block): block is ToolUseBlock =>
+        block.type === 'tool_use' && block.name === 'create_explanation'
+    );
+
+    if (!toolBlock) {
+      // Retry once
+      const retryResponse = await this.#provider.sendMessage({
+        ...prompt,
+        maxTokens: EXPLANATION_MAX_TOKENS,
+      });
+
+      const retryBlock = retryResponse.content.find(
+        (block): block is ToolUseBlock =>
+          block.type === 'tool_use' && block.name === 'create_explanation'
+      );
+
+      if (!retryBlock) {
+        throw new Error(
+          `Failed to generate explanation for topic "${topic.title}" after retry`
+        );
+      }
+
+      return this.#parseExplanation(retryBlock, topic.id);
+    }
+
+    return this.#parseExplanation(toolBlock, topic.id);
+  }
+
+  #parseExplanation(block: ToolUseBlock, topicId: string): Explanation {
+    const input = block.input as Record<string, unknown>;
+
+    const title = typeof input.title === 'string' ? input.title : 'Explanation';
+    const content = typeof input.content === 'string' ? input.content : '';
+
+    if (content.length === 0) {
+      throw new Error(`Empty explanation content for topic "${topicId}"`);
+    }
+
+    return {
+      type: 'explanation',
+      topicId,
+      title,
+      content,
+    };
+  }
+
+  // --- Quiz Generation ---
+
+  async #generateQuizBurst(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string,
+    explanationContent: string
+  ): Promise<Question[]> {
+    const prompt = buildQuizGenerationPrompt({
+      topicTitle: topic.title,
+      topicDescription: topic.description,
+      courseTitle,
+      sectionTitle,
+      explanationContent,
+    });
+
+    const response = await this.#provider.sendMessage({
+      ...prompt,
+      maxTokens: QUIZ_MAX_TOKENS,
+    });
+
+    const toolBlock = response.content.find(
+      (block): block is ToolUseBlock =>
+        block.type === 'tool_use' && block.name === 'create_quiz_questions'
+    );
+
+    if (!toolBlock) {
+      // Retry once
+      const retryResponse = await this.#provider.sendMessage({
+        ...prompt,
+        maxTokens: QUIZ_MAX_TOKENS,
+      });
+
+      const retryBlock = retryResponse.content.find(
+        (block): block is ToolUseBlock =>
+          block.type === 'tool_use' && block.name === 'create_quiz_questions'
+      );
+
+      if (!retryBlock) {
+        throw new Error(`Failed to generate quiz for topic "${topic.title}" after retry`);
+      }
+
+      return this.#parseAndFilterQuestions(retryBlock, topic.id);
+    }
+
+    return this.#parseAndFilterQuestions(toolBlock, topic.id);
+  }
+
+  #parseAndFilterQuestions(block: ToolUseBlock, topicId: string): Question[] {
+    const input = block.input as Record<string, unknown>;
+    const rawQuestions = input.questions;
+
+    if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
+      throw new Error(`No questions generated for topic "${topicId}"`);
+    }
+
+    const questions: Question[] = [];
+    let idCounter = 0;
+
+    for (const raw of rawQuestions) {
+      try {
+        const question = this.#parseQuestion(raw, topicId, idCounter++);
+        const issues = checkQuestionQuality(question);
+        if (issues.length === 0) {
+          questions.push(question);
+        }
+        // Silently drop questions that fail quality filters
+      } catch {
+        // Silently skip unparseable questions — better to have fewer
+        // good questions than to fail the entire section
+      }
+    }
+
+    if (questions.length === 0) {
+      throw new Error(`All generated questions for topic "${topicId}" failed validation`);
+    }
+
+    return questions;
+  }
+
+  // --- Question Parsing ---
+
+  #parseQuestion(raw: unknown, topicId: string, index: number): Question {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new Error('Question is not an object');
+    }
+
+    const obj = raw as Record<string, unknown>;
+    const type = obj.type as QuestionType;
+    const questionText = obj.question as string;
+
+    if (!questionText || typeof questionText !== 'string') {
+      throw new Error('Question missing text');
+    }
+
+    const id = `${topicId}-q${index}`;
+
+    switch (type) {
+      case 'multiple-choice':
+        return this.#parseMCQ(obj, id, topicId, questionText);
+      case 'numeric-input':
+        return this.#parseNumeric(obj, id, topicId, questionText);
+      case 'ordering':
+        return this.#parseOrdering(obj, id, topicId, questionText);
+      case 'multi-select':
+        return this.#parseMultiSelect(obj, id, topicId, questionText);
+      case 'two-stage':
+        return this.#parseTwoStage(obj, id, topicId, questionText);
+      default:
+        throw new Error(`Unknown question type: ${type}`);
+    }
+  }
+
+  #parseMCQ(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const options = this.#requireStringArray(obj.options, 'options', 2);
+    const correctIndex = this.#requireIndex(obj.correctIndex, options.length);
+
+    return { type: 'multiple-choice', id, topicId, question, options, correctIndex };
+  }
+
+  #parseNumeric(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    if (typeof obj.correctValue !== 'number') {
+      throw new Error('numeric-input missing correctValue');
+    }
+
+    return {
+      type: 'numeric-input',
+      id,
+      topicId,
+      question,
+      correctValue: obj.correctValue,
+      tolerance: typeof obj.tolerance === 'number' ? obj.tolerance : 0,
+      unit: typeof obj.unit === 'string' ? obj.unit : undefined,
+    };
+  }
+
+  #parseOrdering(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const items = this.#requireStringArray(obj.items, 'items', 2);
+    const correctOrder = this.#requireNumberArray(obj.correctOrder, 'correctOrder');
+
+    if (correctOrder.length !== items.length) {
+      throw new Error('ordering: correctOrder length must match items length');
+    }
+
+    return { type: 'ordering', id, topicId, question, items, correctOrder };
+  }
+
+  #parseMultiSelect(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const options = this.#requireStringArray(obj.options, 'options', 2);
+    const correctIndices = this.#requireNumberArray(obj.correctIndices, 'correctIndices');
+
+    for (const idx of correctIndices) {
+      if (idx < 0 || idx >= options.length) {
+        throw new Error(
+          `multi-select: correctIndices contains out-of-range index ${idx}`
+        );
+      }
+    }
+
+    return { type: 'multi-select', id, topicId, question, options, correctIndices };
+  }
+
+  #parseTwoStage(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const options = this.#requireStringArray(obj.options, 'options', 2);
+    const correctIndex = this.#requireIndex(obj.correctIndex, options.length);
+    const followUp = obj.followUp;
+    if (typeof followUp !== 'string' || followUp.length === 0) {
+      throw new Error('two-stage missing followUp');
+    }
+    const followUpOptions = this.#requireStringArray(
+      obj.followUpOptions,
+      'followUpOptions',
+      2
+    );
+    const followUpCorrectIndex = this.#requireIndex(
+      obj.followUpCorrectIndex,
+      followUpOptions.length
+    );
+
+    return {
+      type: 'two-stage',
+      id,
+      topicId,
+      question,
+      options,
+      correctIndex,
+      followUp,
+      followUpOptions,
+      followUpCorrectIndex,
+    };
+  }
+
+  // --- Validation Helpers ---
+
+  #requireStringArray(value: unknown, name: string, minLength: number): string[] {
+    if (!Array.isArray(value) || value.length < minLength) {
+      throw new Error(`${name} must be an array with at least ${minLength} items`);
+    }
+    for (const item of value) {
+      if (typeof item !== 'string') {
+        throw new Error(`${name} must contain only strings`);
+      }
+    }
+    return value as string[];
+  }
+
+  #requireNumberArray(value: unknown, name: string): number[] {
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new Error(`${name} must be a non-empty array`);
+    }
+    for (const item of value) {
+      if (typeof item !== 'number') {
+        throw new Error(`${name} must contain only numbers`);
+      }
+    }
+    return value as number[];
+  }
+
+  #requireIndex(value: unknown, maxExclusive: number): number {
+    if (typeof value !== 'number' || value < 0 || value >= maxExclusive) {
+      throw new Error(`Index must be a number in [0, ${maxExclusive})`);
+    }
+    return value;
+  }
+}

--- a/packages/engine/src/content/quality-filters.ts
+++ b/packages/engine/src/content/quality-filters.ts
@@ -1,0 +1,121 @@
+// --- Quality Filters ---
+// Structural quality checks inherited from PageQuizzer.
+// These catch common LLM failure modes that make questions
+// too guessable or low-value for learning.
+
+import type { Question } from './types.js';
+
+export type QualityIssue = {
+  questionId: string;
+  reason: string;
+};
+
+/**
+ * Run all quality filters on a question.
+ * Returns a list of issues found (empty = passed).
+ */
+export function checkQuestionQuality(question: Question): QualityIssue[] {
+  const issues: QualityIssue[] = [];
+
+  if (isLengthOutlier(question)) {
+    issues.push({
+      questionId: question.id,
+      reason: 'Correct answer is significantly longer than other options (too guessable)',
+    });
+  }
+
+  if (isFrontMatterQuestion(question)) {
+    issues.push({
+      questionId: question.id,
+      reason: 'Question asks about publication metadata (low learning value)',
+    });
+  }
+
+  if (hasDuplicateOptions(question)) {
+    issues.push({
+      questionId: question.id,
+      reason: 'Question has duplicate options',
+    });
+  }
+
+  return issues;
+}
+
+// --- Length Outlier Detection ---
+// If the correct answer is the only long, detailed, or specific option,
+// the question is too guessable. Students learn to pick the longest answer.
+
+function isLengthOutlier(question: Question): boolean {
+  if (question.type === 'numeric-input' || question.type === 'ordering') {
+    return false; // These types don't have text options to compare
+  }
+
+  const options = getOptions(question);
+  if (!options || options.length < 3) return false;
+
+  const correctIndex = getCorrectIndex(question);
+  if (correctIndex === undefined || correctIndex < 0 || correctIndex >= options.length) {
+    return false;
+  }
+
+  const correctLength = options[correctIndex].length;
+  const otherLengths = options.filter((_, i) => i !== correctIndex).map((o) => o.length);
+  const avgOtherLength =
+    otherLengths.reduce((sum, len) => sum + len, 0) / otherLengths.length;
+
+  // Flag if correct answer is more than 2x the average of others
+  return correctLength > avgOtherLength * 2 && correctLength > 30;
+}
+
+// --- Front-Matter Question Detection ---
+// Questions about publication metadata, authors, or edition numbers
+// are low-value for learning.
+
+const FRONT_MATTER_PATTERNS = [
+  /\bauthor\b/i,
+  /\bedition\b/i,
+  /\bpublish/i,
+  /\bISBN\b/i,
+  /\bpage\s+(?:number|count)/i,
+  /\btextbook\b/i,
+  /\bcopyright\b/i,
+  /\bprerequisite\s+course/i,
+];
+
+function isFrontMatterQuestion(question: Question): boolean {
+  const text = question.question;
+  return FRONT_MATTER_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+// --- Duplicate Options ---
+
+function hasDuplicateOptions(question: Question): boolean {
+  const options = getOptions(question);
+  if (!options) return false;
+
+  const normalized = options.map((o) => o.trim().toLowerCase());
+  return new Set(normalized).size !== normalized.length;
+}
+
+// --- Helpers ---
+
+function getOptions(question: Question): string[] | undefined {
+  switch (question.type) {
+    case 'multiple-choice':
+    case 'multi-select':
+    case 'two-stage':
+      return question.options;
+    default:
+      return undefined;
+  }
+}
+
+function getCorrectIndex(question: Question): number | undefined {
+  switch (question.type) {
+    case 'multiple-choice':
+    case 'two-stage':
+      return question.correctIndex;
+    default:
+      return undefined;
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,6 +6,8 @@ export { ProviderError } from './provider/types.js';
 export { StudentModel } from './student/StudentModel.js';
 export { SyllabusParser, validateCurriculumPlan } from './curriculum/SyllabusParser.js';
 export { CurriculumManager } from './curriculum/CurriculumManager.js';
+export { ContentGenerator } from './content/ContentGenerator.js';
+export { checkQuestionQuality } from './content/quality-filters.js';
 
 export type {
   CourseEngineConfig,
@@ -30,6 +32,11 @@ export {
   buildSyllabusAnalysisPrompt,
   SYLLABUS_ANALYSIS_VERSION,
 } from './prompts/syllabus-analysis.js';
+export { buildExplanationPrompt, EXPLANATION_VERSION } from './prompts/explanation.js';
+export {
+  buildQuizGenerationPrompt,
+  QUIZ_GENERATION_VERSION,
+} from './prompts/quiz-generation.js';
 export type { PromptMessages } from './prompts/types.js';
 export type { MasteryUpdate } from './student/StudentModel.js';
 
@@ -57,5 +64,6 @@ export type {
   ToolChoice,
 } from './provider/types.js';
 
+export type { QualityIssue } from './content/quality-filters.js';
 export type { ClaudeProviderConfig } from './provider/ClaudeProvider.js';
 export type { RateLimiterConfig } from './provider/rate-limiter.js';

--- a/packages/engine/src/prompts/explanation.ts
+++ b/packages/engine/src/prompts/explanation.ts
@@ -1,0 +1,90 @@
+// --- Explanation Prompt ---
+// Generates a focused 2-3 paragraph explanation for one topic.
+// The explanation exists to give the student something to be quizzed on —
+// it is the means, not the end (see Learning Model in AGENTS.md).
+
+import type { PromptMessages } from './types.js';
+
+export const EXPLANATION_VERSION = '1.0';
+
+// --- Tool Schema ---
+
+const EXPLANATION_TOOL = {
+  name: 'create_explanation',
+  description:
+    'Create a focused, concise explanation of a topic for a student. ' +
+    'The explanation should be 2-3 paragraphs and give the student enough ' +
+    'understanding to answer quiz questions about the topic.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        description: 'A clear title for this explanation',
+      },
+      content: {
+        type: 'string',
+        description:
+          'The explanation text in markdown. 2-3 paragraphs. ' +
+          'Focused, clear, and self-contained.',
+      },
+    },
+    required: ['title', 'content'],
+  },
+};
+
+// --- Prompt Builders ---
+
+function buildSystemPrompt(): string {
+  return `You are an expert tutor creating concise learning material. Your explanations are brief, focused, and designed to prepare students for quiz questions.
+
+Guidelines:
+- Write 2-3 paragraphs maximum
+- Use concrete examples where possible
+- Define key terms on first use
+- Stay within the scope of the topic — don't wander into adjacent concepts
+- Write at an introductory level unless the topic description indicates otherwise
+- Use markdown formatting for clarity (bold key terms, code blocks for code)`;
+}
+
+function buildUserPrompt(
+  topicTitle: string,
+  topicDescription: string,
+  courseTitle: string,
+  sectionTitle: string
+): string {
+  return `Create a brief explanation for the following topic.
+
+Course: ${courseTitle}
+Section: ${sectionTitle}
+Topic: ${topicTitle}
+Description: ${topicDescription}
+
+Write a focused 2-3 paragraph explanation that prepares the student to answer quiz questions on this topic.`;
+}
+
+// --- Public API ---
+
+export function buildExplanationPrompt(params: {
+  topicTitle: string;
+  topicDescription: string;
+  courseTitle: string;
+  sectionTitle: string;
+}): PromptMessages {
+  return {
+    system: buildSystemPrompt(),
+    messages: [
+      {
+        role: 'user',
+        content: buildUserPrompt(
+          params.topicTitle,
+          params.topicDescription,
+          params.courseTitle,
+          params.sectionTitle
+        ),
+      },
+    ],
+    tools: [EXPLANATION_TOOL],
+    toolChoice: { type: 'tool', name: 'create_explanation' },
+  };
+}

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -1,0 +1,176 @@
+// --- Quiz Generation Prompt ---
+// Generates a burst of quiz questions for one topic.
+// Uses all 5 OpenQuizzer question types: MCQ, numeric input,
+// ordering, multi-select, two-stage.
+
+import type { PromptMessages } from './types.js';
+
+export const QUIZ_GENERATION_VERSION = '1.0';
+
+// --- Tool Schema ---
+
+const QUIZ_TOOL = {
+  name: 'create_quiz_questions',
+  description:
+    'Generate 3-5 quiz questions for a single topic. ' +
+    'Use a mix of question types. Questions must be self-contained — ' +
+    'a student should understand the question without needing to reference source material.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      questions: {
+        type: 'array',
+        description: 'Array of quiz questions',
+        items: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: [
+                'multiple-choice',
+                'numeric-input',
+                'ordering',
+                'multi-select',
+                'two-stage',
+              ],
+              description: 'The question type',
+            },
+            question: {
+              type: 'string',
+              description: 'The question text',
+            },
+            // Multiple choice fields
+            options: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Answer options (for multiple-choice, multi-select, two-stage)',
+            },
+            correctIndex: {
+              type: 'number',
+              description: 'Index of the correct option (for multiple-choice, two-stage)',
+            },
+            // Numeric input fields
+            correctValue: {
+              type: 'number',
+              description: 'The correct numeric answer (for numeric-input)',
+            },
+            tolerance: {
+              type: 'number',
+              description: 'Acceptable tolerance (for numeric-input)',
+            },
+            unit: {
+              type: 'string',
+              description: 'Unit of measurement (for numeric-input)',
+            },
+            // Ordering fields
+            items: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Items to be ordered (for ordering)',
+            },
+            correctOrder: {
+              type: 'array',
+              items: { type: 'number' },
+              description: 'Correct sequence as indices into items array (for ordering)',
+            },
+            // Multi-select fields
+            correctIndices: {
+              type: 'array',
+              items: { type: 'number' },
+              description: 'Indices of all correct options (for multi-select)',
+            },
+            // Two-stage fields
+            followUp: {
+              type: 'string',
+              description: 'Follow-up question text (for two-stage)',
+            },
+            followUpOptions: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Follow-up answer options (for two-stage)',
+            },
+            followUpCorrectIndex: {
+              type: 'number',
+              description: 'Index of the correct follow-up option (for two-stage)',
+            },
+          },
+          required: ['type', 'question'],
+        },
+        minItems: 3,
+        maxItems: 5,
+      },
+    },
+    required: ['questions'],
+  },
+};
+
+// --- Prompt Builders ---
+
+function buildSystemPrompt(): string {
+  return `You are an expert quiz designer creating questions to test understanding of specific topics. Your questions emphasize active recall.
+
+Question type guidelines:
+- **multiple-choice**: 4 options, exactly 1 correct. Options should be plausible — no joke answers.
+- **numeric-input**: Ask for a specific number. Include tolerance if approximate answers are acceptable. Include unit if applicable.
+- **ordering**: 3-5 items that have a natural sequence (chronological, logical steps, ranked). Provide items in a shuffled order; correctOrder gives the right sequence as indices.
+- **multi-select**: 4-6 options, 2-3 correct. Clearly ask "select ALL that apply."
+- **two-stage**: First question + follow-up. Both are multiple-choice. The follow-up probes deeper understanding.
+
+Quality rules:
+- Questions must be self-contained — answerable without the source material
+- All options should be similar in length and specificity — don't make the correct answer the only detailed one
+- Don't ask about publication metadata, authors, edition numbers, or page references
+- Don't use "all of the above" or "none of the above"
+- Vary question types within a burst — don't use the same type for every question`;
+}
+
+function buildUserPrompt(
+  topicTitle: string,
+  topicDescription: string,
+  courseTitle: string,
+  sectionTitle: string,
+  explanationContent: string
+): string {
+  return `Generate 3-5 quiz questions for the following topic.
+
+Course: ${courseTitle}
+Section: ${sectionTitle}
+Topic: ${topicTitle}
+Description: ${topicDescription}
+
+The student just read this explanation:
+<explanation>
+${explanationContent}
+</explanation>
+
+Generate questions that test understanding of this topic. Use a mix of question types.`;
+}
+
+// --- Public API ---
+
+export function buildQuizGenerationPrompt(params: {
+  topicTitle: string;
+  topicDescription: string;
+  courseTitle: string;
+  sectionTitle: string;
+  explanationContent: string;
+}): PromptMessages {
+  return {
+    system: buildSystemPrompt(),
+    messages: [
+      {
+        role: 'user',
+        content: buildUserPrompt(
+          params.topicTitle,
+          params.topicDescription,
+          params.courseTitle,
+          params.sectionTitle,
+          params.explanationContent
+        ),
+      },
+    ],
+    tools: [QUIZ_TOOL],
+    toolChoice: { type: 'tool', name: 'create_quiz_questions' },
+  };
+}

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ContentGenerator } from '../src/content/ContentGenerator.js';
+import { checkQuestionQuality } from '../src/content/quality-filters.js';
+import {
+  buildExplanationPrompt,
+  EXPLANATION_VERSION,
+} from '../src/prompts/explanation.js';
+import {
+  buildQuizGenerationPrompt,
+  QUIZ_GENERATION_VERSION,
+} from '../src/prompts/quiz-generation.js';
+import type { ClaudeProvider } from '../src/provider/ClaudeProvider.js';
+import type { ProviderResponse } from '../src/provider/types.js';
+import type { Section, Topic } from '../src/curriculum/types.js';
+import type { Question } from '../src/content/types.js';
+import {
+  explanationResponse,
+  quizResponse,
+  textOnlyResponse,
+  GOOD_MCQ,
+  GOOD_NUMERIC,
+  GOOD_ORDERING,
+  GOOD_MULTI_SELECT,
+  GOOD_TWO_STAGE,
+  LENGTH_OUTLIER_MCQ,
+  FRONT_MATTER_MCQ,
+  DUPLICATE_OPTIONS_MCQ,
+} from './fixtures/content-generation.js';
+
+// --- Helpers ---
+
+function mockProvider(...responses: ProviderResponse[]): ClaudeProvider {
+  const fn = vi.fn();
+  for (const response of responses) {
+    fn.mockResolvedValueOnce(response);
+  }
+  return { sendMessage: fn } as unknown as ClaudeProvider;
+}
+
+const TOPIC: Topic = {
+  id: 'binary-search',
+  title: 'Binary Search',
+  description: 'Searching a sorted array by repeatedly dividing the search interval.',
+};
+
+const SECTION: Section = {
+  id: 'searching',
+  title: 'Search Algorithms',
+  order: 0,
+  topics: [TOPIC],
+};
+
+const TWO_TOPIC_SECTION: Section = {
+  id: 'sorting',
+  title: 'Sorting',
+  order: 1,
+  topics: [
+    {
+      id: 'merge-sort',
+      title: 'Merge Sort',
+      description: 'A divide-and-conquer sorting algorithm.',
+    },
+    {
+      id: 'quick-sort',
+      title: 'Quick Sort',
+      description: 'A partition-based sorting algorithm.',
+    },
+  ],
+};
+
+// --- Prompt Builders ---
+
+describe('explanation prompt', () => {
+  it('exports version constant', () => {
+    expect(EXPLANATION_VERSION).toBe('1.0');
+  });
+
+  it('builds prompt with topic context', () => {
+    const prompt = buildExplanationPrompt({
+      topicTitle: 'Binary Search',
+      topicDescription: 'Searching a sorted array',
+      courseTitle: 'Algorithms',
+      sectionTitle: 'Search',
+    });
+
+    expect(prompt.system).toContain('tutor');
+    expect(prompt.messages[0].content).toContain('Binary Search');
+    expect(prompt.messages[0].content).toContain('Algorithms');
+    expect(prompt.tools![0].name).toBe('create_explanation');
+    expect(prompt.toolChoice).toEqual({ type: 'tool', name: 'create_explanation' });
+  });
+
+  it('puts topic info in user message, not system prompt', () => {
+    const prompt = buildExplanationPrompt({
+      topicTitle: 'SECRET_TOPIC',
+      topicDescription: 'SECRET_DESC',
+      courseTitle: 'Course',
+      sectionTitle: 'Section',
+    });
+
+    expect(prompt.messages[0].content).toContain('SECRET_TOPIC');
+    expect(prompt.system).not.toContain('SECRET_TOPIC');
+  });
+});
+
+describe('quiz generation prompt', () => {
+  it('exports version constant', () => {
+    expect(QUIZ_GENERATION_VERSION).toBe('1.0');
+  });
+
+  it('builds prompt with topic and explanation context', () => {
+    const prompt = buildQuizGenerationPrompt({
+      topicTitle: 'Binary Search',
+      topicDescription: 'Searching a sorted array',
+      courseTitle: 'Algorithms',
+      sectionTitle: 'Search',
+      explanationContent: 'Binary search works by...',
+    });
+
+    expect(prompt.system).toContain('quiz designer');
+    expect(prompt.messages[0].content).toContain('Binary Search');
+    expect(prompt.messages[0].content).toContain('Binary search works by...');
+    expect(prompt.tools![0].name).toBe('create_quiz_questions');
+  });
+
+  it('system prompt includes quality rules', () => {
+    const prompt = buildQuizGenerationPrompt({
+      topicTitle: 'T',
+      topicDescription: 'D',
+      courseTitle: 'C',
+      sectionTitle: 'S',
+      explanationContent: 'E',
+    });
+
+    expect(prompt.system).toContain('self-contained');
+    expect(prompt.system).toContain('similar in length');
+    expect(prompt.system).toContain('metadata');
+  });
+});
+
+// --- Quality Filters ---
+
+describe('quality filters', () => {
+  it('passes a good MCQ', () => {
+    const q: Question = { ...GOOD_MCQ, id: 'q1', topicId: 't1' } as Question;
+    expect(checkQuestionQuality(q)).toEqual([]);
+  });
+
+  it('flags length outlier', () => {
+    const q: Question = { ...LENGTH_OUTLIER_MCQ, id: 'q1', topicId: 't1' } as Question;
+    const issues = checkQuestionQuality(q);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].reason).toContain('longer');
+  });
+
+  it('flags front-matter question', () => {
+    const q: Question = { ...FRONT_MATTER_MCQ, id: 'q1', topicId: 't1' } as Question;
+    const issues = checkQuestionQuality(q);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].reason).toContain('metadata');
+  });
+
+  it('flags duplicate options', () => {
+    const q: Question = { ...DUPLICATE_OPTIONS_MCQ, id: 'q1', topicId: 't1' } as Question;
+    const issues = checkQuestionQuality(q);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].reason).toContain('duplicate');
+  });
+
+  it('passes numeric-input (no length check)', () => {
+    const q: Question = { ...GOOD_NUMERIC, id: 'q1', topicId: 't1' } as Question;
+    expect(checkQuestionQuality(q)).toEqual([]);
+  });
+
+  it('passes ordering (no length check)', () => {
+    const q: Question = { ...GOOD_ORDERING, id: 'q1', topicId: 't1' } as Question;
+    expect(checkQuestionQuality(q)).toEqual([]);
+  });
+});
+
+// --- ContentGenerator ---
+
+describe('ContentGenerator', () => {
+  it('generates explanation + quiz burst for a single topic', async () => {
+    const provider = mockProvider(
+      explanationResponse('Binary Search', 'Binary search divides...'),
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Algorithms');
+
+    expect(items).toHaveLength(3); // 1 explanation + 2 questions
+    expect(items[0].type).toBe('explanation');
+    expect(items[0].topicId).toBe('binary-search');
+    expect(items[1].type).toBe('multiple-choice');
+    expect(items[2].type).toBe('numeric-input');
+  });
+
+  it('generates content for multiple topics in order', async () => {
+    const provider = mockProvider(
+      // Topic 1: merge-sort
+      explanationResponse('Merge Sort', 'Merge sort divides...'),
+      quizResponse([GOOD_MCQ]),
+      // Topic 2: quick-sort
+      explanationResponse('Quick Sort', 'Quick sort partitions...'),
+      quizResponse([GOOD_ORDERING])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(TWO_TOPIC_SECTION, 'Algorithms');
+
+    expect(items).toHaveLength(4); // 2 explanations + 2 questions
+    expect(items[0].type).toBe('explanation');
+    expect(items[0].topicId).toBe('merge-sort');
+    expect(items[1].topicId).toBe('merge-sort');
+    expect(items[2].type).toBe('explanation');
+    expect(items[2].topicId).toBe('quick-sort');
+    expect(items[3].topicId).toBe('quick-sort');
+  });
+
+  it('parses all 5 question types', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      quizResponse([
+        GOOD_MCQ,
+        GOOD_NUMERIC,
+        GOOD_ORDERING,
+        GOOD_MULTI_SELECT,
+        GOOD_TWO_STAGE,
+      ])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Course');
+    const questions = items.filter((i) => i.type !== 'explanation');
+
+    expect(questions).toHaveLength(5);
+    const types = questions.map((q) => q.type);
+    expect(types).toContain('multiple-choice');
+    expect(types).toContain('numeric-input');
+    expect(types).toContain('ordering');
+    expect(types).toContain('multi-select');
+    expect(types).toContain('two-stage');
+  });
+
+  it('filters out low-quality questions silently', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      quizResponse([GOOD_MCQ, LENGTH_OUTLIER_MCQ, FRONT_MATTER_MCQ, GOOD_NUMERIC])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Course');
+    const questions = items.filter((i) => i.type !== 'explanation');
+
+    // LENGTH_OUTLIER_MCQ and FRONT_MATTER_MCQ should be filtered out
+    expect(questions).toHaveLength(2);
+  });
+
+  it('retries explanation on malformed response', async () => {
+    const provider = mockProvider(
+      textOnlyResponse(), // first attempt fails
+      explanationResponse('Binary Search', 'Content...'), // retry succeeds
+      quizResponse([GOOD_MCQ])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Course');
+
+    expect(items[0].type).toBe('explanation');
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
+  });
+
+  it('retries quiz on malformed response', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      textOnlyResponse(), // first quiz attempt fails
+      quizResponse([GOOD_MCQ]) // retry succeeds
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Course');
+
+    expect(items).toHaveLength(2); // explanation + 1 question
+  });
+
+  it('throws after retry if explanation still fails', async () => {
+    const provider = mockProvider(textOnlyResponse(), textOnlyResponse());
+    const gen = new ContentGenerator(provider);
+
+    await expect(gen.generateSection(SECTION, 'Course')).rejects.toThrow(
+      'Failed to generate explanation'
+    );
+  });
+
+  it('throws after retry if quiz still fails', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      textOnlyResponse(),
+      textOnlyResponse()
+    );
+    const gen = new ContentGenerator(provider);
+
+    await expect(gen.generateSection(SECTION, 'Course')).rejects.toThrow(
+      'Failed to generate quiz'
+    );
+  });
+
+  it('throws if all questions fail validation', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      quizResponse([LENGTH_OUTLIER_MCQ, FRONT_MATTER_MCQ])
+    );
+    const gen = new ContentGenerator(provider);
+
+    await expect(gen.generateSection(SECTION, 'Course')).rejects.toThrow(
+      'failed validation'
+    );
+  });
+
+  it('assigns unique IDs to questions', async () => {
+    const provider = mockProvider(
+      explanationResponse('Topic', 'Content...'),
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const items = await gen.generateSection(SECTION, 'Course');
+    const questions = items.filter((i) => i.type !== 'explanation');
+    const ids = questions.map((q) => (q as Question).id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids[0]).toContain('binary-search');
+  });
+});

--- a/packages/engine/tests/fixtures/content-generation.ts
+++ b/packages/engine/tests/fixtures/content-generation.ts
@@ -1,0 +1,122 @@
+// --- Fixture: Content Generation Responses ---
+// Recorded fixtures for explanation and quiz generation.
+
+import type { ProviderResponse } from '../../src/provider/types.js';
+
+export function explanationResponse(title: string, content: string): ProviderResponse {
+  return {
+    id: 'msg_explanation',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_expl',
+        name: 'create_explanation',
+        input: { title, content },
+      },
+    ],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'tool_use',
+    usage: { inputTokens: 200, outputTokens: 300 },
+  };
+}
+
+export function quizResponse(questions: Record<string, unknown>[]): ProviderResponse {
+  return {
+    id: 'msg_quiz',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_quiz',
+        name: 'create_quiz_questions',
+        input: { questions },
+      },
+    ],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'tool_use',
+    usage: { inputTokens: 300, outputTokens: 800 },
+  };
+}
+
+export function textOnlyResponse(): ProviderResponse {
+  return {
+    id: 'msg_text',
+    content: [{ type: 'text', text: 'I cannot generate that content.' }],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'end_turn',
+    usage: { inputTokens: 100, outputTokens: 20 },
+  };
+}
+
+// --- Sample Quiz Questions ---
+
+export const GOOD_MCQ = {
+  type: 'multiple-choice',
+  question: 'What is the time complexity of binary search?',
+  options: ['O(n)', 'O(log n)', 'O(n²)', 'O(1)'],
+  correctIndex: 1,
+};
+
+export const GOOD_NUMERIC = {
+  type: 'numeric-input',
+  question: 'What is the value of 2^10?',
+  correctValue: 1024,
+  tolerance: 0,
+};
+
+export const GOOD_ORDERING = {
+  type: 'ordering',
+  question:
+    'Order these sorting algorithms by worst-case time complexity (fastest to slowest):',
+  items: ['Bubble Sort', 'Merge Sort', 'Quick Sort'],
+  correctOrder: [1, 2, 0],
+};
+
+export const GOOD_MULTI_SELECT = {
+  type: 'multi-select',
+  question: 'Select ALL stable sorting algorithms:',
+  options: ['Merge Sort', 'Quick Sort', 'Insertion Sort', 'Heap Sort'],
+  correctIndices: [0, 2],
+};
+
+export const GOOD_TWO_STAGE = {
+  type: 'two-stage',
+  question: 'What data structure does BFS use?',
+  options: ['Stack', 'Queue', 'Heap'],
+  correctIndex: 1,
+  followUp: 'Why is a queue appropriate for BFS?',
+  followUpOptions: [
+    'It processes nodes in FIFO order, exploring level by level',
+    'It processes nodes in LIFO order',
+    'It always picks the smallest element',
+  ],
+  followUpCorrectIndex: 0,
+};
+
+// Question with correct answer much longer than others (should be filtered)
+export const LENGTH_OUTLIER_MCQ = {
+  type: 'multiple-choice',
+  question: 'What is an algorithm?',
+  options: [
+    'A number',
+    'A color',
+    'A well-defined computational procedure that takes some value or set of values as input and produces some value or set of values as output, transforming the input to the output through a finite sequence of steps',
+    'A food',
+  ],
+  correctIndex: 2,
+};
+
+// Front-matter question (should be filtered)
+export const FRONT_MATTER_MCQ = {
+  type: 'multiple-choice',
+  question: 'Who is the author of the textbook used in this course?',
+  options: ['Cormen', 'Knuth', 'Dijkstra', 'Turing'],
+  correctIndex: 0,
+};
+
+// Question with duplicate options (should be filtered)
+export const DUPLICATE_OPTIONS_MCQ = {
+  type: 'multiple-choice',
+  question: 'What is 2 + 2?',
+  options: ['4', '3', '4', '5'],
+  correctIndex: 0,
+};


### PR DESCRIPTION
## Summary
- Adds `ContentGenerator` class implementing the content/quiz loop from the Learning Model: for each topic in a section, generates a brief explanation followed by a burst of quiz questions via Claude tool_use
- Adds versioned prompts for explanation (v1.0) and quiz generation (v1.0) with structured output via tool_use
- Ports quality filters from PageQuizzer: length outlier detection, front-matter question detection, duplicate option detection
- Supports all 5 question types: MCQ, numeric-input, ordering, multi-select, two-stage
- Retry-once on malformed LLM responses for both explanations and quizzes
- 22 new tests covering prompt builders, quality filters, and full content generation flow

Closes #5

## Test plan
- [x] All 143 tests pass (`pnpm -r test`)
- [x] Build succeeds (`pnpm -r build`)
- [x] Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)