### PR TITLE
feat: add engine session store with reactive Svelte 5 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0 — 2026-04-12
+
+### Phase 2: App Foundation (continued)
+
+- Engine session store (`src/lib/stores/engine-session.svelte.ts`): reactive Svelte 5 wrapper around CourseEngine
+- Translates all engine events into reactive state via `$state` runes
+- Exposes: engineState, curriculum, currentSection, currentItem, lastResult, studentState, progress, apiLoading, error
+- Actions pass through to CourseEngine: loadCurriculum, startSection, setSectionContent, submitAnswer, nextItem, skipQuestion, nextSection
+- Auto-saves engine snapshots to course storage on answer submission, section completion, and course completion
+- Snapshot restore support: restored sessions reflect correct initial state
+- Dispose clears all subscriptions and resets state to prevent duplicate listeners
+- API key never appears in serialized snapshots
+- Vitest config updated with Svelte vite plugin for `.svelte.ts` file support
+- 19 new engine session store tests covering state flow, auto-save, restore, dispose, and security
+
 ## 0.3.0 — 2026-04-09
 
 ### Phase 2: App Foundation

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -1,0 +1,280 @@
+// --- Engine Session Store ---
+// Owns the active CourseEngine instance and translates engine events into
+// reactive Svelte 5 state. Consumers read state via getters; all mutations
+// flow through engine actions. The UI never computes mastery or adaptive
+// logic — it reads what the engine emits.
+
+import {
+  CourseEngine,
+  type CourseEngineConfig,
+  type CurriculumPlan,
+  type EngineState,
+  type EngineSnapshot,
+  type ContentItem,
+  type AnswerResult,
+  type StudentAnswer,
+  type StudentState,
+  type SessionProgress,
+  type Section,
+  type Listener,
+} from 'quizzer-engine';
+import { updateCourse } from '../storage/course-storage.js';
+
+// --- Types ---
+
+type SectionInfo = {
+  section: Section;
+  sectionIndex: number;
+  totalSections: number;
+};
+
+type ItemInfo = {
+  item: ContentItem;
+  itemIndex: number;
+  totalItems: number;
+};
+
+type ResultInfo = {
+  result: AnswerResult;
+  studentState: StudentState;
+  progress: SessionProgress;
+};
+
+type ErrorInfo = {
+  message: string;
+  recoverable: boolean;
+};
+
+export type EngineSessionConfig = {
+  apiKey: string;
+  snapshot?: EngineSnapshot;
+  courseId?: string;
+  storage?: Storage;
+};
+
+export type EngineSession = ReturnType<typeof createEngineSession>;
+
+// --- Factory ---
+
+export function createEngineSession(config: EngineSessionConfig) {
+  const engineConfig: CourseEngineConfig = { apiKey: config.apiKey };
+
+  let engine: CourseEngine | null = config.snapshot
+    ? CourseEngine.restore(config.snapshot, engineConfig)
+    : new CourseEngine(engineConfig);
+
+  // --- Reactive state ---
+
+  let engineState = $state<EngineState>(engine.state);
+  let curriculum = $state<CurriculumPlan | null>(engine.curriculum);
+  let currentSection = $state<SectionInfo | null>(null);
+  let currentItem = $state<ItemInfo | null>(null);
+  let lastResult = $state<ResultInfo | null>(null);
+  let studentState = $state<StudentState | null>(null);
+  let progress = $state<SessionProgress | null>(null);
+  let apiLoading = $state(false);
+  let error = $state<ErrorInfo | null>(null);
+
+  // If restoring, sync initial state from snapshot
+  if (config.snapshot && engine) {
+    engineState = engine.state;
+    curriculum = engine.curriculum;
+    studentState = engine.studentState;
+    progress = engine.sessionProgress;
+  }
+
+  // --- Event handlers ---
+
+  const onStateChange: Listener<'stateChange'> = (payload) => {
+    engineState = payload.to;
+  };
+
+  const onSyllabusLoaded: Listener<'syllabusLoaded'> = (payload) => {
+    curriculum = payload.curriculum;
+  };
+
+  const onSectionStart: Listener<'sectionStart'> = (payload) => {
+    currentSection = {
+      section: payload.section,
+      sectionIndex: payload.sectionIndex,
+      totalSections: payload.totalSections,
+    };
+    // Reset item and result state for the new section
+    currentItem = null;
+    lastResult = null;
+  };
+
+  const onItemShow: Listener<'itemShow'> = (payload) => {
+    currentItem = {
+      item: payload.item,
+      itemIndex: payload.itemIndex,
+      totalItems: payload.totalItems,
+    };
+  };
+
+  const onAnswerResult: Listener<'answerResult'> = (payload) => {
+    lastResult = {
+      result: payload.result,
+      studentState: payload.studentState,
+      progress: payload.progress,
+    };
+    studentState = payload.studentState;
+    progress = payload.progress;
+    autoSave();
+  };
+
+  const onSectionComplete: Listener<'sectionComplete'> = (payload) => {
+    studentState = payload.studentState;
+    progress = payload.progress;
+    autoSave();
+  };
+
+  const onCourseComplete: Listener<'courseComplete'> = (payload) => {
+    studentState = payload.studentState;
+    progress = payload.progress;
+    autoSave();
+  };
+
+  const onApiCallStart: Listener<'apiCallStart'> = () => {
+    apiLoading = true;
+  };
+
+  const onApiCallComplete: Listener<'apiCallComplete'> = () => {
+    apiLoading = false;
+  };
+
+  const onError: Listener<'error'> = (payload) => {
+    error = { message: payload.message, recoverable: payload.recoverable };
+  };
+
+  // --- Subscribe to engine events ---
+
+  function subscribe(eng: CourseEngine): void {
+    eng.on('stateChange', onStateChange);
+    eng.on('syllabusLoaded', onSyllabusLoaded);
+    eng.on('sectionStart', onSectionStart);
+    eng.on('itemShow', onItemShow);
+    eng.on('answerResult', onAnswerResult);
+    eng.on('sectionComplete', onSectionComplete);
+    eng.on('courseComplete', onCourseComplete);
+    eng.on('apiCallStart', onApiCallStart);
+    eng.on('apiCallComplete', onApiCallComplete);
+    eng.on('error', onError);
+  }
+
+  function unsubscribe(eng: CourseEngine): void {
+    eng.off('stateChange', onStateChange);
+    eng.off('syllabusLoaded', onSyllabusLoaded);
+    eng.off('sectionStart', onSectionStart);
+    eng.off('itemShow', onItemShow);
+    eng.off('answerResult', onAnswerResult);
+    eng.off('sectionComplete', onSectionComplete);
+    eng.off('courseComplete', onCourseComplete);
+    eng.off('apiCallStart', onApiCallStart);
+    eng.off('apiCallComplete', onApiCallComplete);
+    eng.off('error', onError);
+  }
+
+  subscribe(engine);
+
+  // --- Auto-save ---
+
+  function autoSave(): void {
+    if (!config.courseId || !config.storage || !engine) return;
+    const snapshot = engine.serialize();
+    updateCourse(config.courseId, { snapshot }, config.storage);
+  }
+
+  // --- Public API ---
+
+  return {
+    // Reactive state (read via getters)
+    get engineState() {
+      return engineState;
+    },
+    get curriculum() {
+      return curriculum;
+    },
+    get currentSection() {
+      return currentSection;
+    },
+    get currentItem() {
+      return currentItem;
+    },
+    get lastResult() {
+      return lastResult;
+    },
+    get studentState() {
+      return studentState;
+    },
+    get progress() {
+      return progress;
+    },
+    get apiLoading() {
+      return apiLoading;
+    },
+    get error() {
+      return error;
+    },
+
+    // --- Engine actions ---
+
+    loadCurriculum(plan: CurriculumPlan): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.loadCurriculum(plan);
+    },
+
+    startSection(sectionId: string): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.startSection(sectionId);
+    },
+
+    setSectionContent(items: ContentItem[]): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.setSectionContent(items);
+    },
+
+    submitAnswer(answer: StudentAnswer): AnswerResult {
+      if (!engine) throw new Error('Session is disposed');
+      return engine.submitAnswer(answer);
+    },
+
+    nextItem(): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.nextItem();
+    },
+
+    skipQuestion(): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.skipQuestion();
+    },
+
+    nextSection(): void {
+      if (!engine) throw new Error('Session is disposed');
+      engine.nextSection();
+    },
+
+    // --- Lifecycle ---
+
+    serialize(): EngineSnapshot | null {
+      if (!engine) return null;
+      return engine.serialize();
+    },
+
+    dispose(): void {
+      if (engine) {
+        unsubscribe(engine);
+        engine = null;
+      }
+      engineState = 'idle';
+      curriculum = null;
+      currentSection = null;
+      currentItem = null;
+      lastResult = null;
+      studentState = null;
+      progress = null;
+      apiLoading = false;
+      error = null;
+    },
+  };
+}

