### PR TITLE
feat: add course list and course overview pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.0 — 2026-04-12
+
+### Phase 2: App Foundation (continued)
+
+- Course list home page: shows all courses with progress summary, open link, and delete with confirmation
+- Course overview page: curriculum sections with expanded topics, progress bar, mastery percentages, Start/Resume Learning action
+- Progress helper module (`src/lib/stores/course-progress.ts`): extracts per-section and overall progress from snapshot data
+- Delete course with explicit confirmation step on both home and overview pages
+- Graceful handling of missing/invalid course IDs with helpful message
+- Empty state for new users with API key prompt and create-course link
+- All user/LLM text rendered with Svelte auto-escaping (no `{@html}`)
+- 12 new tests covering progress extraction, mastery formatting, and progress labels
+
 ## 0.5.0 — 2026-04-12
 
 ### Phase 2: App Foundation (continued)

--- a/apps/coursequizzer/src/lib/stores/course-progress.ts
+++ b/apps/coursequizzer/src/lib/stores/course-progress.ts
@@ -62,10 +62,12 @@ export function getCourseProgress(record: CourseRecord): CourseProgressSummary |
   });
 
   const allMasteries = Object.values(masteryMap) as TopicMastery[];
+  const attemptedMasteries = allMasteries.filter((m) => m.questionsAnswered > 0);
   const totalAnswered = allMasteries.reduce((sum, m) => sum + m.questionsAnswered, 0);
   const overallMastery =
