### PR TITLE
fix: mask short stored API keys in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.5 — 2026-04-12
+
+### Fixes
+
+- Mask short stored API keys in Settings instead of displaying them verbatim — `getMaskedApiKey()` now always returns a masked value for any non-empty key
+
 ## 0.7.4 — 2026-04-12
 
 ### Fixes

--- a/apps/coursequizzer/src/lib/stores/api-key.ts
+++ b/apps/coursequizzer/src/lib/stores/api-key.ts
@@ -7,8 +7,14 @@
 export const API_KEY_STORAGE_KEY = 'coursequizzer:api-key';
 
 const MASK_CHAR = '•';
-const VISIBLE_PREFIX_LENGTH = 7; // "sk-ant-" prefix
-const VISIBLE_SUFFIX_LENGTH = 4;
+const LONG_PREFIX_LENGTH = 7; // "sk-ant-" prefix for standard Anthropic keys
+const LONG_SUFFIX_LENGTH = 4;
+const SHORT_PREFIX_LENGTH = 2;
+const SHORT_SUFFIX_LENGTH = 2;
+// Keys shorter than this use the short prefix/suffix; longer keys use the standard masking
+const SHORT_KEY_THRESHOLD = LONG_PREFIX_LENGTH + LONG_SUFFIX_LENGTH + 1;
+// Keys at or below this length are fully masked (no visible chars)
+const FULLY_MASKED_THRESHOLD = SHORT_PREFIX_LENGTH + SHORT_SUFFIX_LENGTH;
 
 /**
  * Save an API key to localStorage.
@@ -46,11 +52,22 @@ export function getMaskedApiKey(storage: Storage): string | null {
   const key = storage.getItem(API_KEY_STORAGE_KEY);
   if (key === null) return null;
 
-  const minMaskableLength = VISIBLE_PREFIX_LENGTH + VISIBLE_SUFFIX_LENGTH + 1;
-  if (key.length <= minMaskableLength) return key;
+  // Short keys: mask entirely or show minimal context
+  if (key.length <= FULLY_MASKED_THRESHOLD) {
+    return MASK_CHAR.repeat(key.length);
+  }
 
-  const prefix = key.slice(0, VISIBLE_PREFIX_LENGTH);
-  const suffix = key.slice(-VISIBLE_SUFFIX_LENGTH);
-  const maskedLength = key.length - VISIBLE_PREFIX_LENGTH - VISIBLE_SUFFIX_LENGTH;
+  // Medium keys: show first 2 + mask + last 2
+  if (key.length < SHORT_KEY_THRESHOLD) {
+    const prefix = key.slice(0, SHORT_PREFIX_LENGTH);
+    const suffix = key.slice(-SHORT_SUFFIX_LENGTH);
+    const maskedLength = key.length - SHORT_PREFIX_LENGTH - SHORT_SUFFIX_LENGTH;
+    return prefix + MASK_CHAR.repeat(maskedLength) + suffix;
+  }
+
+  // Standard Anthropic-style keys: show "sk-ant-" prefix + last 4
+  const prefix = key.slice(0, LONG_PREFIX_LENGTH);
+  const suffix = key.slice(-LONG_SUFFIX_LENGTH);
+  const maskedLength = key.length - LONG_PREFIX_LENGTH - LONG_SUFFIX_LENGTH;
   return prefix + MASK_CHAR.repeat(maskedLength) + suffix;
 }

--- a/apps/coursequizzer/tests/unit/api-key-store.test.ts
+++ b/apps/coursequizzer/tests/unit/api-key-store.test.ts
@@ -103,11 +103,25 @@ describe('api-key store', () => {
     expect(getMaskedApiKey(storage)).toBeNull();
   });
 
-  it('masks a short key without crashing', () => {
+  it('masks a short key instead of returning it verbatim', () => {
     saveApiKey('abcd', storage);
     const masked = getMaskedApiKey(storage);
-    // A 4-char key: show all 4 since there's nothing to mask
-    expect(masked).toBe('abcd');
+    // Short keys are fully masked — never shown verbatim
+    expect(masked).toBe('••••');
+    expect(masked).not.toBe('abcd');
+  });
+
+  it('masks a very short key (1 char)', () => {
+    saveApiKey('x', storage);
+    const masked = getMaskedApiKey(storage);
+    expect(masked).toBe('•');
+  });
+
+  it('masks a medium-short key showing partial prefix and suffix', () => {
+    saveApiKey('secret99', storage);
+    const masked = getMaskedApiKey(storage);
+    // 8 chars: show first 2, mask middle, show last 2
+    expect(masked).toBe('se••••99');
   });
 
   it('masks a key with exactly the prefix plus a few chars', () => {
@@ -115,5 +129,14 @@ describe('api-key store', () => {
     const masked = getMaskedApiKey(storage);
     // 15 chars: prefix "sk-ant-" (7) + 4 masked + suffix "3-xy" (4)
     expect(masked).toBe('sk-ant-••••3-xy');
+  });
+
+  it('never returns a stored key verbatim regardless of length', () => {
+    // Verify the core invariant across various lengths
+    for (const key of ['a', 'ab', 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefgh']) {
+      saveApiKey(key, storage);
+      const masked = getMaskedApiKey(storage);
+      expect(masked, `key "${key}" was returned verbatim`).not.toBe(key);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `getMaskedApiKey()` previously returned the raw key verbatim when shorter than the mask threshold (11 chars)
- Now all non-empty keys are masked: very short keys (≤4 chars) fully masked, medium keys show first 2 + last 2 chars, standard keys keep existing behavior
- Added tests covering 1-char, 4-char, and 8-char keys plus a sweep invariant that no key is ever returned verbatim

## Test plan
- [x] Short key (4 chars) returns all mask chars
- [x] Very short key (1 char) returns single mask char
- [x] Medium key (8 chars) shows first 2 + mask + last 2
- [x] Standard Anthropic key masking unchanged
- [x] Invariant test: no key of any length returned verbatim
- [x] All 276 tests pass (160 engine + 116 app)
- [x] `pnpm -r build` succeeds
- [x] `pnpm format` clean

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)