--- a/apps/coursequizzer/tests/unit/engine-session.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import {
+  createEngineSession,
+  type EngineSession,
+} from '../../src/lib/stores/engine-session.svelte.js';
+import type {
+  CurriculumPlan,
+  ContentItem,
+  EngineSnapshot,
+  StudentAnswer,
+} from 'quizzer-engine';
+import {
+  updateCourse,
+  createCourse,
+  getCourse,
+  COURSES_STORAGE_KEY,
+} from '../../src/lib/storage/course-storage.js';
+
+// --- localStorage mock ---
+
+function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => store.clear()),
+    get length() {
+      return store.size;
+    },
+    key: vi.fn((_index: number) => null),
+  };
+}
+
+// --- Test fixtures ---
+
+function mockCurriculumPlan(): CurriculumPlan {
+  return {
+    courseTitle: 'Test Course',
+    sections: [
+      {
+        id: 's1',
+        title: 'Section 1',
+        topics: [{ id: 't1', name: 'Topic 1', section: 's1' }],
+      },
+      {
+        id: 's2',
+        title: 'Section 2',
+        topics: [{ id: 't2', name: 'Topic 2', section: 's2' }],
+      },
+    ],
+  };
+}
+
+function mockContentItems(): ContentItem[] {
+  return [
+    {
+      type: 'explanation',
+      topicId: 't1',
+      title: 'Intro to Topic 1',
+      content: 'This is an explanation.',
+    },
+    {
+      type: 'multiple-choice',
+      id: 'q1',
+      topicId: 't1',
+      question: 'What is 2+2?',
+      options: ['3', '4', '5', '6'],
+      correctIndex: 1,
+    },
+  ];
+}
+
+function correctAnswer(): StudentAnswer {
+  return { type: 'multiple-choice', selectedIndex: 1 };
+}
+
+function wrongAnswer(): StudentAnswer {
+  return { type: 'multiple-choice', selectedIndex: 0 };
+}
+
+describe('createEngineSession', () => {
+  // --- Initial state ---
+
+  it('starts in idle state with null values', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    expect(session.engineState).toBe('idle');
+    expect(session.curriculum).toBeNull();
+    expect(session.currentSection).toBeNull();
+    expect(session.currentItem).toBeNull();
+    expect(session.lastResult).toBeNull();
+    expect(session.progress).toBeNull();
+    expect(session.studentState).toBeNull();
+    expect(session.apiLoading).toBe(false);
+    expect(session.error).toBeNull();
+  });
+
+  // --- Curriculum loading ---
+
+  it('updates state after loading a curriculum', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+
+    expect(session.engineState).toBe('ready');
+    expect(session.curriculum).not.toBeNull();
+    expect(session.curriculum!.courseTitle).toBe('Test Course');
+    expect(session.curriculum!.sections).toHaveLength(2);
+  });
+
+  // --- Section start ---
+
+  it('updates currentSection when a section starts', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+
+    expect(session.engineState).toBe('loading');
+    expect(session.currentSection).not.toBeNull();
+    expect(session.currentSection!.section.id).toBe('s1');
+    expect(session.currentSection!.sectionIndex).toBe(0);
+    expect(session.currentSection!.totalSections).toBe(2);
+  });
+
+  // --- Content ready and item display ---
+
+  it('updates currentItem when content is set', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+
+    expect(session.engineState).toBe('practicing');
+    expect(session.currentItem).not.toBeNull();
+    expect(session.currentItem!.item.type).toBe('explanation');
+    expect(session.currentItem!.itemIndex).toBe(0);
+    expect(session.currentItem!.totalItems).toBe(2);
+  });
+
+  // --- Answer submission ---
+
+  it('updates lastResult after submitting an answer', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+
+    // Advance past the explanation
+    session.nextItem();
+
+    // Now on the question — submit a correct answer
+    const result = session.submitAnswer(correctAnswer());
+    expect(result.correct).toBe(true);
+
+    expect(session.engineState).toBe('answered');
+    expect(session.lastResult).not.toBeNull();
+    expect(session.lastResult!.result.correct).toBe(true);
+    expect(session.lastResult!.studentState).toBeDefined();
+    expect(session.lastResult!.progress).toBeDefined();
+  });
+
+  it('tracks incorrect answers', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem(); // past explanation
+
+    const result = session.submitAnswer(wrongAnswer());
+    expect(result.correct).toBe(false);
+    expect(session.lastResult!.result.correct).toBe(false);
+  });
+
+  // --- Item navigation ---
+
+  it('advances to the next item after answering', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem(); // past explanation
+    session.submitAnswer(correctAnswer());
+    session.nextItem(); // past the answered question
+
+    // Section should be complete (only 2 items)
+    expect(session.engineState).toBe('sectionComplete');
+  });
+
+  // --- Skip question ---
+
+  it('skips a question and advances', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem(); // past explanation
+    session.skipQuestion();
+
+    // Section complete after skipping the only question
+    expect(session.engineState).toBe('sectionComplete');
+  });
+
+  // --- Section completion ---
+
+  it('tracks section completion with student state and progress', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem(); // past explanation
+    session.submitAnswer(correctAnswer());
+    session.nextItem(); // triggers section complete
+
+    expect(session.engineState).toBe('sectionComplete');
+    expect(session.studentState).not.toBeNull();
+    expect(session.progress).not.toBeNull();
+  });
+
+  // --- Course completion ---
+
+  it('tracks course completion after all sections', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+
+    // Complete section 1
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem();
+    session.submitAnswer(correctAnswer());
+    session.nextItem();
+
+    // Start and complete section 2
+    session.startSection('s2');
+    session.setSectionContent([
+      {
+        type: 'multiple-choice',
+        id: 'q2',
+        topicId: 't2',
+        question: 'What is 3+3?',
+        options: ['5', '6', '7', '8'],
+        correctIndex: 1,
+      },
+    ]);
+    session.submitAnswer({ type: 'multiple-choice', selectedIndex: 1 });
+    session.nextItem(); // complete section 2
+    session.nextSection(); // triggers course complete
+
+    expect(session.engineState).toBe('complete');
+    expect(session.studentState).not.toBeNull();
+    expect(session.progress).not.toBeNull();
+  });
+
+  // --- Error tracking ---
+
+  it('captures engine errors', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+
+    // Trying to start a section without loading curriculum should throw
+    expect(() => session.startSection('s1')).toThrow();
+  });
+
+  // --- Dispose / cleanup ---
+
+  it('clears state on dispose', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+
+    expect(session.engineState).toBe('ready');
+    session.dispose();
+
+    expect(session.engineState).toBe('idle');
+    expect(session.curriculum).toBeNull();
+  });
+
+  it('unsubscribes from engine events on dispose', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.dispose();
+
+    // After dispose, creating a new session should work independently
+    const session2 = createEngineSession({ apiKey: 'test-key-2' });
+    session2.loadCurriculum(mockCurriculumPlan());
+    expect(session2.engineState).toBe('ready');
+    // Original session should still show idle (disposed)
+    expect(session.engineState).toBe('idle');
+  });
+
+  // --- Restore from snapshot ---
+
+  it('restores session from a snapshot', () => {
+    // Build a session and take a snapshot
+    const session1 = createEngineSession({ apiKey: 'test-key' });
+    session1.loadCurriculum(mockCurriculumPlan());
+    session1.startSection('s1');
+    session1.setSectionContent(mockContentItems());
+
+    const snapshot = session1.serialize()!;
+    expect(snapshot).not.toBeNull();
+
+    // Restore into a new session
+    const session2 = createEngineSession({ apiKey: 'test-key', snapshot });
+
+    expect(session2.engineState).toBe('practicing');
+    expect(session2.curriculum).not.toBeNull();
+    expect(session2.curriculum!.courseTitle).toBe('Test Course');
+  });
+
+  // --- Auto-save to course storage ---
+
+  it('auto-saves snapshot after answer submission when courseId and storage are provided', () => {
+    const storage = createLocalStorageMock();
+    const course = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+
+    const session = createEngineSession({
+      apiKey: 'test-key',
+      courseId: course.id,
+      storage,
+    });
+
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem();
+    session.submitAnswer(correctAnswer());
+
+    // Verify that course storage was updated with a snapshot
+    const updated = getCourse(course.id, storage);
+    expect(updated).not.toBeNull();
+    expect(updated!.snapshot).not.toBeNull();
+    expect(updated!.snapshot!.state).toBe('answered');
+  });
+
+  it('auto-saves snapshot on section completion', () => {
+    const storage = createLocalStorageMock();
+    const course = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+
+    const session = createEngineSession({
+      apiKey: 'test-key',
+      courseId: course.id,
+      storage,
+    });
+
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem();
+    session.submitAnswer(correctAnswer());
+    session.nextItem(); // triggers section complete
+
+    const updated = getCourse(course.id, storage);
+    expect(updated!.snapshot).not.toBeNull();
+    expect(updated!.snapshot!.state).toBe('sectionComplete');
+  });
+
+  it('does not auto-save when courseId is not provided', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockContentItems());
+    session.nextItem();
+    session.submitAnswer(correctAnswer());
+    // No crash, no storage interaction — just verifying it doesn't blow up
+    expect(session.lastResult).not.toBeNull();
+  });
+
+  // --- API key not leaked ---
+
+  it('does not expose the API key in serialized snapshots', () => {
+    const session = createEngineSession({ apiKey: 'sk-ant-secret-key-12345' });
+    session.loadCurriculum(mockCurriculumPlan());
+    const snapshot = session.serialize()!;
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain('sk-ant-secret-key-12345');
+  });
+
+  // --- Replacing a session disposes the old one ---
+
+  it('serialize returns null after dispose', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.dispose();
+    expect(session.serialize()).toBeNull();
+  });
+});

