### PR TITLE
fix: fail closed on bad persisted engine snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Harden `course-storage` persisted-data validation so malformed curriculum records are filtered out before app routes read them
 - Null out malformed persisted engine snapshots instead of attempting to restore them
 - Add storage tests covering malformed curriculum and snapshot payloads, and align engine-session test fixtures with the current curriculum shape
+- Fail closed on bad persisted engine snapshots: stale or malformed snapshots no longer crash the learn page — the session falls back to a fresh engine with the curriculum reloaded, and the bad snapshot is cleared from storage
+- Allow `updateCourse` to accept `null` snapshot for clearing persisted snapshots
 
 ## 0.7.3 — 2026-04-12
 

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -27,7 +27,7 @@ export type CreateCourseInput = {
 
 export type UpdateCourseInput = {
   title?: string;
-  snapshot?: EngineSnapshot;
+  snapshot?: EngineSnapshot | null;
   curriculum?: CurriculumPlan;
 };
 
@@ -311,7 +311,7 @@ export function updateCourse(
   if (input.title !== undefined) record.title = input.title;
   if (input.curriculum !== undefined) record.curriculum = deepCopy(input.curriculum);
   if (input.snapshot !== undefined) {
-    record.snapshot = deepCopy(sanitizeSnapshot(input.snapshot));
+    record.snapshot = input.snapshot ? deepCopy(sanitizeSnapshot(input.snapshot)) : null;
   }
   record.updatedAt = new Date().toISOString();
 

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -59,6 +59,18 @@ export type EngineSession = ReturnType<typeof createEngineSession>;
 
 export function createEngineSession(config: EngineSessionConfig) {
   const engineConfig: CourseEngineConfig = { apiKey: config.apiKey };
+  let initialError: ErrorInfo | null = null;
+
+  function clearBadSnapshot(): void {
+    if (!config.courseId || !config.storage) return;
+
+    try {
+      updateCourse(config.courseId, { snapshot: null }, config.storage);
+    } catch (err) {
+      const normalized = normalizeError(err);
+      initialError = { message: normalized.message, recoverable: true };
+    }
+  }
 
   // --- Attempt snapshot restore, fall back to fresh engine on failure ---
 
@@ -73,9 +85,7 @@ export function createEngineSession(config: EngineSessionConfig) {
       didRestoreFail = true;
 
       // Clear the bad snapshot from storage so the next load doesn't repeat the failure
-      if (config.courseId && config.storage) {
-        updateCourse(config.courseId, { snapshot: null }, config.storage);
-      }
+      clearBadSnapshot();
     }
   } else {
     engine = new CourseEngine(engineConfig);
@@ -91,7 +101,7 @@ export function createEngineSession(config: EngineSessionConfig) {
   let studentState = $state<StudentState | null>(null);
   let progress = $state<SessionProgress | null>(null);
   let apiLoading = $state(false);
-  let error = $state<ErrorInfo | null>(null);
+  let error = $state<ErrorInfo | null>(initialError);
 
   // If restoring successfully, sync initial state from snapshot
   if (config.snapshot && !didRestoreFail && engine) {

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -60,9 +60,26 @@ export type EngineSession = ReturnType<typeof createEngineSession>;
 export function createEngineSession(config: EngineSessionConfig) {
   const engineConfig: CourseEngineConfig = { apiKey: config.apiKey };
 
-  let engine: CourseEngine | null = config.snapshot
-    ? CourseEngine.restore(config.snapshot, engineConfig)
-    : new CourseEngine(engineConfig);
+  // --- Attempt snapshot restore, fall back to fresh engine on failure ---
+
+  let engine: CourseEngine | null;
+  let didRestoreFail = false;
+
+  if (config.snapshot) {
+    try {
+      engine = CourseEngine.restore(config.snapshot, engineConfig);
+    } catch {
+      engine = new CourseEngine(engineConfig);
+      didRestoreFail = true;
+
+      // Clear the bad snapshot from storage so the next load doesn't repeat the failure
+      if (config.courseId && config.storage) {
+        updateCourse(config.courseId, { snapshot: null }, config.storage);
+      }
+    }
+  } else {
+    engine = new CourseEngine(engineConfig);
+  }
 
   // --- Reactive state ---
 
@@ -76,8 +93,8 @@ export function createEngineSession(config: EngineSessionConfig) {
   let apiLoading = $state(false);
   let error = $state<ErrorInfo | null>(null);
 
-  // If restoring, sync initial state from snapshot
-  if (config.snapshot && engine) {
+  // If restoring successfully, sync initial state from snapshot
+  if (config.snapshot && !didRestoreFail && engine) {
     engineState = engine.state;
     curriculum = engine.curriculum;
     studentState = engine.studentState;
@@ -226,6 +243,9 @@ export function createEngineSession(config: EngineSessionConfig) {
     },
     get error() {
       return error;
+    },
+    get restoreFailed() {
+      return didRestoreFail;
     },
 
     // --- Engine actions ---

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -37,8 +37,8 @@
       snapshot: course.snapshot ?? undefined,
     });
 
-    // If no snapshot, load the curriculum fresh
-    if (!course.snapshot) {
+    // If no snapshot or restore failed, load the curriculum fresh
+    if (!course.snapshot || newSession.restoreFailed) {
       newSession.loadCurriculum(course.curriculum);
     }
     session = newSession;

--- a/apps/coursequizzer/tests/unit/engine-session.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session.test.ts
@@ -11,7 +11,6 @@ import type {
   StudentAnswer,
 } from 'quizzer-engine';
 import {
-  updateCourse,
   createCourse,
   getCourse,
   COURSES_STORAGE_KEY,
@@ -462,28 +461,33 @@ describe('createEngineSession', () => {
       { title: 'Test', curriculum: mockCurriculumPlan() },
       storage
     );
+    const badSnapshot = { version: 999 } as unknown as EngineSnapshot;
 
-    // Manually set a bad snapshot
-    updateCourse(
-      course.id,
-      { snapshot: { version: 999 } as unknown as EngineSnapshot },
-      storage
-    );
+    // Seed raw persisted data with a legacy bad snapshot that storage validation
+    // will null out on read, but that may still be passed into restore by a stale caller.
+    const rawRecords = JSON.parse(storage.getItem(COURSES_STORAGE_KEY) ?? '[]') as Array<
+      Record<string, unknown>
+    >;
+    rawRecords[0] = { ...rawRecords[0], snapshot: badSnapshot };
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify(rawRecords));
 
-    const stored = getCourse(course.id, storage);
-    expect(stored!.snapshot).not.toBeNull();
+    const persistedBefore = JSON.parse(
+      storage.getItem(COURSES_STORAGE_KEY) ?? '[]'
+    ) as Array<{ snapshot: EngineSnapshot | null }>;
+    expect(persistedBefore[0]?.snapshot).toEqual(badSnapshot);
 
     const session = createEngineSession({
       apiKey: 'test-key',
       courseId: course.id,
       storage,
-      snapshot: stored!.snapshot!,
+      snapshot: badSnapshot,
     });
 
     expect(session.restoreFailed).toBe(true);
 
-    // The bad snapshot should be cleared from storage
-    const updated = getCourse(course.id, storage);
-    expect(updated!.snapshot).toBeNull();
+    const persistedAfter = JSON.parse(
+      storage.getItem(COURSES_STORAGE_KEY) ?? '[]'
+    ) as Array<{ snapshot: EngineSnapshot | null }>;
+    expect(persistedAfter[0]?.snapshot).toBeNull();
   });
 });

--- a/apps/coursequizzer/tests/unit/engine-session.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session.test.ts
@@ -490,4 +490,45 @@ describe('createEngineSession', () => {
     ) as Array<{ snapshot: EngineSnapshot | null }>;
     expect(persistedAfter[0]?.snapshot).toBeNull();
   });
+
+  it('treats snapshot cleanup storage failures as recoverable restore errors', () => {
+    const storage = createLocalStorageMock();
+    const course = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+    const badSnapshot = { version: 999 } as unknown as EngineSnapshot;
+
+    const rawRecords = JSON.parse(storage.getItem(COURSES_STORAGE_KEY) ?? '[]') as Array<
+      Record<string, unknown>
+    >;
+    rawRecords[0] = { ...rawRecords[0], snapshot: badSnapshot };
+    storage.setItem(COURSES_STORAGE_KEY, JSON.stringify(rawRecords));
+
+    vi.mocked(storage.setItem).mockImplementation(() => {
+      throw new DOMException(
+        'quota hit while clearing bad snapshot',
+        'QuotaExceededError'
+      );
+    });
+
+    let session: EngineSession | null = null;
+
+    expect(() => {
+      session = createEngineSession({
+        apiKey: 'test-key',
+        courseId: course.id,
+        storage,
+        snapshot: badSnapshot,
+      });
+    }).not.toThrow();
+
+    expect(session).not.toBeNull();
+    expect(session!.restoreFailed).toBe(true);
+    expect(session!.engineState).toBe('idle');
+    expect(session!.error).toEqual({
+      message: 'Browser storage is full. Please delete some courses to free space.',
+      recoverable: true,
+    });
+  });
 });

--- a/apps/coursequizzer/tests/unit/engine-session.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session.test.ts
@@ -406,4 +406,84 @@ describe('createEngineSession', () => {
     session.dispose();
     expect(session.serialize()).toBeNull();
   });
+
+  // --- Snapshot restore failure (fail-closed) ---
+
+  it('falls back to fresh engine when snapshot has unsupported version', () => {
+    const badSnapshot: EngineSnapshot = {
+      version: 999,
+      state: 'ready',
+      curriculum: mockCurriculumPlan(),
+      currentSectionIndex: -1,
+      currentItemIndex: -1,
+      sectionItems: [],
+      studentState: { topicMastery: {}, totalAnswered: 0, totalCorrect: 0 },
+      lastAnswerResult: null,
+    };
+
+    const session = createEngineSession({ apiKey: 'test-key', snapshot: badSnapshot });
+
+    // Should not crash — falls back to idle (fresh engine)
+    expect(session.engineState).toBe('idle');
+    expect(session.restoreFailed).toBe(true);
+    expect(session.curriculum).toBeNull();
+  });
+
+  it('falls back to fresh engine when snapshot is malformed', () => {
+    // A snapshot missing required fields
+    const malformedSnapshot = {
+      version: 3,
+      state: 'ready',
+      // Missing curriculum, sectionItems, studentState, etc.
+    } as unknown as EngineSnapshot;
+
+    const session = createEngineSession({
+      apiKey: 'test-key',
+      snapshot: malformedSnapshot,
+    });
+
+    expect(session.engineState).toBe('idle');
+    expect(session.restoreFailed).toBe(true);
+  });
+
+  it('sets restoreFailed to false when snapshot restores successfully', () => {
+    const session1 = createEngineSession({ apiKey: 'test-key' });
+    session1.loadCurriculum(mockCurriculumPlan());
+    const snapshot = session1.serialize()!;
+
+    const session2 = createEngineSession({ apiKey: 'test-key', snapshot });
+    expect(session2.restoreFailed).toBe(false);
+    expect(session2.engineState).toBe('ready');
+  });
+
+  it('clears bad snapshot from storage on restore failure', () => {
+    const storage = createLocalStorageMock();
+    const course = createCourse(
+      { title: 'Test', curriculum: mockCurriculumPlan() },
+      storage
+    );
+
+    // Manually set a bad snapshot
+    updateCourse(
+      course.id,
+      { snapshot: { version: 999 } as unknown as EngineSnapshot },
+      storage
+    );
+
+    const stored = getCourse(course.id, storage);
+    expect(stored!.snapshot).not.toBeNull();
+
+    const session = createEngineSession({
+      apiKey: 'test-key',
+      courseId: course.id,
+      storage,
+      snapshot: stored!.snapshot!,
+    });
+
+    expect(session.restoreFailed).toBe(true);
+
+    // The bad snapshot should be cleared from storage
+    const updated = getCourse(course.id, storage);
+    expect(updated!.snapshot).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- `createEngineSession` now catches `CourseEngine.restore()` failures (unsupported version, malformed data) and falls back to a fresh engine instead of crashing
- Exposes `restoreFailed` flag so the learn page reloads the curriculum from storage rather than attempting to use the failed snapshot
- Clears the bad snapshot from course storage on failure so subsequent loads don't repeat the crash
- Widens `UpdateCourseInput.snapshot` to accept `null` for explicit snapshot clearing

## Test plan
- [x] Unsupported snapshot version falls back to idle state with `restoreFailed: true`
- [x] Malformed snapshot (missing required fields) falls back to idle state with `restoreFailed: true`
- [x] Successful snapshot restore sets `restoreFailed: false`
- [x] Bad snapshot is cleared from course storage on restore failure
- [x] All existing tests continue to pass (160 engine + 114 app)
- [x] `pnpm -r build` succeeds
- [x] `pnpm format` clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)