### PR TITLE
feat: add Phase 2 app tests for critical browser flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.0 — 2026-04-12
+
+### Phase 2: App Foundation (continued)
+
+- Critical-path integration test: full flow from syllabus analysis → save course → create session → answer questions → verify auto-save
+- Session restore/resume test: serialize session, restore into new session, continue answering
+- Analysis failure and retry test: verifies graceful failure then successful retry
+- Static security scan tests: verify no `{@html}`, no `eval()`/`new Function()`, no API key logging in app source
+- Runtime security tests: API key not in serialized snapshots, not in persisted course records, malformed import data handled gracefully
+- 9 new tests across 2 test files (critical-path.test.ts, security.test.ts), total app tests now 90
+
 ## 0.6.0 — 2026-04-12
 
 ### Phase 2: App Foundation (continued)

--- a/apps/coursequizzer/tests/unit/critical-path.test.ts
+++ b/apps/coursequizzer/tests/unit/critical-path.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  analyzeSyllabus,
+  saveCourseFromPlan,
+  MIN_SYLLABUS_LENGTH,
+} from '../../src/lib/stores/new-course.js';
+import {
+  createEngineSession,
+  type EngineSession,
+} from '../../src/lib/stores/engine-session.svelte.js';
+import { getCourse, listCourses } from '../../src/lib/storage/course-storage.js';
+import type { CurriculumPlan, ProviderResponse, ContentItem } from 'quizzer-engine';
+
+// --- localStorage mock ---
+
+function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => store.clear()),
+    get length() {
+      return store.size;
+    },
+    key: vi.fn((_index: number) => null),
+  };
+}
+
+// --- Fixtures (mimic realistic Claude API response) ---
+
+function mockCurriculumPlan(): CurriculumPlan {
+  return {
+    title: 'Data Structures',
+    description: 'An introduction to fundamental data structures.',
+    sections: [
+      {
+        id: 'arrays-and-lists',
+        title: 'Arrays and Linked Lists',
+        order: 0,
+        topics: [
+          {
+            id: 'arrays',
+            title: 'Arrays',
+            description: 'Contiguous memory storage with O(1) access.',
+          },
+          {
+            id: 'linked-lists',
+            title: 'Linked Lists',
+            description: 'Node-based storage with O(1) insertion.',
+          },
+        ],
+      },
+      {
+        id: 'trees',
+        title: 'Trees',
+        order: 1,
+        topics: [
+          {
+            id: 'binary-trees',
+            title: 'Binary Trees',
+            description: 'Hierarchical structures with two children per node.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function mockProviderResponse(plan: CurriculumPlan): ProviderResponse {
+  return {
+    id: 'msg_integration_01',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_integration_01',
+        name: 'create_curriculum_plan',
+        input: plan as unknown as Record<string, unknown>,
+      },
+    ],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'tool_use',
+    usage: { inputTokens: 150, outputTokens: 300 },
+  };
+}
+
+function mockSectionContent(): ContentItem[] {
+  return [
+    {
+      type: 'explanation',
+      topicId: 'arrays',
+      title: 'Understanding Arrays',
+      content:
+        'An array stores elements in contiguous memory locations, providing O(1) random access by index.',
+    },
+    {
+      type: 'multiple-choice',
+      id: 'q-arrays-1',
+      topicId: 'arrays',
+      question:
+        'What is the time complexity of accessing an element by index in an array?',
+      options: ['O(1)', 'O(n)', 'O(log n)', 'O(n²)'],
+      correctIndex: 0,
+    },
+    {
+      type: 'numeric-input',
+      id: 'q-arrays-2',
+      topicId: 'arrays',
+      question:
+        'If an array has 8 elements, how many comparisons does binary search need in the worst case?',
+      correctValue: 3,
+      tolerance: 0,
+    },
+  ];
+}
+
+// --- Critical path: syllabus → analyze → save → session → answer ---
+
+describe('critical path integration', () => {
+  it('analyzes syllabus, saves course, creates session, and answers questions', async () => {
+    const storage = createLocalStorageMock();
+    const plan = mockCurriculumPlan();
+    const syllabusText = 'A'.repeat(MIN_SYLLABUS_LENGTH + 100);
+
+    // Step 1: Analyze syllabus with mocked provider
+    const mockSendMessage = vi.fn().mockResolvedValue(mockProviderResponse(plan));
+    const analysisResult = await analyzeSyllabus({
+      syllabusText,
+      sendMessage: mockSendMessage,
+    });
+
+    expect(analysisResult.ok).toBe(true);
+    if (!analysisResult.ok) throw new Error('Analysis failed');
+    expect(analysisResult.plan.title).toBe('Data Structures');
+    expect(analysisResult.plan.sections).toHaveLength(2);
+
+    // Step 2: Save course from the analyzed plan
+    const courseRecord = saveCourseFromPlan(analysisResult.plan, storage);
+    expect(courseRecord.id).toBeTruthy();
+    expect(courseRecord.title).toBe('Data Structures');
+
+    // Verify the course is in storage
+    const courses = listCourses(storage);
+    expect(courses).toHaveLength(1);
+    expect(courses[0].id).toBe(courseRecord.id);
+
+    // Step 3: Create an engine session with auto-save
+    const session = createEngineSession({
+      apiKey: 'sk-ant-test-key',
+      courseId: courseRecord.id,
+      storage,
+    });
+
+    session.loadCurriculum(analysisResult.plan);
+    expect(session.engineState).toBe('ready');
+    expect(session.curriculum).not.toBeNull();
+
+    // Step 4: Start section and load content
+    session.startSection('arrays-and-lists');
+    expect(session.engineState).toBe('loading');
+    expect(session.currentSection!.section.id).toBe('arrays-and-lists');
+
+    session.setSectionContent(mockSectionContent());
+    expect(session.engineState).toBe('practicing');
+
+    // Step 5: Read explanation, then answer questions
+    expect(session.currentItem!.item.type).toBe('explanation');
+    session.nextItem();
+
+    // Answer multiple-choice correctly
+    expect(session.currentItem!.item.type).toBe('multiple-choice');
+    const mcResult = session.submitAnswer({
+      type: 'multiple-choice',
+      selectedIndex: 0,
+    });
+    expect(mcResult.correct).toBe(true);
+    expect(session.engineState).toBe('answered');
+    session.nextItem();
+
+    // Answer numeric-input correctly
+    expect(session.currentItem!.item.type).toBe('numeric-input');
+    const numResult = session.submitAnswer({
+      type: 'numeric-input',
+      value: 3,
+    });
+    expect(numResult.correct).toBe(true);
+    session.nextItem();
+
+    // Section complete
+    expect(session.engineState).toBe('sectionComplete');
+
+    // Step 6: Verify auto-save persisted progress
+    const savedCourse = getCourse(courseRecord.id, storage);
+    expect(savedCourse).not.toBeNull();
+    expect(savedCourse!.snapshot).not.toBeNull();
+    expect(savedCourse!.snapshot!.state).toBe('sectionComplete');
+
+    // Step 7: Verify API key is NOT in persisted data
+    const raw = JSON.stringify(savedCourse);
+    expect(raw).not.toContain('sk-ant-test-key');
+
+    // Clean up
+    session.dispose();
+  });
+
+  it('restores a saved session and continues answering', async () => {
+    const storage = createLocalStorageMock();
+    const plan = mockCurriculumPlan();
+
+    // Create and progress a session
+    const courseRecord = saveCourseFromPlan(plan, storage);
+    const session1 = createEngineSession({
+      apiKey: 'sk-ant-key-1',
+      courseId: courseRecord.id,
+      storage,
+    });
+
+    session1.loadCurriculum(plan);
+    session1.startSection('arrays-and-lists');
+    session1.setSectionContent(mockSectionContent());
+    session1.nextItem(); // past explanation
+    session1.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+
+    // Take snapshot and dispose
+    const snapshot = session1.serialize()!;
+    expect(snapshot).not.toBeNull();
+    session1.dispose();
+
+    // Restore into a new session (simulating page reload)
+    const session2 = createEngineSession({
+      apiKey: 'sk-ant-key-2',
+      courseId: courseRecord.id,
+      storage,
+      snapshot,
+    });
+
+    // Session should be in the answered state
+    expect(session2.engineState).toBe('answered');
+    expect(session2.curriculum).not.toBeNull();
+    expect(session2.curriculum!.title).toBe('Data Structures');
+
+    // Continue to the next item
+    session2.nextItem();
+    expect(session2.currentItem!.item.type).toBe('numeric-input');
+
+    // Answer and complete section
+    session2.submitAnswer({ type: 'numeric-input', value: 3 });
+    session2.nextItem();
+    expect(session2.engineState).toBe('sectionComplete');
+
+    // Verify the restored session's API key isn't leaked
+    const snapshot2 = session2.serialize()!;
+    const serialized = JSON.stringify(snapshot2);
+    expect(serialized).not.toContain('sk-ant-key-1');
+    expect(serialized).not.toContain('sk-ant-key-2');
+
+    session2.dispose();
+  });
+
+  it('handles analysis failure and allows retry', async () => {
+    const plan = mockCurriculumPlan();
+    const syllabusText = 'A'.repeat(MIN_SYLLABUS_LENGTH + 10);
+
+    // First attempt: both calls return malformed responses
+    const badResponse: ProviderResponse = {
+      id: 'msg_bad',
+      content: [{ type: 'text', text: 'I cannot analyze this.' }],
+      model: 'claude-sonnet-4-20250514',
+      stopReason: 'end_turn',
+      usage: { inputTokens: 50, outputTokens: 50 },
+    };
+
+    const failingSendMessage = vi.fn().mockResolvedValue(badResponse);
+    const failResult = await analyzeSyllabus({
+      syllabusText,
+      sendMessage: failingSendMessage,
+    });
+
+    expect(failResult.ok).toBe(false);
+
+    // Retry: succeeds on first call
+    const succeedingSendMessage = vi.fn().mockResolvedValue(mockProviderResponse(plan));
+    const retryResult = await analyzeSyllabus({
+      syllabusText,
+      sendMessage: succeedingSendMessage,
+    });
+
+    expect(retryResult.ok).toBe(true);
+    if (retryResult.ok) {
+      expect(retryResult.plan.title).toBe('Data Structures');
+    }
+  });
+});

--- a/apps/coursequizzer/tests/unit/security.test.ts
+++ b/apps/coursequizzer/tests/unit/security.test.ts
@@ -7,6 +7,7 @@ import {
   getCourse,
   listCourses,
   updateCourse,
+  COURSES_STORAGE_KEY,
 } from '../../src/lib/storage/course-storage.js';
 import type { CurriculumPlan, EngineSnapshot } from 'quizzer-engine';
 
@@ -133,20 +134,29 @@ describe('API key safety at runtime', () => {
 
   it('API key is not present in course records persisted to storage', () => {
     const storage = createLocalStorageMock();
+
+    // Create the course first so we can use its generated ID
+    const courseRecord = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+
     const session = createEngineSession({
       apiKey: 'sk-ant-api03-PERSISTCHECK',
-      courseId: 'test-course',
+      courseId: courseRecord.id,
       storage,
     });
 
     session.loadCurriculum(mockCurriculumPlan());
 
-    // Create the course in storage so auto-save has a target
-    createCourse({ title: 'Test', curriculum: mockCurriculumPlan() }, storage);
+    // Simulate what auto-save does: serialize the session and persist via updateCourse
+    const snapshot = session.serialize()!;
+    updateCourse(courseRecord.id, { snapshot }, storage);
 
-    // Check all persisted data
-    const courses = listCourses(storage);
-    const allStoredData = JSON.stringify(courses);
+    // Verify the persisted course record does not contain the API key
+    const persisted = getCourse(courseRecord.id, storage);
+    expect(persisted).not.toBeNull();
+    const allStoredData = JSON.stringify(persisted);
     expect(allStoredData).not.toContain('sk-ant-api03-PERSISTCHECK');
 
     session.dispose();
@@ -156,15 +166,15 @@ describe('API key safety at runtime', () => {
     const storage = createLocalStorageMock();
 
     // Simulate corrupted localStorage
-    storage.setItem('cq:courses', 'not-valid-json{{{');
+    storage.setItem(COURSES_STORAGE_KEY, 'not-valid-json{{{');
     expect(listCourses(storage)).toEqual([]);
 
     // Simulate data with wrong shape
-    storage.setItem('cq:courses', JSON.stringify([{ invalid: true }]));
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([{ invalid: true }]));
     expect(listCourses(storage)).toEqual([]);
 
     // Simulate array of nulls
-    storage.setItem('cq:courses', JSON.stringify([null, undefined, 42]));
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([null, undefined, 42]));
     expect(listCourses(storage)).toEqual([]);
   });
 });

--- a/apps/coursequizzer/tests/unit/security.test.ts
+++ b/apps/coursequizzer/tests/unit/security.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { createEngineSession } from '../../src/lib/stores/engine-session.svelte.js';
+import {
+  createCourse,
+  getCourse,
+  listCourses,
+  updateCourse,
+} from '../../src/lib/storage/course-storage.js';
+import type { CurriculumPlan, EngineSnapshot } from 'quizzer-engine';
+
+// --- Helpers ---
+
+function createLocalStorageMock(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => store.clear()),
+    get length() {
+      return store.size;
+    },
+    key: vi.fn((_index: number) => null),
+  };
+}
+
+function mockCurriculumPlan(): CurriculumPlan {
+  return {
+    title: 'Security Test Course',
+    description: 'Testing security constraints.',
+    sections: [
+      {
+        id: 's1',
+        title: 'Section 1',
+        order: 0,
+        topics: [{ id: 't1', title: 'Topic 1', description: 'A topic.' }],
+      },
+    ],
+  };
+}
+
+// --- Collect all source files in a directory tree ---
+
+function collectFiles(dir: string, ext: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory() && entry !== 'node_modules' && entry !== '.svelte-kit') {
+      results.push(...collectFiles(fullPath, ext));
+    } else if (entry.endsWith(ext)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// --- Static source code security checks ---
+
+describe('source code security scan', () => {
+  const appSrcDir = join(__dirname, '../../src');
+
+  it('does not use {@html} in any Svelte component', () => {
+    const svelteFiles = collectFiles(appSrcDir, '.svelte');
+    const violations: string[] = [];
+
+    for (const file of svelteFiles) {
+      const content = readFileSync(file, 'utf-8');
+      if (content.includes('{@html')) {
+        violations.push(file);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('does not use eval() or new Function() in any source file', () => {
+    const tsFiles = collectFiles(appSrcDir, '.ts');
+    const svelteFiles = collectFiles(appSrcDir, '.svelte');
+    const allFiles = [...tsFiles, ...svelteFiles];
+    const violations: string[] = [];
+
+    for (const file of allFiles) {
+      const content = readFileSync(file, 'utf-8');
+      // Match eval( but not .evaluate or similar
+      if (/\beval\s*\(/.test(content) || /\bnew\s+Function\s*\(/.test(content)) {
+        violations.push(file);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('does not log API keys in any source file', () => {
+    const tsFiles = collectFiles(appSrcDir, '.ts');
+    const svelteFiles = collectFiles(appSrcDir, '.svelte');
+    const allFiles = [...tsFiles, ...svelteFiles];
+    const violations: string[] = [];
+
+    for (const file of allFiles) {
+      const content = readFileSync(file, 'utf-8');
+      // Check for console.log that includes apiKey variable
+      if (/console\.\w+\(.*apiKey/i.test(content)) {
+        violations.push(file);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});
+
+// --- Runtime security checks ---
+
+describe('API key safety at runtime', () => {
+  it('API key is not present in serialized engine snapshots', () => {
+    const session = createEngineSession({ apiKey: 'sk-ant-api03-SECRETKEY12345' });
+    session.loadCurriculum(mockCurriculumPlan());
+
+    const snapshot = session.serialize()!;
+    const json = JSON.stringify(snapshot);
+
+    expect(json).not.toContain('sk-ant-api03-SECRETKEY12345');
+    expect(json).not.toContain('SECRETKEY');
+
+    session.dispose();
+  });
+
+  it('API key is not present in course records persisted to storage', () => {
+    const storage = createLocalStorageMock();
+    const session = createEngineSession({
+      apiKey: 'sk-ant-api03-PERSISTCHECK',
+      courseId: 'test-course',
+      storage,
+    });
+
+    session.loadCurriculum(mockCurriculumPlan());
+
+    // Create the course in storage so auto-save has a target
+    createCourse({ title: 'Test', curriculum: mockCurriculumPlan() }, storage);
+
+    // Check all persisted data
+    const courses = listCourses(storage);
+    const allStoredData = JSON.stringify(courses);
+    expect(allStoredData).not.toContain('sk-ant-api03-PERSISTCHECK');
+
+    session.dispose();
+  });
+
+  it('course storage rejects malformed import data gracefully', () => {
+    const storage = createLocalStorageMock();
+
+    // Simulate corrupted localStorage
+    storage.setItem('cq:courses', 'not-valid-json{{{');
+    expect(listCourses(storage)).toEqual([]);
+
+    // Simulate data with wrong shape
+    storage.setItem('cq:courses', JSON.stringify([{ invalid: true }]));
+    expect(listCourses(storage)).toEqual([]);
+
+    // Simulate array of nulls
+    storage.setItem('cq:courses', JSON.stringify([null, undefined, 42]));
+    expect(listCourses(storage)).toEqual([]);
+  });
+});

--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -17,11 +17,13 @@ gh pr view <n> --json comments --jq '.comments[] | select(.body | contains("## R
 ```
 
 A PR needs action if it has a review comment with findings and no commits pushed after that comment. Check the **Verdict** line:
+
 - `Clean approve — no action needed` → skip, nothing to do (reviewer already merged it)
 - `Approved with required fixes` → fix everything, then merge after pushing
 - `Changes requested` → fix everything, push, wait for re-review (do NOT merge)
 
 If a PR needs action:
+
 1. Check out the PR branch
 2. Read the review comment — the entire comment, not just the status line
 3. Address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
@@ -39,6 +41,7 @@ gh issue list --state open --label in-progress --json number,title,createdAt
 ```
 
 For each, check if an open PR exists that references it. If no PR exists:
+
 1. Remove and re-add the `in-progress` label (to reclaim it)
 2. Pull latest main, create a feature branch
 3. Implement the issue from scratch
@@ -60,6 +63,7 @@ Verify the issue author is johnmarkos (`gh issue view <n> --json author`). Skip 
 **Pick the lowest-numbered eligible issue. Do not skip issues because their body mentions dependencies on other issues.** Dependency ordering is the planning agent's job — if an issue exists and is not labeled `in-progress`, it is ready to work on.
 
 If an eligible issue exists:
+
 1. Add the `in-progress` label: `gh issue edit <n> --add-label in-progress`
 2. Pull latest main, create a feature branch (feat/, fix/, or chore/ prefix)
 3. Read the issue carefully — understand scope and acceptance criteria

--- a/scripts/prompts/reviewer.md
+++ b/scripts/prompts/reviewer.md
@@ -5,6 +5,7 @@ Do exactly ONE of the following, then exit.
 ## Priority 1: Review a PR that needs it
 
 Find open PRs that need a review. A PR needs review if:
+
 - It has no review comment (comment starting with `## Review — Reviewer Agent`), OR
 - It has commits pushed AFTER the most recent review comment (author addressed feedback)
 


### PR DESCRIPTION
## Summary

- Adds critical-path integration test covering the full browser flow: analyze syllabus → save course → create session → load curriculum → start section → answer questions → verify auto-save and API key exclusion
- Adds session restore/resume test: serialize mid-session, restore into new session, continue answering
- Adds analysis failure + retry test: verifies graceful failure then successful retry
- Adds static source code security scan tests: verify no `{@html}`, no `eval()`/`new Function()`, no API key logging across all app source files
- Adds runtime security tests: API key not in serialized snapshots, not in persisted course records, malformed import data rejected gracefully
- 9 new tests across 2 test files (`critical-path.test.ts`, `security.test.ts`), total app tests now 90

Closes #23

## Test plan

- [x] All 250 tests pass (`pnpm -r test`: 160 engine + 90 app)
- [x] `pnpm -r build` passes
- [x] `pnpm format` clean
- [x] Critical path covered with deterministic mocked data (no real API calls)
- [x] API key exclusion verified in both snapshots and persisted course records
- [x] Static security scan covers all `.svelte` and `.ts` files in app `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)