### PR TITLE
feat: implement Export and Import functionality (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - **Engine:** Robust validation — Imported bundles are validated for structure and version compatibility before restoration
 - **Engine:** Automatic migration — Support for migrating version 3 snapshots to version 4 (adding `allGeneratedContent` support)
 
+### Fixes
+
+- **Engine/App:** Tighten import validation so malformed snapshot indices, section content, and `allGeneratedContent` payloads are rejected before persistence or restore
+
 ## 0.8.0 — 2026-04-13
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.2 — 2026-04-13
+
+### Features
+
+- **Engine/App:** Implement Export and Import functionality — users can now download a JSON bundle of their course progress and import it on other machines
+- **Engine:** Export bundle includes curriculum, student mastery, and all generated content across all sections
+- **Engine:** Secure by design — API keys are strictly excluded from all export bundles
+- **Engine:** Robust validation — Imported bundles are validated for structure and version compatibility before restoration
+- **Engine:** Automatic migration — Support for migrating version 3 snapshots to version 4 (adding `allGeneratedContent` support)
+
 ## 0.8.0 — 2026-04-13
 
 ### Infrastructure

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -184,24 +184,24 @@ function isValidContentItem(value: unknown): boolean {
 function validateSnapshot(value: unknown): EngineSnapshot | null {
   if (!isPlainObject(value)) return null;
 
-  let snapshot = sanitizeSnapshot(value as EngineSnapshot);
+  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
 
-  // Migration: v3 -> v4
-  if (snapshot.version === 3) {
-    snapshot = { ...snapshot, version: SNAPSHOT_VERSION, allGeneratedContent: {} };
-  }
+  // Supported versions for restoration
+  const supportedVersions = [3, SNAPSHOT_VERSION];
 
   if (
-    snapshot.version !== SNAPSHOT_VERSION ||
+    !supportedVersions.includes(snapshot.version) ||
     !isValidEngineState(snapshot.state) ||
     !Number.isInteger(snapshot.currentSectionIndex) ||
     !Number.isInteger(snapshot.currentItemIndex) ||
     !Array.isArray(snapshot.sectionItems) ||
     !snapshot.sectionItems.every(isValidContentItem) ||
-    !isPlainObject(snapshot.allGeneratedContent) ||
-    !Object.values(snapshot.allGeneratedContent).every(
-      (items) => Array.isArray(items) && items.every(isValidContentItem)
-    ) ||
+    (snapshot.version === SNAPSHOT_VERSION &&
+      !isPlainObject(snapshot.allGeneratedContent)) ||
+    (snapshot.version === SNAPSHOT_VERSION &&
+      !Object.values(snapshot.allGeneratedContent).every(
+        (items) => Array.isArray(items) && items.every(isValidContentItem)
+      )) ||
     !isValidStudentState(snapshot.studentState) ||
     (snapshot.curriculum !== null && !isValidCurriculum(snapshot.curriculum)) ||
     !('lastAnswerResult' in snapshot) ||
@@ -302,11 +302,17 @@ export function importCourse(
   storage: Storage
 ): string {
   const now = new Date().toISOString();
+
+  const validatedSnapshot = validateSnapshot(input.snapshot);
+  if (!validatedSnapshot) {
+    throw new Error('Invalid course snapshot in import data');
+  }
+
   const record: CourseRecord = {
     id: generateId(),
     title: input.title,
     curriculum: deepCopy(input.curriculum),
-    snapshot: deepCopy(sanitizeSnapshot(input.snapshot)),
+    snapshot: deepCopy(validatedSnapshot),
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -4,7 +4,7 @@
 
 import {
   validateCurriculumPlan,
-  SNAPSHOT_VERSION,
+  validateEngineSnapshot,
   type CurriculumPlan,
   type EngineSnapshot,
 } from 'quizzer-engine';
@@ -48,170 +48,11 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
-}
-
-function isValidEngineState(value: unknown): boolean {
-  return (
-    value === 'idle' ||
-    value === 'planning' ||
-    value === 'ready' ||
-    value === 'loading' ||
-    value === 'practicing' ||
-    value === 'answered' ||
-    value === 'sectionComplete' ||
-    value === 'complete'
-  );
-}
-
-function isValidStudentState(value: unknown): boolean {
-  if (!isPlainObject(value)) return false;
-  if (!isPlainObject(value.masteryByTopic) || !isStringArray(value.gaps)) return false;
-
-  return Object.entries(value.masteryByTopic).every(([topicId, mastery]) => {
-    if (!isPlainObject(mastery)) return false;
-    return (
-      mastery.topicId === topicId &&
-      typeof mastery.score === 'number' &&
-      typeof mastery.questionsAnswered === 'number' &&
-      typeof mastery.questionsCorrect === 'number'
-    );
-  });
-}
-
-function isValidStudentAnswer(value: unknown): boolean {
-  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
-
-  switch (value.type) {
-    case 'multiple-choice':
-      return typeof value.selectedIndex === 'number';
-    case 'numeric-input':
-      return typeof value.value === 'number';
-    case 'ordering':
-      return (
-        Array.isArray(value.order) &&
-        value.order.every((entry) => typeof entry === 'number')
-      );
-    case 'multi-select':
-      return (
-        Array.isArray(value.selectedIndices) &&
-        value.selectedIndices.every((entry) => typeof entry === 'number')
-      );
-    case 'two-stage':
-      return (
-        typeof value.selectedIndex === 'number' &&
-        typeof value.followUpSelectedIndex === 'number'
-      );
-    default:
-      return false;
-  }
-}
-
-function isValidAnswerResult(value: unknown): boolean {
-  if (!isPlainObject(value)) return false;
-  return (
-    typeof value.correct === 'boolean' &&
-    typeof value.questionId === 'string' &&
-    typeof value.topicId === 'string' &&
-    typeof value.correctAnswer === 'string' &&
-    (value.explanation === undefined || typeof value.explanation === 'string') &&
-    isValidStudentAnswer(value.userAnswer)
-  );
-}
-
-function isValidContentItem(value: unknown): boolean {
-  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
-
-  switch (value.type) {
-    case 'explanation':
-      return (
-        typeof value.topicId === 'string' &&
-        typeof value.title === 'string' &&
-        typeof value.content === 'string'
-      );
-    case 'multiple-choice':
-      return (
-        typeof value.id === 'string' &&
-        typeof value.topicId === 'string' &&
-        typeof value.question === 'string' &&
-        isStringArray(value.options) &&
-        typeof value.correctIndex === 'number'
-      );
-    case 'numeric-input':
-      return (
-        typeof value.id === 'string' &&
-        typeof value.topicId === 'string' &&
-        typeof value.question === 'string' &&
-        typeof value.correctValue === 'number' &&
-        (value.tolerance === undefined || typeof value.tolerance === 'number') &&
-        (value.unit === undefined || typeof value.unit === 'string')
-      );
-    case 'ordering':
-      return (
-        typeof value.id === 'string' &&
-        typeof value.topicId === 'string' &&
-        typeof value.question === 'string' &&
-        isStringArray(value.items) &&
-        Array.isArray(value.correctOrder) &&
-        value.correctOrder.every((entry) => typeof entry === 'number')
-      );
-    case 'multi-select':
-      return (
-        typeof value.id === 'string' &&
-        typeof value.topicId === 'string' &&
-        typeof value.question === 'string' &&
-        isStringArray(value.options) &&
-        Array.isArray(value.correctIndices) &&
-        value.correctIndices.every((entry) => typeof entry === 'number')
-      );
-    case 'two-stage':
-      return (
-        typeof value.id === 'string' &&
-        typeof value.topicId === 'string' &&
-        typeof value.question === 'string' &&
-        isStringArray(value.options) &&
-        typeof value.correctIndex === 'number' &&
-        typeof value.followUp === 'string' &&
-        isStringArray(value.followUpOptions) &&
-        typeof value.followUpCorrectIndex === 'number'
-      );
-    default:
-      return false;
-  }
-}
-
 function validateSnapshot(value: unknown): EngineSnapshot | null {
-  if (!isPlainObject(value)) return null;
-
-  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
-
-  // Supported versions for restoration
-  const supportedVersions = [3, SNAPSHOT_VERSION];
-
-  if (
-    !supportedVersions.includes(snapshot.version) ||
-    !isValidEngineState(snapshot.state) ||
-    !Number.isInteger(snapshot.currentSectionIndex) ||
-    !Number.isInteger(snapshot.currentItemIndex) ||
-    !Array.isArray(snapshot.sectionItems) ||
-    !snapshot.sectionItems.every(isValidContentItem) ||
-    (snapshot.version === SNAPSHOT_VERSION &&
-      !isPlainObject(snapshot.allGeneratedContent)) ||
-    (snapshot.version === SNAPSHOT_VERSION &&
-      !Object.values(snapshot.allGeneratedContent).every(
-        (items) => Array.isArray(items) && items.every(isValidContentItem)
-      )) ||
-    !isValidStudentState(snapshot.studentState) ||
-    (snapshot.curriculum !== null && !isValidCurriculum(snapshot.curriculum)) ||
-    !('lastAnswerResult' in snapshot) ||
-    (snapshot.lastAnswerResult !== null &&
-      !isValidAnswerResult(snapshot.lastAnswerResult))
-  ) {
-    return null;
-  }
-
-  return deepCopy(snapshot);
+  const sanitized = isPlainObject(value)
+    ? sanitizeSnapshot(value as EngineSnapshot)
+    : value;
+  return validateEngineSnapshot(sanitized);
 }
 
 function isValidCurriculum(value: unknown): value is CurriculumPlan {

--- a/apps/coursequizzer/src/lib/storage/course-storage.ts
+++ b/apps/coursequizzer/src/lib/storage/course-storage.ts
@@ -184,7 +184,12 @@ function isValidContentItem(value: unknown): boolean {
 function validateSnapshot(value: unknown): EngineSnapshot | null {
   if (!isPlainObject(value)) return null;
 
-  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
+  let snapshot = sanitizeSnapshot(value as EngineSnapshot);
+
+  // Migration: v3 -> v4
+  if (snapshot.version === 3) {
+    snapshot = { ...snapshot, version: SNAPSHOT_VERSION, allGeneratedContent: {} };
+  }
 
   if (
     snapshot.version !== SNAPSHOT_VERSION ||
@@ -193,6 +198,10 @@ function validateSnapshot(value: unknown): EngineSnapshot | null {
     !Number.isInteger(snapshot.currentItemIndex) ||
     !Array.isArray(snapshot.sectionItems) ||
     !snapshot.sectionItems.every(isValidContentItem) ||
+    !isPlainObject(snapshot.allGeneratedContent) ||
+    !Object.values(snapshot.allGeneratedContent).every(
+      (items) => Array.isArray(items) && items.every(isValidContentItem)
+    ) ||
     !isValidStudentState(snapshot.studentState) ||
     (snapshot.curriculum !== null && !isValidCurriculum(snapshot.curriculum)) ||
     !('lastAnswerResult' in snapshot) ||
@@ -286,6 +295,27 @@ export function createCourse(input: CreateCourseInput, storage: Storage): Course
   saveRecords(records, storage);
 
   return deepCopy(record);
+}
+
+export function importCourse(
+  input: { title: string; curriculum: CurriculumPlan; snapshot: EngineSnapshot },
+  storage: Storage
+): string {
+  const now = new Date().toISOString();
+  const record: CourseRecord = {
+    id: generateId(),
+    title: input.title,
+    curriculum: deepCopy(input.curriculum),
+    snapshot: deepCopy(sanitizeSnapshot(input.snapshot)),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const records = loadRecords(storage);
+  records.push(record);
+  saveRecords(records, storage);
+
+  return record.id;
 }
 
 export function getCourse(id: string, storage: Storage): CourseRecord | null {

--- a/apps/coursequizzer/src/routes/+page.svelte
+++ b/apps/coursequizzer/src/routes/+page.svelte
@@ -63,6 +63,7 @@
 
   <nav>
     <a href="/course/new">New Course</a>
+    <a href="/import">Import Course</a>
     <a href="/settings">Settings</a>
   </nav>
 

--- a/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
@@ -10,11 +10,37 @@
   } from '$lib/stores/course-progress.js';
   import { normalizeError } from '$lib/errors/app-errors.js';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
-  import { Exporter } from 'quizzer-engine';
+  import { Exporter, SNAPSHOT_VERSION } from 'quizzer-engine';
 
   const courseId = $derived(page.params.courseId);
 
-  // ... (rest of imports and state)
+  // Load course — errors are returned as part of the result object to avoid
+  // mutating reactive state inside a $derived computation.
+  const courseResult = $derived.by(() => {
+    if (!courseId) return { data: null, error: '' };
+    try {
+      return { data: getCourse(courseId, localStorage), error: '' };
+    } catch (err) {
+      return { data: null, error: normalizeError(err).message };
+    }
+  });
+
+  const course = $derived(courseResult.data);
+  const loadError = $derived(courseResult.error);
+  const progress = $derived(course ? getCourseProgress(course) : null);
+  const apiKeyStored = $derived(hasApiKey(localStorage));
+
+  // --- Delete confirmation ---
+
+  let confirmingDelete = $state(false);
+
+  function requestDelete() {
+    confirmingDelete = true;
+  }
+
+  function cancelDelete() {
+    confirmingDelete = false;
+  }
 
   function confirmDelete() {
     if (!courseId) return;
@@ -30,7 +56,7 @@
       const exporter = new Exporter();
       // Use the snapshot directly if available, or create a minimal one from curriculum
       const snapshot = course.snapshot || {
-        version: 3,
+        version: SNAPSHOT_VERSION,
         state: 'ready',
         curriculum: course.curriculum,
         currentSectionIndex: -1,
@@ -85,8 +111,15 @@
     <ErrorAlert message={loadError} />
   {:else if course}
     <header>
-      <h1>{course.title}</h1>
-      <p class="description">{course.curriculum.description}</p>
+      <div class="header-main">
+        <div>
+          <h1>{course.title}</h1>
+          <p class="description">{course.curriculum.description}</p>
+        </div>
+        <button type="button" class="btn-secondary" onclick={exportCourse}>
+          Export Course
+        </button>
+      </div>
 
       {#if progress && progress.hasProgress}
         <div class="progress-bar-container">
@@ -143,29 +176,25 @@
       {/each}
     </ol>
 
-    <!-- Export/Delete -->
+    <!-- Delete -->
     <section class="danger-zone">
-      <div class="actions">
-        <button type="button" class="btn-secondary" onclick={exportCourse}>
-          Export Course
-        </button>
-
-        {#if confirmingDelete}
-          <div class="delete-confirm">
-            <span class="confirm-text">Are you sure?</span>
-            <button type="button" class="btn-danger" onclick={confirmDelete}>
-              Yes, delete
-            </button>
-            <button type="button" class="btn-secondary" onclick={cancelDelete}>
-              Cancel
-            </button>
-          </div>
-        {:else}
-          <button type="button" class="btn-secondary" onclick={requestDelete}>
-            Delete course
+      {#if confirmingDelete}
+        <p class="confirm-text">
+          Are you sure you want to delete this course? This cannot be undone.
+        </p>
+        <div class="actions">
+          <button type="button" class="btn-danger" onclick={confirmDelete}>
+            Yes, delete
           </button>
-        {/if}
-      </div>
+          <button type="button" class="btn-secondary" onclick={cancelDelete}>
+            Cancel
+          </button>
+        </div>
+      {:else}
+        <button type="button" class="btn-secondary" onclick={requestDelete}>
+          Delete course
+        </button>
+      {/if}
     </section>
   {:else}
     <h1>Course not found</h1>
@@ -185,6 +214,13 @@
 
   header {
     margin-bottom: 1.5rem;
+  }
+
+  .header-main {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
   }
 
   .description {
@@ -318,20 +354,6 @@
     display: flex;
     gap: 0.5rem;
     margin-top: 0.5rem;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-
-  .delete-confirm {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .confirm-text {
-    color: #c00;
-    font-weight: 600;
-    margin-right: 0.5rem;
   }
 
   .btn-secondary {

--- a/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/+page.svelte
@@ -10,41 +10,48 @@
   } from '$lib/stores/course-progress.js';
   import { normalizeError } from '$lib/errors/app-errors.js';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import { Exporter } from 'quizzer-engine';
 
   const courseId = $derived(page.params.courseId);
 
-  // Load course — errors are returned as part of the result object to avoid
-  // mutating reactive state inside a $derived computation.
-  const courseResult = $derived.by(() => {
-    if (!courseId) return { data: null, error: '' };
-    try {
-      return { data: getCourse(courseId, localStorage), error: '' };
-    } catch (err) {
-      return { data: null, error: normalizeError(err).message };
-    }
-  });
-
-  const course = $derived(courseResult.data);
-  const loadError = $derived(courseResult.error);
-  const progress = $derived(course ? getCourseProgress(course) : null);
-  const apiKeyStored = $derived(hasApiKey(localStorage));
-
-  // --- Delete confirmation ---
-
-  let confirmingDelete = $state(false);
-
-  function requestDelete() {
-    confirmingDelete = true;
-  }
-
-  function cancelDelete() {
-    confirmingDelete = false;
-  }
+  // ... (rest of imports and state)
 
   function confirmDelete() {
     if (!courseId) return;
     deleteCourse(courseId, localStorage);
     goto('/');
+  }
+
+  // --- Export logic ---
+
+  function exportCourse() {
+    if (!course) return;
+    try {
+      const exporter = new Exporter();
+      // Use the snapshot directly if available, or create a minimal one from curriculum
+      const snapshot = course.snapshot || {
+        version: 3,
+        state: 'ready',
+        curriculum: course.curriculum,
+        currentSectionIndex: -1,
+        currentItemIndex: -1,
+        sectionItems: [],
+        allGeneratedContent: {},
+        studentState: { masteryByTopic: {}, gaps: [] },
+        lastAnswerResult: null,
+      };
+
+      const bundle = exporter.exportToString(snapshot);
+      const blob = new Blob([bundle], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `course-export-${course.title.toLowerCase().replace(/\s+/g, '-')}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert(`Export failed: ${normalizeError(err).message}`);
+    }
   }
 
   // --- Section resume logic ---
@@ -136,25 +143,29 @@
       {/each}
     </ol>
 
-    <!-- Delete -->
+    <!-- Export/Delete -->
     <section class="danger-zone">
-      {#if confirmingDelete}
-        <p class="confirm-text">
-          Are you sure you want to delete this course? This cannot be undone.
-        </p>
-        <div class="actions">
-          <button type="button" class="btn-danger" onclick={confirmDelete}>
-            Yes, delete
-          </button>
-          <button type="button" class="btn-secondary" onclick={cancelDelete}>
-            Cancel
-          </button>
-        </div>
-      {:else}
-        <button type="button" class="btn-secondary" onclick={requestDelete}>
-          Delete course
+      <div class="actions">
+        <button type="button" class="btn-secondary" onclick={exportCourse}>
+          Export Course
         </button>
-      {/if}
+
+        {#if confirmingDelete}
+          <div class="delete-confirm">
+            <span class="confirm-text">Are you sure?</span>
+            <button type="button" class="btn-danger" onclick={confirmDelete}>
+              Yes, delete
+            </button>
+            <button type="button" class="btn-secondary" onclick={cancelDelete}>
+              Cancel
+            </button>
+          </div>
+        {:else}
+          <button type="button" class="btn-secondary" onclick={requestDelete}>
+            Delete course
+          </button>
+        {/if}
+      </div>
     </section>
   {:else}
     <h1>Course not found</h1>
@@ -307,6 +318,20 @@
     display: flex;
     gap: 0.5rem;
     margin-top: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .delete-confirm {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .confirm-text {
+    color: #c00;
+    font-weight: 600;
+    margin-right: 0.5rem;
   }
 
   .btn-secondary {

--- a/apps/coursequizzer/src/routes/import/+page.svelte
+++ b/apps/coursequizzer/src/routes/import/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { Importer } from 'quizzer-engine';
+  import { importCourse } from '$lib/storage/course-storage.js';
+  import { normalizeError } from '$lib/errors/app-errors.js';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+
+  let error = $state('');
+  let importing = $state(false);
+
+  async function handleFileSelect(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+
+    const file = input.files[0];
+    error = '';
+    importing = true;
+
+    try {
+      const text = await file.text();
+      const importer = new Importer();
+      const snapshot = importer.import(text);
+
+      if (!snapshot.curriculum) {
+         throw new Error('Imported course has no curriculum');
+      }
+
+      const courseId = importCourse(
+        {
+          title: snapshot.curriculum.title,
+          curriculum: snapshot.curriculum,
+          snapshot,
+        },
+        localStorage
+      );
+
+      goto(`/course/${courseId}`);
+    } catch (err) {
+      error = normalizeError(err).message;
+    } finally {
+      importing = false;
+      input.value = ''; // Reset file input
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Import Course — CourseQuizzer</title>
+</svelte:head>
+
+<main>
+  <h1>Import Course</h1>
+  <p>Upload a course export JSON file to continue your progress.</p>
+
+  {#if error}
+    <ErrorAlert message={error} />
+  {/if}
+
+  <section class="import-area">
+    <label for="file-upload" class="file-label">
+      {#if importing}
+        Importing...
+      {:else}
+        Select course-export.json file
+      {/if}
+      <input
+        id="file-upload"
+        type="file"
+        accept=".json,application/json"
+        onchange={handleFileSelect}
+        disabled={importing}
+      />
+    </label>
+    <p class="help-text">
+      This will add the course to your browser storage. API keys from the original machine are never imported.
+    </p>
+  </section>
+
+  <p><a href="/">← Back to home</a></p>
+</main>
+
+<style>
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1rem;
+  }
+
+  .import-area {
+    margin: 2rem 0;
+    padding: 2rem;
+    border: 2px dashed #ccc;
+    border-radius: 8px;
+    text-align: center;
+  }
+
+  .file-label {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    background: #333;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .file-label:hover {
+    background: #555;
+  }
+
+  .file-label input {
+    display: none;
+  }
+
+  .help-text {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: #666;
+  }
+</style>

--- a/apps/coursequizzer/tests/unit/course-storage.test.ts
+++ b/apps/coursequizzer/tests/unit/course-storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   createCourse,
   getCourse,
+  importCourse,
   listCourses,
   updateCourse,
   deleteCourse,
@@ -65,6 +66,7 @@ function mockSnapshot(): EngineSnapshot {
     currentSectionIndex: 0,
     currentItemIndex: 0,
     sectionItems: [],
+    allGeneratedContent: {},
     studentState: { masteryByTopic: {}, gaps: [] },
     lastAnswerResult: null,
   };
@@ -276,6 +278,25 @@ describe('course-storage', () => {
     storage.setItem(COURSES_STORAGE_KEY, JSON.stringify([recordWithOldSnapshot]));
 
     expect(getCourse('old-snapshot', storage)?.snapshot).toBeNull();
+  });
+
+  it('rejects imported version 3 snapshots with malformed allGeneratedContent', () => {
+    const version3Snapshot = {
+      ...mockSnapshot(),
+      version: 3,
+      allGeneratedContent: { bad: 1 },
+    } as EngineSnapshot;
+
+    expect(() =>
+      importCourse(
+        {
+          title: 'Imported course',
+          curriculum: mockCurriculumPlan(),
+          snapshot: version3Snapshot,
+        },
+        storage
+      )
+    ).toThrow('Invalid course snapshot in import data');
   });
 
   // --- Security: no API key in persisted data ---

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -23,9 +23,11 @@ import type {
 import type { StudentAnswer, Question } from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
-export const SNAPSHOT_VERSION = 3;
+export const SNAPSHOT_VERSION = 4;
 
 function copySection(section: Section): Section {
+  // ... (omitting for brevity in this thought but I'll provide full in the call)
+
   return {
     ...section,
     topics: section.topics.map((topic) => ({ ...topic })),
@@ -97,6 +99,7 @@ export class CourseEngine extends EventEmitter {
   #currentSectionIndex = -1;
   #currentItemIndex = -1;
   #sectionItems: ContentItem[] = [];
+  #allGeneratedContent: Record<string, ContentItem[]> = {};
   #studentModel: StudentModel = new StudentModel();
   #lastAnswerResult: AnswerResult | null = null;
   #contentManager: ContentManager;
@@ -246,10 +249,11 @@ export class CourseEngine extends EventEmitter {
   setSectionContent(items: ContentItem[]): void {
     this.#requireState('setSectionContent', 'loading');
 
+    const section = this.currentSection!;
     this.#sectionItems = items.map(copyContentItem);
+    this.#allGeneratedContent[section.id] = items.map(copyContentItem);
     this.#currentItemIndex = 0;
 
-    const section = this.currentSection!;
     this.emit('contentReady', {
       items: this.#sectionItems.map(copyContentItem),
       section,
@@ -474,6 +478,11 @@ export class CourseEngine extends EventEmitter {
   // --- Persistence ---
 
   serialize(): EngineSnapshot {
+    const allGeneratedContent: Record<string, ContentItem[]> = {};
+    for (const [id, items] of Object.entries(this.#allGeneratedContent)) {
+      allGeneratedContent[id] = items.map(copyContentItem);
+    }
+
     return {
       version: SNAPSHOT_VERSION,
       state: this.#state,
@@ -481,6 +490,7 @@ export class CourseEngine extends EventEmitter {
       currentSectionIndex: this.#currentSectionIndex,
       currentItemIndex: this.#currentItemIndex,
       sectionItems: this.#sectionItems.map(copyContentItem),
+      allGeneratedContent,
       studentState: this.#studentModel.getState(),
       lastAnswerResult: this.#lastAnswerResult
         ? copyAnswerResult(this.#lastAnswerResult)
@@ -490,9 +500,18 @@ export class CourseEngine extends EventEmitter {
 
   static restore(snapshot: EngineSnapshot, config: CourseEngineConfig): CourseEngine {
     if (snapshot.version !== SNAPSHOT_VERSION) {
-      throw new Error(
-        `Unsupported snapshot version: ${snapshot.version} (expected ${SNAPSHOT_VERSION})`
-      );
+      // Migrate version 3 to version 4
+      if (snapshot.version === 3) {
+        snapshot = {
+          ...snapshot,
+          version: 4,
+          allGeneratedContent: snapshot.allGeneratedContent || {},
+        };
+      } else {
+        throw new Error(
+          `Unsupported snapshot version: ${snapshot.version} (expected ${SNAPSHOT_VERSION})`
+        );
+      }
     }
 
     // Constructor does not emit events for idle state.
@@ -513,6 +532,15 @@ export class CourseEngine extends EventEmitter {
     engine.#currentSectionIndex = snapshot.currentSectionIndex;
     engine.#currentItemIndex = snapshot.currentItemIndex;
     engine.#sectionItems = snapshot.sectionItems.map(copyContentItem);
+
+    const allGeneratedContent: Record<string, ContentItem[]> = {};
+    if (snapshot.allGeneratedContent) {
+      for (const [id, items] of Object.entries(snapshot.allGeneratedContent)) {
+        allGeneratedContent[id] = items.map(copyContentItem);
+      }
+    }
+    engine.#allGeneratedContent = allGeneratedContent;
+
     engine.#studentModel = new StudentModel(snapshot.studentState);
     engine.#lastAnswerResult = snapshot.lastAnswerResult
       ? copyAnswerResult(snapshot.lastAnswerResult)

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -92,6 +92,26 @@ function copyAnswerResult(result: AnswerResult): AnswerResult {
   };
 }
 
+function isValidGeneratedContentRecord(
+  value: unknown
+): value is Record<string, ContentItem[]> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(
+    (items) =>
+      Array.isArray(items) &&
+      items.every((item) => {
+        try {
+          return copyContentItem(item as ContentItem) !== undefined;
+        } catch {
+          return false;
+        }
+      })
+  );
+}
+
 export class CourseEngine extends EventEmitter {
   #state: EngineState = 'idle';
   #config: CourseEngineConfig;
@@ -504,8 +524,10 @@ export class CourseEngine extends EventEmitter {
       if (snapshot.version === 3) {
         snapshot = {
           ...snapshot,
-          version: 4,
-          allGeneratedContent: snapshot.allGeneratedContent || {},
+          version: SNAPSHOT_VERSION,
+          allGeneratedContent: isValidGeneratedContentRecord(snapshot.allGeneratedContent)
+            ? snapshot.allGeneratedContent
+            : {},
         };
       } else {
         throw new Error(

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -36,6 +36,7 @@ export type EngineSnapshot = {
   currentSectionIndex: number;
   currentItemIndex: number;
   sectionItems: ContentItem[];
+  allGeneratedContent: Record<string, ContentItem[]>;
   studentState: StudentState;
   lastAnswerResult: AnswerResult | null;
 };

--- a/packages/engine/src/export/Exporter.ts
+++ b/packages/engine/src/export/Exporter.ts
@@ -1,0 +1,33 @@
+import type { EngineSnapshot } from '../engine/types.js';
+
+export interface ExportBundle {
+  type: 'coursequizzer-export';
+  version: number;
+  timestamp: string;
+  data: EngineSnapshot;
+}
+
+/**
+ * Handles exporting course data into a portable JSON bundle.
+ */
+export class Exporter {
+  /**
+   * Creates an export bundle from an engine snapshot.
+   * Ensure no sensitive data (like API keys) is in the snapshot before calling.
+   */
+  export(snapshot: EngineSnapshot): ExportBundle {
+    return {
+      type: 'coursequizzer-export',
+      version: 1,
+      timestamp: new Date().toISOString(),
+      data: { ...snapshot },
+    };
+  }
+
+  /**
+   * Convenience method to export as a JSON string.
+   */
+  exportToString(snapshot: EngineSnapshot): string {
+    return JSON.stringify(this.export(snapshot), null, 2);
+  }
+}

--- a/packages/engine/src/export/Exporter.ts
+++ b/packages/engine/src/export/Exporter.ts
@@ -20,7 +20,8 @@ export class Exporter {
       type: 'coursequizzer-export',
       version: 1,
       timestamp: new Date().toISOString(),
-      data: { ...snapshot },
+      // Deep copy to ensure isolation of the exported bundle
+      data: JSON.parse(JSON.stringify(snapshot)),
     };
   }
 

--- a/packages/engine/src/export/Importer.ts
+++ b/packages/engine/src/export/Importer.ts
@@ -1,0 +1,64 @@
+import type { ExportBundle } from './Exporter.js';
+import type { EngineSnapshot } from '../engine/types.js';
+
+/**
+ * Handles importing course data from a portable JSON bundle.
+ * Validates the bundle structure and version compatibility.
+ */
+export class Importer {
+  /**
+   * Validates that the provided object is a valid ExportBundle.
+   * Throws an error if validation fails.
+   */
+  validate(bundle: unknown): ExportBundle {
+    if (typeof bundle !== 'object' || bundle === null) {
+      throw new Error('Import data must be a JSON object');
+    }
+
+    const b = bundle as Partial<ExportBundle>;
+
+    if (b.type !== 'coursequizzer-export') {
+      throw new Error('Invalid export bundle type');
+    }
+
+    if (typeof b.version !== 'number' || b.version < 1) {
+      throw new Error('Unsupported or missing export bundle version');
+    }
+
+    if (!b.data || typeof b.data !== 'object') {
+      throw new Error('Missing or malformed data in export bundle');
+    }
+
+    // Basic structural validation of EngineSnapshot
+    const snapshot = b.data as Partial<EngineSnapshot>;
+    if (
+      typeof snapshot.version !== 'number' ||
+      !snapshot.state ||
+      !snapshot.studentState
+    ) {
+      throw new Error('Invalid engine snapshot in export bundle');
+    }
+
+    // Ensure it's not a course in planning/analysis (v1 restriction)
+    if (!snapshot.curriculum) {
+      throw new Error('Cannot import an incomplete course (no curriculum found)');
+    }
+
+    return b as ExportBundle;
+  }
+
+  /**
+   * Parses and validates a JSON string as an ExportBundle,
+   * returning the contained EngineSnapshot.
+   */
+  import(bundleString: string): EngineSnapshot {
+    try {
+      const parsed = JSON.parse(bundleString);
+      const validated = this.validate(parsed);
+      return validated.data;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Import failed: ${message}`);
+    }
+  }
+}

--- a/packages/engine/src/export/Importer.ts
+++ b/packages/engine/src/export/Importer.ts
@@ -1,6 +1,7 @@
 import type { ExportBundle } from './Exporter.js';
 import type { EngineSnapshot } from '../engine/types.js';
 import { validateCurriculumPlan } from '../curriculum/SyllabusParser.js';
+import { validateEngineSnapshot } from './snapshot-validation.js';
 
 /**
  * Handles importing course data from a portable JSON bundle.
@@ -30,21 +31,9 @@ export class Importer {
       throw new Error('Missing or malformed data in export bundle');
     }
 
-    // Basic structural validation of EngineSnapshot
-    const snapshot = b.data as Partial<EngineSnapshot>;
-    if (typeof snapshot.version !== 'number' || !snapshot.state) {
+    const snapshot = validateEngineSnapshot(b.data);
+    if (!snapshot) {
       throw new Error('Invalid engine snapshot in export bundle');
-    }
-
-    // Deeper validation of studentState
-    if (
-      !snapshot.studentState ||
-      typeof snapshot.studentState !== 'object' ||
-      typeof snapshot.studentState.masteryByTopic !== 'object' ||
-      snapshot.studentState.masteryByTopic === null ||
-      !Array.isArray(snapshot.studentState.gaps)
-    ) {
-      throw new Error('Invalid student state in export bundle');
     }
 
     // Deeper validation of curriculum
@@ -59,7 +48,10 @@ export class Importer {
       throw new Error(`Invalid curriculum in export bundle: ${message}`);
     }
 
-    return b as ExportBundle;
+    return {
+      ...b,
+      data: snapshot,
+    } as ExportBundle;
   }
 
   /**

--- a/packages/engine/src/export/Importer.ts
+++ b/packages/engine/src/export/Importer.ts
@@ -1,5 +1,6 @@
 import type { ExportBundle } from './Exporter.js';
 import type { EngineSnapshot } from '../engine/types.js';
+import { validateCurriculumPlan } from '../curriculum/SyllabusParser.js';
 
 /**
  * Handles importing course data from a portable JSON bundle.
@@ -31,17 +32,31 @@ export class Importer {
 
     // Basic structural validation of EngineSnapshot
     const snapshot = b.data as Partial<EngineSnapshot>;
-    if (
-      typeof snapshot.version !== 'number' ||
-      !snapshot.state ||
-      !snapshot.studentState
-    ) {
+    if (typeof snapshot.version !== 'number' || !snapshot.state) {
       throw new Error('Invalid engine snapshot in export bundle');
     }
 
-    // Ensure it's not a course in planning/analysis (v1 restriction)
+    // Deeper validation of studentState
+    if (
+      !snapshot.studentState ||
+      typeof snapshot.studentState !== 'object' ||
+      typeof snapshot.studentState.masteryByTopic !== 'object' ||
+      snapshot.studentState.masteryByTopic === null ||
+      !Array.isArray(snapshot.studentState.gaps)
+    ) {
+      throw new Error('Invalid student state in export bundle');
+    }
+
+    // Deeper validation of curriculum
     if (!snapshot.curriculum) {
       throw new Error('Cannot import an incomplete course (no curriculum found)');
+    }
+
+    try {
+      validateCurriculumPlan(snapshot.curriculum);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid curriculum in export bundle: ${message}`);
     }
 
     return b as ExportBundle;

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -1,0 +1,201 @@
+import { validateCurriculumPlan } from '../curriculum/SyllabusParser.js';
+import { SNAPSHOT_VERSION } from '../engine/CourseEngine.js';
+import type { CurriculumPlan, EngineSnapshot } from '../engine/types.js';
+
+function deepCopy<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sanitizeSnapshot(snapshot: EngineSnapshot): EngineSnapshot {
+  const copy = { ...snapshot };
+  delete (copy as Record<string, unknown>)['apiKey'];
+  return copy;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isValidEngineState(value: unknown): boolean {
+  return (
+    value === 'idle' ||
+    value === 'planning' ||
+    value === 'ready' ||
+    value === 'loading' ||
+    value === 'practicing' ||
+    value === 'answered' ||
+    value === 'sectionComplete' ||
+    value === 'complete'
+  );
+}
+
+function isValidStudentState(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (!isPlainObject(value.masteryByTopic) || !isStringArray(value.gaps)) return false;
+
+  return Object.entries(value.masteryByTopic).every(([topicId, mastery]) => {
+    if (!isPlainObject(mastery)) return false;
+    return (
+      mastery.topicId === topicId &&
+      typeof mastery.score === 'number' &&
+      typeof mastery.questionsAnswered === 'number' &&
+      typeof mastery.questionsCorrect === 'number'
+    );
+  });
+}
+
+function isValidStudentAnswer(value: unknown): boolean {
+  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
+
+  switch (value.type) {
+    case 'multiple-choice':
+      return typeof value.selectedIndex === 'number';
+    case 'numeric-input':
+      return typeof value.value === 'number';
+    case 'ordering':
+      return (
+        Array.isArray(value.order) &&
+        value.order.every((entry) => typeof entry === 'number')
+      );
+    case 'multi-select':
+      return (
+        Array.isArray(value.selectedIndices) &&
+        value.selectedIndices.every((entry) => typeof entry === 'number')
+      );
+    case 'two-stage':
+      return (
+        typeof value.selectedIndex === 'number' &&
+        typeof value.followUpSelectedIndex === 'number'
+      );
+    default:
+      return false;
+  }
+}
+
+function isValidAnswerResult(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.correct === 'boolean' &&
+    typeof value.questionId === 'string' &&
+    typeof value.topicId === 'string' &&
+    typeof value.correctAnswer === 'string' &&
+    (value.explanation === undefined || typeof value.explanation === 'string') &&
+    isValidStudentAnswer(value.userAnswer)
+  );
+}
+
+function isValidContentItem(value: unknown): boolean {
+  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
+
+  switch (value.type) {
+    case 'explanation':
+      return (
+        typeof value.topicId === 'string' &&
+        typeof value.title === 'string' &&
+        typeof value.content === 'string'
+      );
+    case 'multiple-choice':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        typeof value.correctIndex === 'number'
+      );
+    case 'numeric-input':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        typeof value.correctValue === 'number' &&
+        (value.tolerance === undefined || typeof value.tolerance === 'number') &&
+        (value.unit === undefined || typeof value.unit === 'string')
+      );
+    case 'ordering':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.items) &&
+        Array.isArray(value.correctOrder) &&
+        value.correctOrder.every((entry) => typeof entry === 'number')
+      );
+    case 'multi-select':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        Array.isArray(value.correctIndices) &&
+        value.correctIndices.every((entry) => typeof entry === 'number')
+      );
+    case 'two-stage':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options) &&
+        typeof value.correctIndex === 'number' &&
+        typeof value.followUp === 'string' &&
+        isStringArray(value.followUpOptions) &&
+        typeof value.followUpCorrectIndex === 'number'
+      );
+    default:
+      return false;
+  }
+}
+
+function isValidCurriculum(value: unknown): value is CurriculumPlan {
+  try {
+    validateCurriculumPlan(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidGeneratedContentRecord(value: unknown): boolean {
+  return (
+    isPlainObject(value) &&
+    Object.values(value).every(
+      (items) => Array.isArray(items) && items.every(isValidContentItem)
+    )
+  );
+}
+
+export function validateEngineSnapshot(value: unknown): EngineSnapshot | null {
+  if (!isPlainObject(value)) return null;
+
+  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
+  const supportedVersions = [3, SNAPSHOT_VERSION];
+  const hasGeneratedContent = 'allGeneratedContent' in snapshot;
+
+  if (
+    !supportedVersions.includes(snapshot.version) ||
+    !isValidEngineState(snapshot.state) ||
+    !Number.isInteger(snapshot.currentSectionIndex) ||
+    !Number.isInteger(snapshot.currentItemIndex) ||
+    !Array.isArray(snapshot.sectionItems) ||
+    !snapshot.sectionItems.every(isValidContentItem) ||
+    (snapshot.version === SNAPSHOT_VERSION &&
+      (!hasGeneratedContent ||
+        !isValidGeneratedContentRecord(snapshot.allGeneratedContent))) ||
+    (snapshot.version === 3 &&
+      hasGeneratedContent &&
+      snapshot.allGeneratedContent !== undefined &&
+      !isValidGeneratedContentRecord(snapshot.allGeneratedContent)) ||
+    !isValidStudentState(snapshot.studentState) ||
+    (snapshot.curriculum !== null && !isValidCurriculum(snapshot.curriculum)) ||
+    !('lastAnswerResult' in snapshot) ||
+    (snapshot.lastAnswerResult !== null &&
+      !isValidAnswerResult(snapshot.lastAnswerResult))
+  ) {
+    return null;
+  }
+
+  return deepCopy(snapshot);
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -10,6 +10,9 @@ export { CurriculumManager } from './curriculum/CurriculumManager.js';
 export { ContentGenerator } from './content/ContentGenerator.js';
 export { ContentManager } from './content/ContentManager.js';
 export { checkQuestionQuality } from './content/quality-filters.js';
+export { Exporter } from './export/Exporter.js';
+export { Importer } from './export/Importer.js';
+export type { ExportBundle } from './export/Exporter.js';
 
 export type {
   CourseEngineConfig,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -12,6 +12,7 @@ export { ContentManager } from './content/ContentManager.js';
 export { checkQuestionQuality } from './content/quality-filters.js';
 export { Exporter } from './export/Exporter.js';
 export { Importer } from './export/Importer.js';
+export { validateEngineSnapshot } from './export/snapshot-validation.js';
 export type { ExportBundle } from './export/Exporter.js';
 
 export type {

--- a/packages/engine/tests/export.test.ts
+++ b/packages/engine/tests/export.test.ts
@@ -31,6 +31,14 @@ function mockSectionContent(): ContentItem[] {
 }
 
 describe('Exporter & Importer', () => {
+  function createValidSnapshot(): ReturnType<CourseEngine['serialize']> {
+    const engine = new CourseEngine({ apiKey: 'sk-test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    engine.setSectionContent(mockSectionContent());
+    return engine.serialize();
+  }
+
   it('round-trips full course data with generated content', () => {
     const engine = new CourseEngine({ apiKey: 'sk-test-key' });
     engine.loadCurriculum(mockCurriculum());
@@ -96,5 +104,55 @@ describe('Exporter & Importer', () => {
     expect(() =>
       importer.import('{"type": "coursequizzer-export", "version": 1, "data": {}}')
     ).toThrow('Invalid engine snapshot');
+  });
+
+  it('rejects bundles with malformed snapshot indices and content collections', () => {
+    const importer = new Importer();
+    const validSnapshot = createValidSnapshot();
+
+    const invalidBundles = [
+      {
+        ...validSnapshot,
+        currentSectionIndex: 1.5,
+      },
+      {
+        ...validSnapshot,
+        currentItemIndex: -0.25,
+      },
+      {
+        ...validSnapshot,
+        sectionItems: { bad: true },
+      },
+      {
+        ...validSnapshot,
+        allGeneratedContent: { 'section-1': 1 },
+      },
+    ];
+
+    for (const snapshot of invalidBundles) {
+      const bundle = JSON.stringify({
+        type: 'coursequizzer-export',
+        version: 1,
+        data: snapshot,
+      });
+
+      expect(() => importer.import(bundle)).toThrow('Invalid engine snapshot');
+    }
+  });
+
+  it('rejects version 3 bundles when malformed allGeneratedContent is present', () => {
+    const importer = new Importer();
+    const validSnapshot = createValidSnapshot();
+    const bundle = JSON.stringify({
+      type: 'coursequizzer-export',
+      version: 1,
+      data: {
+        ...validSnapshot,
+        version: 3,
+        allGeneratedContent: { bad: 1 },
+      },
+    });
+
+    expect(() => importer.import(bundle)).toThrow('Invalid engine snapshot');
   });
 });

--- a/packages/engine/tests/export.test.ts
+++ b/packages/engine/tests/export.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { CourseEngine } from '../src/engine/CourseEngine.js';
+import { Exporter } from '../src/export/Exporter.js';
+import { Importer } from '../src/export/Importer.js';
+import type { CurriculumPlan, ContentItem } from '../src/engine/types.js';
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Intro to Testing',
+    description: 'A course about testing',
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Unit Testing',
+        order: 0,
+        topics: [{ id: 'topic-1', title: 'Assertions', description: 'How to assert' }],
+      },
+    ],
+  };
+}
+
+function mockSectionContent(): ContentItem[] {
+  return [
+    {
+      type: 'explanation',
+      topicId: 'topic-1',
+      title: 'Understanding Assertions',
+      content: 'Assertions verify expected behavior.',
+    },
+  ];
+}
+
+describe('Exporter & Importer', () => {
+  it('round-trips full course data with generated content', () => {
+    const engine = new CourseEngine({ apiKey: 'sk-test-key' });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    const items = mockSectionContent();
+    engine.setSectionContent(items);
+
+    const exporter = new Exporter();
+    const importer = new Importer();
+
+    const snapshot = engine.serialize();
+    const bundle = exporter.exportToString(snapshot);
+
+    // Verify bundle structure
+    expect(bundle).toContain('"type": "coursequizzer-export"');
+    expect(bundle).toContain('"Intro to Testing"');
+    expect(bundle).toContain('"Understanding Assertions"');
+
+    // Security check: ensure API key is NOT in bundle
+    expect(bundle).not.toContain('sk-test-key');
+
+    // Restore into new engine
+    const restoredSnapshot = importer.import(bundle);
+    const restoredEngine = CourseEngine.restore(restoredSnapshot, {
+      apiKey: 'sk-new-key',
+    });
+
+    expect(restoredEngine.state).toBe('practicing');
+    expect(restoredEngine.curriculum?.title).toBe('Intro to Testing');
+    expect(restoredEngine.currentItem?.title).toBe('Understanding Assertions');
+  });
+
+  it('maintains allGeneratedContent across sections', () => {
+    const engine = new CourseEngine({ apiKey: 'sk-test-key' });
+    engine.loadCurriculum(mockCurriculum());
+
+    // Section 1
+    engine.startSection('section-1');
+    engine.setSectionContent([
+      { type: 'explanation', topicId: 'topic-1', title: 'S1', content: 'C1' },
+    ]);
+
+    // Move to answered state by skipping (if we had a question)
+    // Actually, just finish the section
+    engine.nextItem(); // should transition to sectionComplete because only one item
+    expect(engine.state).toBe('sectionComplete');
+
+    const exporter = new Exporter();
+    const snapshot = engine.serialize();
+    const bundle = exporter.exportToString(snapshot);
+
+    expect(bundle).toContain('"S1"');
+    expect(bundle).toContain('"C1"');
+  });
+
+  it('rejects malformed or invalid bundles', () => {
+    const importer = new Importer();
+
+    expect(() => importer.import('{}')).toThrow('Invalid export bundle type');
+    expect(() => importer.import('{"type": "wrong"}')).toThrow(
+      'Invalid export bundle type'
+    );
+    expect(() =>
+      importer.import('{"type": "coursequizzer-export", "version": 1, "data": {}}')
+    ).toThrow('Invalid engine snapshot');
+  });
+});


### PR DESCRIPTION
Closes #53

Implemented portable course bundles for exporting and importing course progress across machines.

Key changes:
- **Engine**:  now tracks all generated items across all sections in .
- **Engine**:  bumped to 4 with automatic migration from v3 in .
- **Engine**: New  and  classes for creating and validating JSON bundles.
- **App**: Updated  to validate the new snapshot structure and migrate legacy snapshots on the fly.
- **App**: Added an "Export Course" button to the course overview page.
- **App**: Added a new "Import Course" page with file upload support.

Security:
- API keys are explicitly excluded from all exports (verified with a security test in ).
- Imported bundles are validated before being saved to local storage.