### PR TITLE
fix: harden course-storage validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.4 — 2026-04-12
+
+### Fixes
+
+- Harden `course-storage` persisted-data validation so malformed curriculum records are filtered out before app routes read them
+- Null out malformed persisted engine snapshots instead of attempting to restore them
+- Add storage tests covering malformed curriculum and snapshot payloads, and align engine-session test fixtures with the current curriculum shape
+
 ## 0.7.3 — 2026-04-12
 
 ### Developer Experience

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -4,12 +4,12 @@
 
 import {
   validateCurriculumPlan,
+  SNAPSHOT_VERSION,
   type CurriculumPlan,
   type EngineSnapshot,
 } from 'quizzer-engine';
 
 export const COURSES_STORAGE_KEY = 'coursequizzer:courses';
-const SUPPORTED_SNAPSHOT_VERSION = 3;
 
 export type CourseRecord = {
   id: string;
@@ -187,7 +187,7 @@ function validateSnapshot(value: unknown): EngineSnapshot | null {
   const snapshot = sanitizeSnapshot(value as EngineSnapshot);
 
   if (
-    snapshot.version !== SUPPORTED_SNAPSHOT_VERSION ||
+    snapshot.version !== SNAPSHOT_VERSION ||
     !isValidEngineState(snapshot.state) ||
     !Number.isInteger(snapshot.currentSectionIndex) ||
     !Number.isInteger(snapshot.currentItemIndex) ||

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -2,9 +2,14 @@
 // Persists course records to localStorage. Each record holds a curriculum plan,
 // an optional engine snapshot, and timestamps. The API key is never stored.
 
-import type { CurriculumPlan, EngineSnapshot } from 'quizzer-engine';
+import {
+  validateCurriculumPlan,
+  type CurriculumPlan,
+  type EngineSnapshot,
+} from 'quizzer-engine';
 
 export const COURSES_STORAGE_KEY = 'coursequizzer:courses';
+const SUPPORTED_SNAPSHOT_VERSION = 3;
 
 export type CourseRecord = {
   id: string;
@@ -39,16 +44,202 @@ function sanitizeSnapshot(snapshot: EngineSnapshot): EngineSnapshot {
   return copy;
 }
 
-function isValidRecord(value: unknown): value is CourseRecord {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isValidEngineState(value: unknown): boolean {
   return (
-    typeof obj.id === 'string' &&
-    typeof obj.title === 'string' &&
-    typeof obj.createdAt === 'string' &&
-    typeof obj.updatedAt === 'string' &&
-    obj.curriculum !== undefined
+    value === 'idle' ||
+    value === 'planning' ||
+    value === 'ready' ||
+    value === 'loading' ||
+    value === 'practicing' ||
+    value === 'answered' ||
+    value === 'sectionComplete' ||
+    value === 'complete'
   );
+}
+
+function isValidStudentState(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (!isPlainObject(value.masteryByTopic) || !isStringArray(value.gaps)) return false;
+
+  return Object.entries(value.masteryByTopic).every(([topicId, mastery]) => {
+    if (!isPlainObject(mastery)) return false;
+    return (
+      mastery.topicId === topicId &&
+      typeof mastery.score === 'number' &&
+      typeof mastery.questionsAnswered === 'number' &&
+      typeof mastery.questionsCorrect === 'number'
+    );
+  });
+}
+
+function isValidStudentAnswer(value: unknown): boolean {
+  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
+
+  switch (value.type) {
+    case 'multiple-choice':
+      return typeof value.selectedIndex === 'number';
+    case 'numeric-input':
+      return typeof value.value === 'number';
+    case 'ordering':
+      return (
+        Array.isArray(value.order) &&
+        value.order.every((entry) => typeof entry === 'number')
+      );
+    case 'multi-select':
+      return (
+        Array.isArray(value.selectedIndices) &&
+        value.selectedIndices.every((entry) => typeof entry === 'number')
+      );
+    case 'two-stage':
+      return (
+        typeof value.selectedIndex === 'number' &&
+        typeof value.followUpSelectedIndex === 'number'
+      );
+    default:
+      return false;
+  }
+}
+
+function isValidAnswerResult(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.correct === 'boolean' &&
+    typeof value.questionId === 'string' &&
+    typeof value.topicId === 'string' &&
+    typeof value.correctAnswer === 'string' &&
+    (value.explanation === undefined || typeof value.explanation === 'string') &&
+    isValidStudentAnswer(value.userAnswer)
+  );
+}
+
+function isValidContentItem(value: unknown): boolean {
+  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
+
+  switch (value.type) {
+    case 'explanation':
+      return (
+        typeof value.topicId === 'string' &&
+        typeof value.title === 'string' &&
+        typeof value.content === 'string'
+      );
+    case 'multiple-choice':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        typeof value.correctIndex === 'number'
+      );
+    case 'numeric-input':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        typeof value.correctValue === 'number' &&
+        (value.tolerance === undefined || typeof value.tolerance === 'number') &&
+        (value.unit === undefined || typeof value.unit === 'string')
+      );
+    case 'ordering':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.items) &&
+        Array.isArray(value.correctOrder) &&
+        value.correctOrder.every((entry) => typeof entry === 'number')
+      );
+    case 'multi-select':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        Array.isArray(value.correctIndices) &&
+        value.correctIndices.every((entry) => typeof entry === 'number')
+      );
+    case 'two-stage':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        typeof value.correctIndex === 'number' &&
+        typeof value.followUp === 'string' &&
+        isStringArray(value.followUpOptions) &&
+        typeof value.followUpCorrectIndex === 'number'
+      );
+    default:
+      return false;
+  }
+}
+
+function validateSnapshot(value: unknown): EngineSnapshot | null {
+  if (!isPlainObject(value)) return null;
+
+  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
+
+  if (
+    snapshot.version !== SUPPORTED_SNAPSHOT_VERSION ||
+    !isValidEngineState(snapshot.state) ||
+    !Number.isInteger(snapshot.currentSectionIndex) ||
+    !Number.isInteger(snapshot.currentItemIndex) ||
+    !Array.isArray(snapshot.sectionItems) ||
+    !snapshot.sectionItems.every(isValidContentItem) ||
+    !isValidStudentState(snapshot.studentState) ||
+    (snapshot.curriculum !== null && !isValidCurriculum(snapshot.curriculum)) ||
+    !('lastAnswerResult' in snapshot) ||
+    (snapshot.lastAnswerResult !== null &&
+      !isValidAnswerResult(snapshot.lastAnswerResult))
+  ) {
+    return null;
+  }
+
+  return deepCopy(snapshot);
+}
+
+function isValidCurriculum(value: unknown): value is CurriculumPlan {
+  try {
+    validateCurriculumPlan(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeRecord(value: unknown): CourseRecord | null {
+  if (!isPlainObject(value)) return null;
+  if (!isValidCurriculum(value.curriculum)) return null;
+
+  if (
+    typeof value.id !== 'string' ||
+    typeof value.title !== 'string' ||
+    typeof value.createdAt !== 'string' ||
+    typeof value.updatedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  const snapshot =
+    value.snapshot === null || value.snapshot === undefined
+      ? null
+      : validateSnapshot(value.snapshot);
+
+  return {
+    id: value.id,
+    title: value.title,
+    curriculum: deepCopy(value.curriculum),
+    snapshot,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
 }
 
 function loadRecords(storage: Storage): CourseRecord[] {
@@ -63,7 +254,9 @@ function loadRecords(storage: Storage): CourseRecord[] {
   }
 
   if (!Array.isArray(parsed)) return [];
-  return parsed.filter(isValidRecord);
+  return parsed
+    .map((record) => normalizeRecord(record))
+    .filter((record): record is CourseRecord => record !== null);
 }
 
 function saveRecords(records: CourseRecord[], storage: Storage): void {

--- a/apps/coursequizzer/tests/unit/course-progress.test.ts
+++ b/apps/coursequizzer/tests/unit/course-progress.test.ts
@@ -5,7 +5,12 @@ import {
   getProgressLabel,
 } from '../../src/lib/stores/course-progress.js';
 import type { CourseRecord } from '../../src/lib/storage/course-storage.js';
-import type { CurriculumPlan, EngineSnapshot, StudentState } from 'quizzer-engine';
+import {
+  SNAPSHOT_VERSION,
+  type CurriculumPlan,
+  type EngineSnapshot,
+  type StudentState,
+} from 'quizzer-engine';
 
 // --- Fixtures ---
 
@@ -56,7 +61,7 @@ function mockRecord(overrides?: Partial<CourseRecord>): CourseRecord {
 
 function mockSnapshot(overrides?: Partial<EngineSnapshot>): EngineSnapshot {
   return {
-    version: 3,
+    version: SNAPSHOT_VERSION,
     state: 'ready',
     curriculum: mockCurriculum(),
     currentSectionIndex: 0,

--- a/apps/coursequizzer/tests/unit/course-storage.test.ts
+++ b/apps/coursequizzer/tests/unit/course-storage.test.ts
@@ -34,12 +34,20 @@ function createLocalStorageMock(): Storage {
 
 function mockCurriculumPlan(): CurriculumPlan {
   return {
-    courseTitle: 'Test Course',
+    title: 'Test Course',
+    description: 'A valid curriculum used for storage tests.',
     sections: [
       {
         id: 's1',
         title: 'Section 1',
-        topics: [{ id: 't1', name: 'Topic 1', section: 's1' }],
+        order: 0,
+        topics: [
+          {
+            id: 't1',
+            title: 'Topic 1',
+            description: 'A test topic.',
+          },
+        ],
       },
     ],
   };
@@ -53,7 +61,7 @@ function mockSnapshot(): EngineSnapshot {
     currentSectionIndex: 0,
     currentItemIndex: 0,
     sectionItems: [],
-    studentState: { topicMastery: {}, answeredQuestions: [] },
+    studentState: { masteryByTopic: {}, gaps: [] },
     lastAnswerResult: null,
   };
 }
@@ -193,6 +201,77 @@ describe('course-storage', () => {
     const list = listCourses(storage);
     expect(list).toHaveLength(1);
     expect(list[0].id).toBe('valid-1');
+  });
+
+  it('filters out records with malformed curriculum payloads', () => {
+    const invalidCurriculumRecord = {
+      id: 'bad-curriculum',
+      title: 'Broken curriculum',
+      curriculum: {
+        title: 'Broken curriculum',
+        description: 'Missing section order and topic descriptions.',
+        sections: [
+          {
+            id: 's1',
+            title: 'Section 1',
+            topics: [{ id: 't1', title: 'Topic 1' }],
+          },
+        ],
+      },
+      snapshot: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([invalidCurriculumRecord]));
+
+    expect(listCourses(storage)).toEqual([]);
+    expect(getCourse('bad-curriculum', storage)).toBeNull();
+  });
+
+  it('nulls out malformed snapshot payloads before returning persisted records', () => {
+    const recordWithBadSnapshot = {
+      id: 'bad-snapshot',
+      title: 'Broken snapshot',
+      curriculum: mockCurriculumPlan(),
+      snapshot: {
+        version: 3,
+        state: 'ready',
+        curriculum: mockCurriculumPlan(),
+        currentSectionIndex: '0',
+        currentItemIndex: 0,
+        sectionItems: [],
+        studentState: { masteryByTopic: {}, gaps: [] },
+        lastAnswerResult: null,
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([recordWithBadSnapshot]));
+
+    const loaded = getCourse('bad-snapshot', storage);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.snapshot).toBeNull();
+    expect(listCourses(storage)[0].snapshot).toBeNull();
+  });
+
+  it('nulls out snapshots with unsupported persisted versions', () => {
+    const recordWithOldSnapshot = {
+      id: 'old-snapshot',
+      title: 'Old snapshot',
+      curriculum: mockCurriculumPlan(),
+      snapshot: {
+        ...mockSnapshot(),
+        version: 2,
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([recordWithOldSnapshot]));
+
+    expect(getCourse('old-snapshot', storage)?.snapshot).toBeNull();
   });
 
   // --- Security: no API key in persisted data ---

--- a/apps/coursequizzer/tests/unit/course-storage.test.ts
+++ b/apps/coursequizzer/tests/unit/course-storage.test.ts
@@ -8,7 +8,11 @@ import {
   COURSES_STORAGE_KEY,
   type CourseRecord,
 } from '../../src/lib/storage/course-storage.js';
-import type { CurriculumPlan, EngineSnapshot } from 'quizzer-engine';
+import {
+  SNAPSHOT_VERSION,
+  type CurriculumPlan,
+  type EngineSnapshot,
+} from 'quizzer-engine';
 
 // --- localStorage mock ---
 
@@ -55,7 +59,7 @@ function mockCurriculumPlan(): CurriculumPlan {
 
 function mockSnapshot(): EngineSnapshot {
   return {
-    version: 3,
+    version: SNAPSHOT_VERSION,
     state: 'ready',
     curriculum: mockCurriculumPlan(),
     currentSectionIndex: 0,
@@ -235,7 +239,7 @@ describe('course-storage', () => {
       title: 'Broken snapshot',
       curriculum: mockCurriculumPlan(),
       snapshot: {
-        version: 3,
+        version: SNAPSHOT_VERSION,
         state: 'ready',
         curriculum: mockCurriculumPlan(),
         currentSectionIndex: '0',

--- a/apps/coursequizzer/tests/unit/engine-session.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session.test.ts
@@ -41,17 +41,32 @@ function createLocalStorageMock(): Storage {
 
 function mockCurriculumPlan(): CurriculumPlan {
   return {
-    courseTitle: 'Test Course',
+    title: 'Test Course',
+    description: 'A valid curriculum used for engine-session tests.',
     sections: [
       {
         id: 's1',
         title: 'Section 1',
-        topics: [{ id: 't1', name: 'Topic 1', section: 's1' }],
+        order: 0,
+        topics: [
+          {
+            id: 't1',
+            title: 'Topic 1',
+            description: 'A test topic.',
+          },
+        ],
       },
       {
         id: 's2',
         title: 'Section 2',
-        topics: [{ id: 't2', name: 'Topic 2', section: 's2' }],
+        order: 1,
+        topics: [
+          {
+            id: 't2',
+            title: 'Topic 2',
+            description: 'Another test topic.',
+          },
+        ],
       },
     ],
   };
@@ -108,7 +123,7 @@ describe('createEngineSession', () => {
 
     expect(session.engineState).toBe('ready');
     expect(session.curriculum).not.toBeNull();
-    expect(session.curriculum!.courseTitle).toBe('Test Course');
+    expect(session.curriculum!.title).toBe('Test Course');
     expect(session.curriculum!.sections).toHaveLength(2);
   });
 
@@ -306,7 +321,7 @@ describe('createEngineSession', () => {
 
     expect(session2.engineState).toBe('practicing');
     expect(session2.curriculum).not.toBeNull();
-    expect(session2.curriculum!.courseTitle).toBe('Test Course');
+    expect(session2.curriculum!.title).toBe('Test Course');
   });
 
   // --- Auto-save to course storage ---

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -20,7 +20,7 @@ import type {
 import type { StudentAnswer, Question } from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
-const SNAPSHOT_VERSION = 3;
+export const SNAPSHOT_VERSION = 3;
 
 function copySection(section: Section): Section {
   return {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,4 @@
-export { CourseEngine } from './engine/CourseEngine.js';
+export { CourseEngine, SNAPSHOT_VERSION } from './engine/CourseEngine.js';
 export { InvalidTransitionError, EngineError } from './engine/errors.js';
 export { ClaudeProvider } from './provider/ClaudeProvider.js';
 export { RateLimiter } from './provider/rate-limiter.js';


### PR DESCRIPTION
## Summary\n- validate persisted curriculum payloads in course storage before returning records\n- null out malformed or unsupported persisted snapshots instead of restoring them\n- add malformed-persistence coverage and update engine-session fixtures to the current curriculum shape\n\n## Verification\n- pnpm -r test\n- pnpm -r build\n- pnpm format\n\nCloses #43