### PR TITLE
fix: rename save button to 'Save Course'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2 — 2026-04-12
+
+### Fixes
+
+- Rename "Save Course & Start Learning" button to "Save Course" on `/course/new` — no learning flow exists yet, so the old label set false expectations
+
 ## 0.7.1 — 2026-04-12
 
 ### Phase 2 Milestone Review Fixes

--- a/apps/coursequizzer/src/routes/course/new/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/new/+page.svelte
@@ -167,7 +167,7 @@
       </ol>
 
       <div class="actions">
-        <button type="button" onclick={handleSave}>Save Course & Start Learning</button>
+        <button type="button" onclick={handleSave}>Save Course</button>
         <button type="button" class="secondary" onclick={handleBackToInput}>
           Back to Edit
         </button>


### PR DESCRIPTION
## Summary

- Renames the "Save Course & Start Learning" button on `/course/new` to "Save Course"
- The learning flow doesn't exist yet, so the old label set false expectations after saving

Closes #37

## Test plan

- [x] `pnpm -r test` — 270 tests pass
- [x] `pnpm -r build` — clean build
- [x] `pnpm format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)