### PR TITLE
feat: add learn page content and answer flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@
 - Empty state for new users with API key prompt and create-course link
 - All user/LLM text rendered with Svelte auto-escaping (no `{@html}`)
 - 12 new tests covering progress extraction, mastery formatting, and progress labels
+- Learn page (`/course/[courseId]/learn`): content generation, explanation display, and answer flow for all 5 question types
+- Section picker: choose a section to start, generates content via ContentGenerator + ClaudeProvider
+- Renders explanations with Svelte auto-escaping (no `{@html}`)
+- Multiple choice: click-to-answer option buttons
+- Numeric input: form with number input and submit
+- Ordering: reorderable list with up/down arrow controls
+- Multi-select: toggle option buttons with visual selected state
+- Two-stage: first answer → follow-up question flow
+- Answer result screen: correct/incorrect feedback with correct answer shown on wrong answers
+- Section complete and course complete screens with mastery percentage
+- Skip question support for all question types
+- Report issue action on every content item (v1: console log)
+- Auto-saves engine snapshots to course storage after each answer and section completion
+- Restores session from snapshot when returning to a course in progress
+- "Start Learning" link added to course overview page
+- 5 new learn-flow tests covering full section completion, incorrect answers, skip, auto-save, and section navigation
 
 ## 0.5.0 — 2026-04-12
 

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -1,0 +1,767 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { getCourse } from '$lib/storage/course-storage.js';
+  import { getApiKey } from '$lib/stores/api-key.js';
+  import {
+    createEngineSession,
+    type EngineSession,
+  } from '$lib/stores/engine-session.svelte.js';
+  import {
+    ClaudeProvider,
+    ContentGenerator,
+    type ContentItem,
+    type Section,
+  } from 'quizzer-engine';
+
+  // --- State ---
+
+  const courseId = $derived(page.params.courseId);
+  const course = $derived(courseId ? getCourse(courseId, localStorage) : null);
+
+  let session: EngineSession | null = $state(null);
+  let generateError = $state('');
+  let generating = $state(false);
+
+  // Initialize session when course loads
+  $effect(() => {
+    if (!course) return;
+    const apiKey = getApiKey(localStorage);
+    if (!apiKey) return;
+
+    const newSession = createEngineSession({
+      apiKey,
+      courseId: course.id,
+      storage: localStorage,
+      snapshot: course.snapshot ?? undefined,
+    });
+
+    // If no snapshot, load the curriculum fresh
+    if (!course.snapshot) {
+      newSession.loadCurriculum(course.curriculum);
+    }
+    session = newSession;
+
+    return () => {
+      newSession.dispose();
+    };
+  });
+
+  // --- Content generation ---
+
+  async function handleStartSection(sectionId: string) {
+    if (!session || !course) return;
+    const apiKey = getApiKey(localStorage);
+    if (!apiKey) return;
+
+    generateError = '';
+    generating = true;
+
+    session.startSection(sectionId);
+
+    const section = course.curriculum.sections.find((s) => s.id === sectionId);
+    if (!section) {
+      generateError = 'Section not found.';
+      generating = false;
+      return;
+    }
+
+    try {
+      const provider = new ClaudeProvider({ apiKey });
+      const generator = new ContentGenerator(provider);
+      const items = await generator.generateSection(section, course.curriculum.title);
+      session.setSectionContent(items);
+    } catch (err) {
+      generateError =
+        err instanceof Error ? err.message : 'Failed to generate content.';
+    } finally {
+      generating = false;
+    }
+  }
+
+  // --- Answer handling ---
+
+  function handleMultipleChoice(selectedIndex: number) {
+    if (!session) return;
+    session.submitAnswer({ type: 'multiple-choice', selectedIndex });
+  }
+
+  function handleNumericInput(value: number) {
+    if (!session) return;
+    session.submitAnswer({ type: 'numeric-input', value });
+  }
+
+  function handleOrdering(order: number[]) {
+    if (!session) return;
+    session.submitAnswer({ type: 'ordering', order });
+  }
+
+  function handleMultiSelect(selectedIndices: number[]) {
+    if (!session) return;
+    session.submitAnswer({ type: 'multi-select', selectedIndices });
+  }
+
+  function handleTwoStage(selectedIndex: number, followUpSelectedIndex: number) {
+    if (!session) return;
+    session.submitAnswer({
+      type: 'two-stage',
+      selectedIndex,
+      followUpSelectedIndex,
+    });
+  }
+
+  function handleNext() {
+    session?.nextItem();
+  }
+
+  function handleSkip() {
+    session?.skipQuestion();
+  }
+
+  function handleNextSection() {
+    session?.nextSection();
+  }
+
+  function handleBackToOverview() {
+    goto(`/course/${courseId}`);
+  }
+
+  function handleReportIssue() {
+    const item = session?.currentItem?.item;
+    if (item) {
+      // v1: log to console per spec
+      console.log('[CourseQuizzer] Content issue reported:', {
+        itemType: item.type,
+        topicId: item.topicId,
+        timestamp: new Date().toISOString(),
+      });
+      reportedItem = true;
+      setTimeout(() => {
+        reportedItem = false;
+      }, 2000);
+    }
+  }
+
+  let reportedItem = $state(false);
+
+  // --- Two-stage local state ---
+
+  let twoStageFirstAnswer = $state<number | null>(null);
+
+  // Reset two-stage state when item changes
+  $effect(() => {
+    if (session?.currentItem) {
+      twoStageFirstAnswer = null;
+    }
+  });
+
+  // --- Ordering local state ---
+
+  let orderingSequence = $state<number[]>([]);
+
+  $effect(() => {
+    const item = session?.currentItem?.item;
+    if (item && item.type === 'ordering') {
+      // Initialize with natural order
+      orderingSequence = item.items.map((_, i) => i);
+    }
+  });
+
+  function moveOrderingItem(fromIdx: number, direction: 'up' | 'down') {
+    const toIdx = direction === 'up' ? fromIdx - 1 : fromIdx + 1;
+    if (toIdx < 0 || toIdx >= orderingSequence.length) return;
+    const copy = [...orderingSequence];
+    [copy[fromIdx], copy[toIdx]] = [copy[toIdx], copy[fromIdx]];
+    orderingSequence = copy;
+  }
+
+  // --- Multi-select local state ---
+
+  let multiSelectChoices = $state<Set<number>>(new Set());
+
+  $effect(() => {
+    const item = session?.currentItem?.item;
+    if (item && item.type === 'multi-select') {
+      multiSelectChoices = new Set();
+    }
+  });
+
+  function toggleMultiSelect(index: number) {
+    const copy = new Set(multiSelectChoices);
+    if (copy.has(index)) {
+      copy.delete(index);
+    } else {
+      copy.add(index);
+    }
+    multiSelectChoices = copy;
+  }
+
+  // --- Numeric input local state ---
+
+  let numericValue = $state('');
+
+  $effect(() => {
+    const item = session?.currentItem?.item;
+    if (item && item.type === 'numeric-input') {
+      numericValue = '';
+    }
+  });
+
+  // --- Derived helpers ---
+
+  const hasApiKey = $derived(getApiKey(localStorage) !== null);
+</script>
+
+<svelte:head>
+  <title>{course?.title ?? 'Learn'} — CourseQuizzer</title>
+</svelte:head>
+
+<main>
+  {#if !course}
+    <h1>Course not found</h1>
+    <p>No course with this ID was found in your browser storage.</p>
+    <p><a href="/">← Back to home</a></p>
+  {:else if !hasApiKey}
+    <h1>{course.title}</h1>
+    <p>
+      You need an Anthropic API key to generate content. Please add one in
+      <a href="/settings">Settings</a>.
+    </p>
+    <p><a href={`/course/${courseId}`}>← Back to course</a></p>
+  {:else if !session}
+    <p>Loading session...</p>
+  {:else}
+    <!-- --- Session active --- -->
+
+    {#if session.engineState === 'ready'}
+      <!-- Section picker -->
+      <h1>{course.title}</h1>
+      <p>Choose a section to start learning.</p>
+      <ol class="section-list">
+        {#each course.curriculum.sections as section (section.id)}
+          <li>
+            <button
+              type="button"
+              class="section-button"
+              onclick={() => handleStartSection(section.id)}
+            >
+              {section.title}
+            </button>
+            <span class="topic-count">({section.topics.length} topics)</span>
+          </li>
+        {/each}
+      </ol>
+      <p><a href={`/course/${courseId}`}>← Back to course</a></p>
+
+    {:else if session.engineState === 'loading' || generating}
+      <!-- Generating content -->
+      <h1>{course.title}</h1>
+      {#if session.currentSection}
+        <h2>{session.currentSection.section.title}</h2>
+      {/if}
+      <p class="loading">Generating learning content...</p>
+      <p>This may take a minute as content is generated for each topic.</p>
+      {#if generateError}
+        <p role="alert" class="error">{generateError}</p>
+        <button type="button" onclick={handleBackToOverview}>Back to Course</button>
+      {/if}
+
+    {:else if session.engineState === 'practicing' && session.currentItem}
+      <!-- Content/quiz loop -->
+      {#if session.currentSection}
+        <header class="progress-bar">
+          <span>
+            Section {session.currentSection.sectionIndex + 1}
+            of {session.currentSection.totalSections}:
+            {session.currentSection.section.title}
+          </span>
+          <span>
+            Item {session.currentItem.itemIndex + 1} of {session.currentItem.totalItems}
+          </span>
+        </header>
+      {/if}
+
+      {#if session.currentItem.item.type === 'explanation'}
+        <!-- Explanation -->
+        <article class="explanation">
+          <h2>{session.currentItem.item.title}</h2>
+          <p>{session.currentItem.item.content}</p>
+          <div class="actions">
+            <button type="button" onclick={handleNext}>Continue</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'multiple-choice'}
+        <!-- Multiple choice -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <div class="options" role="radiogroup">
+            {#each session.currentItem.item.options as option, i}
+              <button
+                type="button"
+                class="option-button"
+                onclick={() => handleMultipleChoice(i)}
+              >
+                {option}
+              </button>
+            {/each}
+          </div>
+          <div class="actions">
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'numeric-input'}
+        <!-- Numeric input -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          {#if session.currentItem.item.unit}
+            <p class="hint">Unit: {session.currentItem.item.unit}</p>
+          {/if}
+          <form
+            onsubmit={(e) => {
+              e.preventDefault();
+              const val = parseFloat(numericValue);
+              if (!isNaN(val)) handleNumericInput(val);
+            }}
+          >
+            <input
+              type="number"
+              step="any"
+              bind:value={numericValue}
+              placeholder="Enter your answer"
+              class="numeric-input"
+            />
+            <div class="actions">
+              <button type="submit">Submit</button>
+              <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+              <button type="button" class="text-button" onclick={handleReportIssue}>
+                {reportedItem ? 'Reported' : 'Report issue'}
+              </button>
+            </div>
+          </form>
+        </article>
+
+      {:else if session.currentItem.item.type === 'ordering'}
+        <!-- Ordering -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <p class="hint">Arrange the items in the correct order using the arrows.</p>
+          <ol class="ordering-list">
+            {#each orderingSequence as itemIdx, position}
+              <li class="ordering-item">
+                <span>{session.currentItem.item.items[itemIdx]}</span>
+                <span class="ordering-controls">
+                  <button
+                    type="button"
+                    class="arrow-button"
+                    disabled={position === 0}
+                    onclick={() => moveOrderingItem(position, 'up')}
+                    aria-label="Move up"
+                  >↑</button>
+                  <button
+                    type="button"
+                    class="arrow-button"
+                    disabled={position === orderingSequence.length - 1}
+                    onclick={() => moveOrderingItem(position, 'down')}
+                    aria-label="Move down"
+                  >↓</button>
+                </span>
+              </li>
+            {/each}
+          </ol>
+          <div class="actions">
+            <button type="button" onclick={() => handleOrdering(orderingSequence)}>
+              Submit
+            </button>
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'multi-select'}
+        <!-- Multi-select -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <p class="hint">Select all that apply.</p>
+          <div class="options">
+            {#each session.currentItem.item.options as option, i}
+              <button
+                type="button"
+                class="option-button"
+                class:selected={multiSelectChoices.has(i)}
+                onclick={() => toggleMultiSelect(i)}
+              >
+                {option}
+              </button>
+            {/each}
+          </div>
+          <div class="actions">
+            <button
+              type="button"
+              onclick={() => handleMultiSelect([...multiSelectChoices])}
+              disabled={multiSelectChoices.size === 0}
+            >
+              Submit
+            </button>
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'two-stage'}
+        <!-- Two-stage -->
+        <article class="question">
+          {#if twoStageFirstAnswer === null}
+            <!-- Stage 1 -->
+            <h2>{session.currentItem.item.question}</h2>
+            <div class="options" role="radiogroup">
+              {#each session.currentItem.item.options as option, i}
+                <button
+                  type="button"
+                  class="option-button"
+                  onclick={() => { twoStageFirstAnswer = i; }}
+                >
+                  {option}
+                </button>
+              {/each}
+            </div>
+          {:else}
+            <!-- Stage 2 -->
+            <h2>{session.currentItem.item.followUp}</h2>
+            <div class="options" role="radiogroup">
+              {#each session.currentItem.item.followUpOptions as option, i}
+                <button
+                  type="button"
+                  class="option-button"
+                  onclick={() => handleTwoStage(twoStageFirstAnswer!, i)}
+                >
+                  {option}
+                </button>
+              {/each}
+            </div>
+          {/if}
+          <div class="actions">
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+      {/if}
+
+    {:else if session.engineState === 'answered' && session.lastResult}
+      <!-- Answer result -->
+      {#if session.currentSection}
+        <header class="progress-bar">
+          <span>
+            Section {session.currentSection.sectionIndex + 1}
+            of {session.currentSection.totalSections}:
+            {session.currentSection.section.title}
+          </span>
+        </header>
+      {/if}
+
+      <article class="result" class:correct={session.lastResult.result.correct} class:incorrect={!session.lastResult.result.correct}>
+        <h2>{session.lastResult.result.correct ? 'Correct!' : 'Incorrect'}</h2>
+        {#if !session.lastResult.result.correct}
+          <p><strong>Correct answer:</strong> {session.lastResult.result.correctAnswer}</p>
+        {/if}
+        {#if session.lastResult.result.explanation}
+          <p>{session.lastResult.result.explanation}</p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={handleNext}>Continue</button>
+        </div>
+      </article>
+
+    {:else if session.engineState === 'sectionComplete'}
+      <!-- Section complete -->
+      <article class="section-complete">
+        <h2>Section Complete!</h2>
+        {#if session.currentSection}
+          <p>You finished <strong>{session.currentSection.section.title}</strong>.</p>
+        {/if}
+        {#if session.progress}
+          <p>
+            Section {session.progress.currentSectionIndex + 1}
+            of {session.progress.totalSections} |
+            Overall mastery: {Math.round(session.progress.overallMastery * 100)}%
+          </p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={handleNextSection}>Next Section</button>
+          <button type="button" class="secondary" onclick={handleBackToOverview}>
+            Back to Course
+          </button>
+        </div>
+      </article>
+
+    {:else if session.engineState === 'complete'}
+      <!-- Course complete -->
+      <article class="course-complete">
+        <h2>Course Complete!</h2>
+        <p>Congratulations — you've completed all sections of <strong>{course.title}</strong>.</p>
+        {#if session.progress}
+          <p>
+            Overall mastery: {Math.round(session.progress.overallMastery * 100)}%
+          </p>
+        {/if}
+        <div class="actions">
+          <button type="button" onclick={handleBackToOverview}>Back to Course</button>
+        </div>
+      </article>
+
+    {:else if session.error}
+      <!-- Error state -->
+      <article>
+        <p role="alert" class="error">{session.error.message}</p>
+        <button type="button" onclick={handleBackToOverview}>Back to Course</button>
+      </article>
+
+    {:else}
+      <p>Loading...</p>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1rem;
+  }
+
+  .progress-bar {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid #ddd;
+    font-size: 0.85rem;
+    color: #666;
+  }
+
+  .explanation {
+    margin: 1rem 0;
+  }
+
+  .question {
+    margin: 1rem 0;
+  }
+
+  .question h2 {
+    margin-bottom: 1rem;
+  }
+
+  .hint {
+    font-size: 0.9rem;
+    color: #666;
+    margin-bottom: 0.75rem;
+  }
+
+  .options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .option-button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.95rem;
+    color: #333;
+  }
+
+  .option-button:hover {
+    background: #f5f5f5;
+    border-color: #999;
+  }
+
+  .option-button.selected {
+    background: #e8f0fe;
+    border-color: #1a73e8;
+    color: #1a73e8;
+  }
+
+  .numeric-input {
+    width: 100%;
+    max-width: 16rem;
+    padding: 0.5rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+  }
+
+  .ordering-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+  }
+
+  .ordering-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.25rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+  }
+
+  .ordering-controls {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .arrow-button {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: #333;
+  }
+
+  .arrow-button:hover:not(:disabled) {
+    background: #f0f0f0;
+  }
+
+  .arrow-button:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .result {
+    margin: 1rem 0;
+    padding: 1rem;
+    border-radius: 4px;
+  }
+
+  .result.correct {
+    background: #e6f4ea;
+    border: 1px solid #34a853;
+  }
+
+  .result.incorrect {
+    background: #fce8e6;
+    border: 1px solid #ea4335;
+  }
+
+  .section-complete,
+  .course-complete {
+    margin: 2rem 0;
+    text-align: center;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    align-items: center;
+  }
+
+  .section-list {
+    list-style: none;
+    padding: 0;
+  }
+
+  .section-list li {
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .section-button {
+    padding: 0.5rem 1rem;
+    border: 1px solid #333;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+
+  .section-button:hover {
+    background: #555;
+  }
+
+  .topic-count {
+    font-size: 0.85rem;
+    color: #666;
+  }
+
+  button {
+    padding: 0.5rem 1rem;
+    font-size: 0.95rem;
+    cursor: pointer;
+    border: 1px solid #333;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+  }
+
+  button:hover {
+    background: #555;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .secondary {
+    background: #fff;
+    color: #333;
+  }
+
+  .secondary:hover {
+    background: #f0f0f0;
+  }
+
+  .text-button {
+    background: none;
+    border: none;
+    color: #666;
+    font-size: 0.85rem;
+    padding: 0.25rem;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .text-button:hover {
+    color: #333;
+    background: none;
+  }
+
+  .loading {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  .error {
+    color: #c00;
+    font-weight: 600;
+  }
+</style>

--- a/apps/coursequizzer/tests/unit/learn-flow.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-flow.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createEngineSession,
+  type EngineSession,
+} from '../../src/lib/stores/engine-session.svelte.js';
+import { createCourse, getCourse } from '../../src/lib/storage/course-storage.js';
+import type { CurriculumPlan, ContentItem, StudentAnswer } from 'quizzer-engine';
+
+// --- Test fixtures ---
+
+function mockCurriculumPlan(): CurriculumPlan {
+  return {
+    title: 'Intro to Testing',
+    description: 'A course about testing fundamentals.',
+    sections: [
+      {
+        id: 's1',
+        title: 'Unit Testing Basics',
+        order: 0,
+        topics: [
+          {
+            id: 't1',
+            title: 'What is a Unit Test?',
+            description: 'The fundamentals of unit testing.',
+          },
+        ],
+      },
+      {
+        id: 's2',
+        title: 'Integration Testing',
+        order: 1,
+        topics: [
+          {
+            id: 't2',
+            title: 'Integration Strategies',
+            description: 'Approaches to integration testing.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// Content items covering all 5 question types plus an explanation
+function mockSectionContent(): ContentItem[] {
+  return [
+    {
+      type: 'explanation',
+      topicId: 't1',
+      title: 'Understanding Unit Tests',
+      content: 'A unit test verifies a single piece of functionality in isolation.',
+    },
+    {
+      type: 'multiple-choice',
+      id: 'q1',
+      topicId: 't1',
+      question: 'What does a unit test verify?',
+      options: [
+        'The entire application',
+        'A single piece of functionality',
+        'Network connectivity',
+        'Database schemas',
+      ],
+      correctIndex: 1,
+    },
+    {
+      type: 'numeric-input',
+      id: 'q2',
+      topicId: 't1',
+      question: 'How many assertions should a focused unit test typically have?',
+      correctValue: 1,
+      tolerance: 1,
+    },
+    {
+      type: 'ordering',
+      id: 'q3',
+      topicId: 't1',
+      question: 'Put the TDD steps in order.',
+      items: ['Red', 'Green', 'Refactor'],
+      correctOrder: [0, 1, 2],
+    },
+    {
+      type: 'multi-select',
+      id: 'q4',
+      topicId: 't1',
+      question: 'Which are benefits of unit testing?',
+      options: [
+        'Fast feedback',
+        'Slower builds',
+        'Regression prevention',
+        'Increased code size',
+      ],
+      correctIndices: [0, 2],
+    },
+    {
+      type: 'two-stage',
+      id: 'q5',
+      topicId: 't1',
+      question: 'Which testing level runs fastest?',
+      options: ['Unit', 'Integration', 'E2E'],
+      correctIndex: 0,
+      followUp: 'Why does it run fastest?',
+      followUpOptions: ['No external deps', 'More code coverage', 'Uses caching'],
+      followUpCorrectIndex: 0,
+    },
+  ];
+}
+
+describe('learn page flow', () => {
+  // --- Full answer flow with mocked generated content ---
+
+  it('completes a full section: explanation → answer questions → section complete', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockSectionContent());
+
+    // Item 0: explanation
+    expect(session.engineState).toBe('practicing');
+    expect(session.currentItem!.item.type).toBe('explanation');
+    expect(session.currentItem!.itemIndex).toBe(0);
+    expect(session.currentItem!.totalItems).toBe(6);
+
+    // Advance past explanation
+    session.nextItem();
+
+    // Item 1: multiple-choice
+    expect(session.currentItem!.item.type).toBe('multiple-choice');
+    const mcResult = session.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 1,
+    });
+    expect(mcResult.correct).toBe(true);
+    expect(session.engineState).toBe('answered');
+    expect(session.lastResult!.result.correct).toBe(true);
+    session.nextItem();
+
+    // Item 2: numeric-input
+    expect(session.currentItem!.item.type).toBe('numeric-input');
+    const numResult = session.submitAnswer({
+      type: 'numeric-input',
+      value: 1,
+    });
+    expect(numResult.correct).toBe(true);
+    session.nextItem();
+
+    // Item 3: ordering
+    expect(session.currentItem!.item.type).toBe('ordering');
+    const orderResult = session.submitAnswer({
+      type: 'ordering',
+      order: [0, 1, 2],
+    });
+    expect(orderResult.correct).toBe(true);
+    session.nextItem();
+
+    // Item 4: multi-select
+    expect(session.currentItem!.item.type).toBe('multi-select');
+    const msResult = session.submitAnswer({
+      type: 'multi-select',
+      selectedIndices: [0, 2],
+    });
+    expect(msResult.correct).toBe(true);
+    session.nextItem();
+
+    // Item 5: two-stage
+    expect(session.currentItem!.item.type).toBe('two-stage');
+    const tsResult = session.submitAnswer({
+      type: 'two-stage',
+      selectedIndex: 0,
+      followUpSelectedIndex: 0,
+    });
+    expect(tsResult.correct).toBe(true);
+    session.nextItem();
+
+    // Section should be complete
+    expect(session.engineState).toBe('sectionComplete');
+    expect(session.studentState).not.toBeNull();
+    expect(session.progress).not.toBeNull();
+  });
+
+  it('handles incorrect answers and shows correct answer in result', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockSectionContent());
+
+    session.nextItem(); // past explanation
+
+    // Wrong answer on multiple-choice
+    const result = session.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 0,
+    });
+    expect(result.correct).toBe(false);
+    expect(result.correctAnswer).toBe('A single piece of functionality');
+    expect(session.lastResult!.result.correct).toBe(false);
+  });
+
+  it('can skip a question and continue', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockSectionContent());
+
+    session.nextItem(); // past explanation
+    expect(session.currentItem!.item.type).toBe('multiple-choice');
+
+    session.skipQuestion();
+    // Should advance to numeric-input
+    expect(session.currentItem!.item.type).toBe('numeric-input');
+  });
+
+  it('persists progress via auto-save after each answer', () => {
+    const store = new Map<string, string>();
+    const storage: Storage = {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key);
+      }),
+      clear: vi.fn(() => store.clear()),
+      get length() {
+        return store.size;
+      },
+      key: vi.fn((_index: number) => null),
+    };
+
+    // Create a course in storage first
+    const course = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+
+    const session = createEngineSession({
+      apiKey: 'test-key',
+      courseId: course.id,
+      storage,
+    });
+
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent(mockSectionContent());
+    session.nextItem(); // past explanation
+    session.submitAnswer({ type: 'multiple-choice', selectedIndex: 1 });
+
+    // Snapshot should be saved with answered state
+    const updated = getCourse(course.id, storage);
+    expect(updated!.snapshot).not.toBeNull();
+    expect(updated!.snapshot!.state).toBe('answered');
+  });
+
+  it('navigates from section complete back to ready for next section', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+
+    // Minimal content — just one question
+    session.setSectionContent([
+      {
+        type: 'multiple-choice',
+        id: 'q1',
+        topicId: 't1',
+        question: 'Quick question?',
+        options: ['A', 'B'],
+        correctIndex: 0,
+      },
+    ]);
+
+    session.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    session.nextItem(); // section complete
+
+    expect(session.engineState).toBe('sectionComplete');
+
+    // Start next section
+    session.startSection('s2');
+    expect(session.engineState).toBe('loading');
+    expect(session.currentSection!.section.id).toBe('s2');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds learn page at `/course/[courseId]/learn` with full content generation and answer flow
- Renders all 5 Phase 1 question types (multiple choice, numeric input, ordering, multi-select, two-stage) plus explanations
- Generates section content via ContentGenerator + ClaudeProvider, auto-saves progress, restores sessions from snapshots
- All LLM-generated content rendered with Svelte auto-escaping (no `{@html}`)
- Includes Report Issue action on every content item (v1: console log)

Closes #21

## Test plan

- [x] 5 new unit tests covering full section completion with all question types, incorrect answers, skip, auto-save persistence, and section navigation
- [x] `pnpm -r test` passes (228 tests)
- [x] `pnpm -r build` passes
- [x] `pnpm format` clean
- [ ] Manual browser test: paste syllabus → start section → answer first generated question

🤖 Generated with [Claude Code](https://claude.com/claude-code)