### PR TITLE
chore: add root-level pnpm dev script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.2 — 2026-04-12
+## 0.7.3 — 2026-04-12
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2 — 2026-04-12
+
+### Developer Experience
+
+- Add root-level `pnpm dev` script that builds the engine first, then starts the app dev server
+
 ## 0.7.1 — 2026-04-12
 
 ### Phase 2 Milestone Review Fixes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "pnpm -r test",
     "build": "pnpm -r build",
+    "dev": "pnpm --filter quizzer-engine build && pnpm --filter coursequizzer dev",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
## Summary

- Adds a `dev` script to the root `package.json` that builds the engine first, then starts the app dev server
- `pnpm dev` from repo root now works out of the box — no manual engine build step needed

Closes #38

## Test plan

- [x] `pnpm --filter quizzer-engine build` succeeds
- [x] `pnpm -r test` — all 270 tests pass
- [x] `pnpm -r build` — all packages build
- [x] `pnpm format` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)