-    allMasteries.length > 0
-      ? allMasteries.reduce((sum, m) => sum + m.score, 0) / allMasteries.length
+    attemptedMasteries.length > 0
+      ? attemptedMasteries.reduce((sum, m) => sum + m.score, 0) /
+        attemptedMasteries.length
       : 0;
 
   return {

--- a/apps/coursequizzer/src/lib/stores/course-progress.ts
+++ b/apps/coursequizzer/src/lib/stores/course-progress.ts
@@ -1,0 +1,105 @@
+// --- Course Progress ---
+// Extracts progress information from a CourseRecord's snapshot data.
+// Pure logic — no Svelte, no browser APIs.
+
+import type { CourseRecord } from '../storage/course-storage.js';
+import type { EngineSnapshot, TopicMastery } from 'quizzer-engine';
+
+export type SectionProgress = {
+  sectionId: string;
+  /** Whether the student has started or completed this section. */
+  started: boolean;
+  /** Number of topics with at least one answered question. */
+  topicsAttempted: number;
+  /** Total number of topics in the section. */
+  topicsTotal: number;
+  /** Average mastery score (0–1) across attempted topics in this section. */
+  mastery: number;
+};
+
+export type CourseProgressSummary = {
+  /** Index of the section the student was last working on (from snapshot). */
+  currentSectionIndex: number;
+  /** Total number of sections. */
+  totalSections: number;
+  /** Overall mastery score (0–1) across all attempted topics. */
+  overallMastery: number;
+  /** Total questions answered across all topics. */
+  totalQuestionsAnswered: number;
+  /** Per-section progress. */
+  sections: SectionProgress[];
+  /** Whether the course has been started (snapshot exists with answers). */
+  hasProgress: boolean;
+};
+
+/**
+ * Extract a progress summary from a CourseRecord. Returns null if the course
+ * has no snapshot (never started).
+ */
+export function getCourseProgress(record: CourseRecord): CourseProgressSummary | null {
+  const { curriculum, snapshot } = record;
+  if (!snapshot) return null;
+
+  const masteryMap = snapshot.studentState?.masteryByTopic ?? {};
+  const sections = curriculum.sections;
+
+  const sectionProgress: SectionProgress[] = sections.map((section, index) => {
+    const topicIds = section.topics.map((t) => t.id);
+    const attempted = topicIds.filter((id) => masteryMap[id]?.questionsAnswered > 0);
+    const mastery =
+      attempted.length > 0
+        ? attempted.reduce((sum, id) => sum + (masteryMap[id]?.score ?? 0), 0) /
+          attempted.length
+        : 0;
+
+    return {
+      sectionId: section.id,
+      started: index < snapshot.currentSectionIndex || attempted.length > 0,
+      topicsAttempted: attempted.length,
+      topicsTotal: topicIds.length,
+      mastery,
+    };
+  });
+
+  const allMasteries = Object.values(masteryMap) as TopicMastery[];
+  const totalAnswered = allMasteries.reduce((sum, m) => sum + m.questionsAnswered, 0);
+  const overallMastery =
+    allMasteries.length > 0
+      ? allMasteries.reduce((sum, m) => sum + m.score, 0) / allMasteries.length
+      : 0;
+
+  return {
+    currentSectionIndex: snapshot.currentSectionIndex,
+    totalSections: sections.length,
+    overallMastery,
+    totalQuestionsAnswered: totalAnswered,
+    sections: sectionProgress,
+    hasProgress: totalAnswered > 0,
+  };
+}
+
+/**
+ * Format a mastery score (0–1) as a percentage string like "75%".
+ */
+export function formatMastery(score: number): string {
+  return `${Math.round(score * 100)}%`;
+}
+
+/**
+ * Get a short human-readable progress label for a course.
+ * Examples: "Not started", "Section 2/5 · 75% mastery", "Complete"
+ */
+export function getProgressLabel(record: CourseRecord): string {
+  const progress = getCourseProgress(record);
+  if (!progress || !progress.hasProgress) return 'Not started';
+
+  if (
+    progress.currentSectionIndex >= progress.totalSections &&
+    progress.overallMastery > 0
+  ) {
+    return `Complete · ${formatMastery(progress.overallMastery)} mastery`;
+  }
+
+  const sectionNum = progress.currentSectionIndex + 1;
+  return `Section ${sectionNum}/${progress.totalSections} · ${formatMastery(progress.overallMastery)} mastery`;
+}

--- a/apps/coursequizzer/src/routes/+page.svelte
+++ b/apps/coursequizzer/src/routes/+page.svelte
@@ -1,10 +1,33 @@
 <script lang="ts">
-  import { listCourses } from '$lib/storage/course-storage.js';
+  import { listCourses, deleteCourse } from '$lib/storage/course-storage.js';
   import { hasApiKey } from '$lib/stores/api-key.js';
+  import { getProgressLabel } from '$lib/stores/course-progress.js';
 
-  const courses = $derived(listCourses(localStorage));
+  let courses = $state(listCourses(localStorage));
   const apiKeyStored = $derived(hasApiKey(localStorage));
+
+  // --- Delete confirmation ---
+
+  let confirmDeleteId = $state<string | null>(null);
+
+  function requestDelete(courseId: string) {
+    confirmDeleteId = courseId;
+  }
+
+  function cancelDelete() {
+    confirmDeleteId = null;
+  }
+
+  function confirmDelete(courseId: string) {
+    deleteCourse(courseId, localStorage);
+    courses = listCourses(localStorage);
+    confirmDeleteId = null;
+  }
 </script>
+
+<svelte:head>
+  <title>CourseQuizzer</title>
+</svelte:head>
 
 <main>
   <h1>CourseQuizzer</h1>
@@ -27,13 +50,142 @@
   {#if courses.length > 0}
     <section>
       <h2>Your Courses</h2>
-      <ul>
+      <ul class="course-list">
         {#each courses as course (course.id)}
-          <li>
-            <a href="/course/{course.id}">{course.title}</a>
+          <li class="course-card">
+            <div class="course-info">
+              <a href="/course/{course.id}" class="course-title">{course.title}</a>
+              <span class="course-progress">{getProgressLabel(course)}</span>
+            </div>
+            <div class="course-actions">
+              <a href="/course/{course.id}" class="btn">Open</a>
+              {#if confirmDeleteId === course.id}
+                <span class="confirm-delete">
+                  Delete?
+                  <button type="button" class="btn-danger" onclick={() => confirmDelete(course.id)}>Yes</button>
+                  <button type="button" class="btn-secondary" onclick={cancelDelete}>No</button>
+                </span>
+              {:else}
+                <button type="button" class="btn-secondary" onclick={() => requestDelete(course.id)}>Delete</button>
+              {/if}
+            </div>
           </li>
         {/each}
       </ul>
     </section>
+  {:else if apiKeyStored}
+    <section>
+      <p>No courses yet. <a href="/course/new">Create your first course</a> from a syllabus.</p>
+    </section>
   {/if}
 </main>
+
+<style>
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1rem;
+  }
+
+  nav {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .course-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .course-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+  }
+
+  .course-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .course-title {
+    font-weight: 600;
+    font-size: 1.05rem;
+    text-decoration: none;
+    color: #111;
+  }
+
+  .course-title:hover {
+    text-decoration: underline;
+  }
+
+  .course-progress {
+    font-size: 0.85rem;
+    color: #666;
+  }
+
+  .course-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .btn {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border: 1px solid #333;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .btn:hover {
+    background: #555;
+  }
+
+  .btn-secondary {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border: 1px solid #999;
+    border-radius: 4px;
+    background: #fff;
+    color: #333;
+    cursor: pointer;
+  }
+
+  .btn-secondary:hover {
+    background: #f0f0f0;
+  }
+
+  .btn-danger {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border: 1px solid #c00;
+    border-radius: 4px;
+    background: #c00;
+    color: #fff;
+    cursor: pointer;
+  }
+
+  .btn-danger:hover {
+    background: #a00;
+  }
+
+  .confirm-delete {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+    font-size: 0.9rem;
+    color: #c00;
+    font-weight: 600;
+  }
+</style>

--- a/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
@@ -1,9 +1,56 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { getCourse } from '$lib/storage/course-storage.js';
+  import { goto } from '$app/navigation';
+  import { getCourse, deleteCourse } from '$lib/storage/course-storage.js';
+  import { hasApiKey } from '$lib/stores/api-key.js';
+  import {
+    getCourseProgress,
+    formatMastery,
+    getProgressLabel,
+  } from '$lib/stores/course-progress.js';
 
   const courseId = $derived(page.params.courseId);
   const course = $derived(courseId ? getCourse(courseId, localStorage) : null);
+  const progress = $derived(course ? getCourseProgress(course) : null);
+  const apiKeyStored = $derived(hasApiKey(localStorage));
+
+  // --- Delete confirmation ---
+
+  let confirmingDelete = $state(false);
+
+  function requestDelete() {
+    confirmingDelete = true;
+  }
+
+  function cancelDelete() {
+    confirmingDelete = false;
+  }
+
+  function confirmDelete() {
+    if (!courseId) return;
+    deleteCourse(courseId, localStorage);
+    goto('/');
+  }
+
+  // --- Section resume logic ---
+
+  /**
+   * Determine which section to link to for "Start Learning" / "Resume".
+   * Uses the snapshot's currentSectionIndex if available.
+   */
+  function getResumeSectionId(): string | null {
+    if (!course) return null;
+    const sections = course.curriculum.sections;
+    if (sections.length === 0) return null;
+
+    if (progress && progress.currentSectionIndex < sections.length) {
+      return sections[progress.currentSectionIndex].id;
+    }
+    return sections[0].id;
+  }
+
+  const resumeSectionId = $derived(getResumeSectionId());
+  const hasStarted = $derived(progress?.hasProgress ?? false);
 </script>
 
 <svelte:head>
@@ -12,22 +59,263 @@
 
 <main>
   {#if course}
-    <h1>{course.title}</h1>
-    <p>{course.curriculum.description}</p>
+    <header>
+      <h1>{course.title}</h1>
+      <p class="description">{course.curriculum.description}</p>
 
-    <h2>Sections</h2>
-    <ol>
-      {#each course.curriculum.sections as section (section.id)}
-        <li>
-          <strong>{section.title}</strong>
-          ({section.topics.length} topics)
+      {#if progress && progress.hasProgress}
+        <div class="progress-bar-container">
+          <div class="progress-bar" style="width: {Math.round(progress.overallMastery * 100)}%"></div>
+        </div>
+        <p class="progress-summary">
+          {getProgressLabel(course)} · {progress.totalQuestionsAnswered} questions answered
+        </p>
+      {/if}
+    </header>
+
+    <!-- Primary action -->
+    {#if !apiKeyStored}
+      <section class="callout">
+        <p>
+          Add your Anthropic API key in <a href="/settings">Settings</a> before starting a section.
+        </p>
+      </section>
+    {:else if resumeSectionId}
+      <div class="primary-action">
+        <a href="/course/{course.id}/learn" class="btn-primary">
+          {hasStarted ? 'Resume Learning' : 'Start Learning'}
+        </a>
+      </div>
+    {/if}
+
+    <!-- Sections -->
+    <h2>Sections ({course.curriculum.sections.length})</h2>
+    <ol class="section-list">
+      {#each course.curriculum.sections as section, index (section.id)}
+        {@const sp = progress?.sections[index]}
+        <li class="section-card">
+          <div class="section-header">
+            <strong>{section.title}</strong>
+            {#if sp?.started}
+              <span class="section-status">
+                {sp.topicsAttempted}/{sp.topicsTotal} topics · {formatMastery(sp.mastery)}
+              </span>
+            {:else}
+              <span class="section-status muted">
+                {section.topics.length} topics
+              </span>
+            {/if}
+          </div>
+          <ul class="topic-list">
+            {#each section.topics as topic (topic.id)}
+              <li class="topic-item">
+                <span class="topic-title">{topic.title}</span>
+                <span class="topic-desc">{topic.description}</span>
+              </li>
+            {/each}
+          </ul>
         </li>
       {/each}
     </ol>
+
+    <!-- Delete -->
+    <section class="danger-zone">
+      {#if confirmingDelete}
+        <p class="confirm-text">
+          Are you sure you want to delete this course? This cannot be undone.
+        </p>
+        <div class="actions">
+          <button type="button" class="btn-danger" onclick={confirmDelete}>
+            Yes, delete
+          </button>
+          <button type="button" class="btn-secondary" onclick={cancelDelete}>
+            Cancel
+          </button>
+        </div>
+      {:else}
+        <button type="button" class="btn-secondary" onclick={requestDelete}>
+          Delete course
+        </button>
+      {/if}
+    </section>
   {:else}
     <h1>Course not found</h1>
     <p>No course with this ID was found in your browser storage.</p>
+    <p>It may have been deleted or the link may be incorrect.</p>
   {/if}
 
   <p><a href="/">← Back to home</a></p>
 </main>
+
+<style>
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1rem;
+  }
+
+  header {
+    margin-bottom: 1.5rem;
+  }
+
+  .description {
+    color: #444;
+    margin-top: 0.25rem;
+  }
+
+  .progress-bar-container {
+    background: #e0e0e0;
+    border-radius: 4px;
+    height: 8px;
+    margin-top: 0.75rem;
+    overflow: hidden;
+  }
+
+  .progress-bar {
+    background: #2a7;
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+  }
+
+  .progress-summary {
+    font-size: 0.85rem;
+    color: #666;
+    margin-top: 0.25rem;
+  }
+
+  .callout {
+    padding: 0.75rem;
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 6px;
+    margin-bottom: 1.5rem;
+  }
+
+  .primary-action {
+    margin-bottom: 1.5rem;
+  }
+
+  .btn-primary {
+    display: inline-block;
+    padding: 0.6rem 1.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border: 1px solid #333;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .btn-primary:hover {
+    background: #555;
+  }
+
+  .section-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    counter-reset: section-counter;
+  }
+
+  .section-card {
+    padding: 0.75rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+    counter-increment: section-counter;
+  }
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .section-header strong::before {
+    content: counter(section-counter) '. ';
+  }
+
+  .section-status {
+    font-size: 0.85rem;
+    color: #2a7;
+    font-weight: 600;
+  }
+
+  .section-status.muted {
+    color: #999;
+    font-weight: normal;
+  }
+
+  .topic-list {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0 0 1rem;
+  }
+
+  .topic-item {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .topic-title {
+    font-weight: 500;
+  }
+
+  .topic-desc {
+    color: #666;
+  }
+
+  .topic-desc::before {
+    content: ' — ';
+  }
+
+  .danger-zone {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
+  }
+
+  .confirm-text {
+    color: #c00;
+    font-weight: 600;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .btn-secondary {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border: 1px solid #999;
+    border-radius: 4px;
+    background: #fff;
+    color: #333;
+    cursor: pointer;
+  }
+
+  .btn-secondary:hover {
+    background: #f0f0f0;
+  }
+
+  .btn-danger {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    border: 1px solid #c00;
+    border-radius: 4px;
+    background: #c00;
+    color: #fff;
+    cursor: pointer;
+  }
+
+  .btn-danger:hover {
+    background: #a00;
+  }
+</style>

--- a/apps/coursequizzer/tests/unit/course-progress.test.ts
+++ b/apps/coursequizzer/tests/unit/course-progress.test.ts
@@ -165,6 +165,27 @@ describe('getCourseProgress', () => {
     expect(progress.totalQuestionsAnswered).toBe(9); // 5 + 4
     expect(progress.hasProgress).toBe(true);
   });
+
+  it('excludes unattempted topics from overall mastery', () => {
+    const state: StudentState = {
+      masteryByTopic: {
+        t1: { topicId: 't1', score: 0.8, questionsAnswered: 5, questionsCorrect: 4 },
+        t2: { topicId: 't2', score: 0, questionsAnswered: 0, questionsCorrect: 0 },
+        t3: { topicId: 't3', score: 0.6, questionsAnswered: 3, questionsCorrect: 2 },
+      },
+      gaps: [],
+    };
+    const snapshot = mockSnapshot({
+      currentSectionIndex: 1,
+      studentState: state,
+    });
+    const record = mockRecord({ snapshot });
+    const progress = getCourseProgress(record)!;
+
+    // Only t1 (0.8) and t3 (0.6) are attempted — t2 has 0 answers and must not drag the average down
+    expect(progress.overallMastery).toBeCloseTo(0.7); // avg of 0.8 and 0.6, not (0.8 + 0 + 0.6) / 3
+    expect(progress.totalQuestionsAnswered).toBe(8); // 5 + 3
+  });
 });
 
 // --- formatMastery ---

--- a/apps/coursequizzer/tests/unit/course-progress.test.ts
+++ b/apps/coursequizzer/tests/unit/course-progress.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCourseProgress,
+  formatMastery,
+  getProgressLabel,
+} from '../../src/lib/stores/course-progress.js';
+import type { CourseRecord } from '../../src/lib/storage/course-storage.js';
+import type { CurriculumPlan, EngineSnapshot, StudentState } from 'quizzer-engine';
+
+// --- Fixtures ---
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Algorithms',
+    description: 'An intro to algorithms.',
+    sections: [
+      {
+        id: 's1',
+        title: 'Sorting',
+        order: 0,
+        topics: [
+          { id: 't1', title: 'Bubble Sort', description: 'The simplest sort.' },
+          { id: 't2', title: 'Merge Sort', description: 'Divide and conquer.' },
+        ],
+      },
+      {
+        id: 's2',
+        title: 'Searching',
+        order: 1,
+        topics: [{ id: 't3', title: 'Binary Search', description: 'Log-time search.' }],
+      },
+      {
+        id: 's3',
+        title: 'Graphs',
+        order: 2,
+        topics: [
+          { id: 't4', title: 'BFS', description: 'Breadth-first search.' },
+          { id: 't5', title: 'DFS', description: 'Depth-first search.' },
+        ],
+      },
+    ],
+  };
+}
+
+function mockRecord(overrides?: Partial<CourseRecord>): CourseRecord {
+  return {
+    id: 'course-1',
+    title: 'Algorithms',
+    curriculum: mockCurriculum(),
+    snapshot: null,
+    createdAt: '2026-04-10T00:00:00.000Z',
+    updatedAt: '2026-04-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mockSnapshot(overrides?: Partial<EngineSnapshot>): EngineSnapshot {
+  return {
+    version: 3,
+    state: 'ready',
+    curriculum: mockCurriculum(),
+    currentSectionIndex: 0,
+    currentItemIndex: 0,
+    sectionItems: [],
+    studentState: { masteryByTopic: {}, gaps: [] },
+    lastAnswerResult: null,
+    ...overrides,
+  };
+}
+
+function studentStateWith(
+  topics: Record<string, { score: number; answered: number; correct: number }>
+): StudentState {
+  const masteryByTopic: Record<
+    string,
+    {
+      topicId: string;
+      score: number;
+      questionsAnswered: number;
+      questionsCorrect: number;
+    }
+  > = {};
+  for (const [id, data] of Object.entries(topics)) {
+    masteryByTopic[id] = {
+      topicId: id,
+      score: data.score,
+      questionsAnswered: data.answered,
+      questionsCorrect: data.correct,
+    };
+  }
+  return { masteryByTopic, gaps: [] };
+}
+
+// --- getCourseProgress ---
+
+describe('getCourseProgress', () => {
+  it('returns null when course has no snapshot', () => {
+    const record = mockRecord({ snapshot: null });
+    expect(getCourseProgress(record)).toBeNull();
+  });
+
+  it('returns a summary with zero progress when snapshot has no answered questions', () => {
+    const record = mockRecord({ snapshot: mockSnapshot() });
+    const progress = getCourseProgress(record);
+
+    expect(progress).not.toBeNull();
+    expect(progress!.hasProgress).toBe(false);
+    expect(progress!.overallMastery).toBe(0);
+    expect(progress!.totalQuestionsAnswered).toBe(0);
+    expect(progress!.totalSections).toBe(3);
+    expect(progress!.currentSectionIndex).toBe(0);
+  });
+
+  it('computes per-section progress from student state', () => {
+    const state = studentStateWith({
+      t1: { score: 0.8, answered: 5, correct: 4 },
+      t2: { score: 0.6, answered: 3, correct: 2 },
+    });
+    const snapshot = mockSnapshot({
+      currentSectionIndex: 1,
+      studentState: state,
+    });
+    const record = mockRecord({ snapshot });
+    const progress = getCourseProgress(record)!;
+
+    // Section 1 (s1): both topics attempted
+    expect(progress.sections[0].started).toBe(true);
+    expect(progress.sections[0].topicsAttempted).toBe(2);
+    expect(progress.sections[0].topicsTotal).toBe(2);
+    expect(progress.sections[0].mastery).toBeCloseTo(0.7); // avg of 0.8 and 0.6
+
+    // Section 2 (s2): no topics attempted, but index < currentSectionIndex is false (index=1, current=1)
+    expect(progress.sections[1].started).toBe(false);
+    expect(progress.sections[1].topicsAttempted).toBe(0);
+
+    // Section 3 (s3): not started
+    expect(progress.sections[2].started).toBe(false);
+    expect(progress.sections[2].topicsAttempted).toBe(0);
+  });
+
+  it('marks earlier sections as started based on currentSectionIndex', () => {
+    const snapshot = mockSnapshot({ currentSectionIndex: 2 });
+    const record = mockRecord({ snapshot });
+    const progress = getCourseProgress(record)!;
+
+    // Sections 0 and 1 are before currentSectionIndex
+    expect(progress.sections[0].started).toBe(true);
+    expect(progress.sections[1].started).toBe(true);
+    expect(progress.sections[2].started).toBe(false);
+  });
+
+  it('computes overall mastery across all attempted topics', () => {
+    const state = studentStateWith({
+      t1: { score: 1.0, answered: 5, correct: 5 },
+      t3: { score: 0.5, answered: 4, correct: 2 },
+    });
+    const snapshot = mockSnapshot({
+      currentSectionIndex: 1,
+      studentState: state,
+    });
+    const record = mockRecord({ snapshot });
+    const progress = getCourseProgress(record)!;
+
+    expect(progress.overallMastery).toBeCloseTo(0.75); // avg of 1.0 and 0.5
+    expect(progress.totalQuestionsAnswered).toBe(9); // 5 + 4
+    expect(progress.hasProgress).toBe(true);
+  });
+});
+
+// --- formatMastery ---
+
+describe('formatMastery', () => {
+  it('formats 0 as 0%', () => {
+    expect(formatMastery(0)).toBe('0%');
+  });
+
+  it('formats 1 as 100%', () => {
+    expect(formatMastery(1)).toBe('100%');
+  });
+
+  it('rounds to nearest integer', () => {
+    expect(formatMastery(0.756)).toBe('76%');
+    expect(formatMastery(0.333)).toBe('33%');
+  });
+});
+
+// --- getProgressLabel ---
+
+describe('getProgressLabel', () => {
+  it('returns "Not started" for a course with no snapshot', () => {
+    expect(getProgressLabel(mockRecord())).toBe('Not started');
+  });
+
+  it('returns "Not started" for a snapshot with no answered questions', () => {
+    const record = mockRecord({ snapshot: mockSnapshot() });
+    expect(getProgressLabel(record)).toBe('Not started');
+  });
+
+  it('returns section progress label when in progress', () => {
+    const state = studentStateWith({
+      t1: { score: 0.75, answered: 4, correct: 3 },
+    });
+    const snapshot = mockSnapshot({
+      currentSectionIndex: 0,
+      studentState: state,
+    });
+    const record = mockRecord({ snapshot });
+    expect(getProgressLabel(record)).toBe('Section 1/3 · 75% mastery');
+  });
+
+  it('returns complete label when all sections done', () => {
+    const state = studentStateWith({
+      t1: { score: 0.9, answered: 5, correct: 4 },
+    });
+    const snapshot = mockSnapshot({
+      currentSectionIndex: 3, // past last section
+      studentState: state,
+    });
+    const record = mockRecord({ snapshot });
+    expect(getProgressLabel(record)).toBe('Complete · 90% mastery');
+  });
+});


### PR DESCRIPTION
## Summary

- **Home page** (`/`): replaces the minimal course list with a card-based layout showing course title, progress summary (e.g., "Section 2/5 · 75% mastery"), an Open link, and a Delete button with explicit confirmation step.
- **Course overview** (`/course/[courseId]`): shows curriculum description, progress bar with mastery percentage, Start/Resume Learning action, sections with expanded topics and per-section progress, and delete-with-confirmation.
- **Progress helper** (`src/lib/stores/course-progress.ts`): pure-logic module that extracts per-section and overall progress from `CourseRecord` snapshot data. Computes topics attempted, mastery averages, and human-readable labels.
- Graceful handling of missing/invalid course IDs.
- Empty state for users with no courses yet.
- All text rendered with Svelte auto-escaping (no `{@html}`).
- 12 new unit tests for progress extraction, mastery formatting, and label generation.

## Test plan

- [x] `pnpm -r test` — 235 tests pass (160 engine + 75 app)
- [x] `pnpm -r build` — both packages build cleanly
- [x] `pnpm format` — all files formatted

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)