--- a/apps/coursequizzer/vitest.config.ts
+++ b/apps/coursequizzer/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
+  plugins: [svelte({ hot: false })],
   test: {
     include: ['tests/**/*.test.ts'],
   },


### PR DESCRIPTION
## Summary

- Adds `engine-session.svelte.ts` — a reactive Svelte 5 store wrapper around `CourseEngine` that translates all engine events into `$state` runes
- Exposes read-only reactive state (engineState, curriculum, currentSection, currentItem, lastResult, studentState, progress, apiLoading, error) and pass-through actions (loadCurriculum, startSection, setSectionContent, submitAnswer, nextItem, skipQuestion, nextSection)
- Auto-saves engine snapshots to course storage on answer submission, section completion, and course completion
- Supports restore from snapshots and proper dispose/cleanup of event listeners
- Updates app vitest config with Svelte vite plugin for `.svelte.ts` file compilation in tests

Closes #18

## Test plan

- [x] 19 new tests covering: initial state, curriculum loading, section start, content display, answer submission (correct/incorrect), item navigation, skip, section completion, course completion, error handling, dispose/cleanup, snapshot restore, auto-save to course storage, and API key security
- [x] `pnpm -r test` — all 209 tests pass (160 engine + 49 app)
- [x] `pnpm -r build` — both packages build cleanly
- [x] `pnpm format` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)