### PR TITLE
[Engine/App] Support additional question types for practical skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.8.4 — 2026-04-14
+
+### Features
+
+- **Engine/App:** Support additional question types for practical skills: `checklist`, `code`, and `self-evaluation`
+- **Engine:** Updated `quiz-generation` prompt (v1.2) to support generating these new types for procedural and technical topics
+- **Engine:** Added parsing and grading logic for the new types, including regex-based validation for code snippets
+- **App:** Updated learn flow UI to render interactive checklists, code editors (textarea), and self-evaluation options
+- **App:** Added state management and answer handlers for the new question types in the Svelte 5 learn page
+
+### Fixes
+
+- **Engine:** Updated quality filters to support the new question types, enabling duplicate option checks for checklists and self-evaluations
+- **Engine:** Updated version expectation in content generator tests to match the new prompt version
+- 5 new engine tests covering the grading and serialization of the new question types
+
 ## 0.8.3 — 2026-04-14
 
 ### Features

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -80,6 +80,21 @@
     });
   }
 
+  function handleChecklist(indices: number[]) {
+    if (!session) return;
+    session.submitAnswer({ type: 'checklist', checkedIndices: indices });
+  }
+
+  function handleCode(code: string) {
+    if (!session) return;
+    session.submitAnswer({ type: 'code', code });
+  }
+
+  function handleSelfEvaluation(selectedIndex: number) {
+    if (!session) return;
+    session.submitAnswer({ type: 'self-evaluation', selectedIndex });
+  }
+
   function handleNext() {
     session?.nextItem();
   }
@@ -165,6 +180,38 @@
     }
     multiSelectChoices = copy;
   }
+
+  // --- Checklist local state ---
+
+  let checklistChoices = $state<Set<number>>(new Set());
+
+  $effect(() => {
+    const item = session?.currentItem?.item;
+    if (item && item.type === 'checklist') {
+      checklistChoices = new Set();
+    }
+  });
+
+  function toggleCheck(index: number) {
+    const copy = new Set(checklistChoices);
+    if (copy.has(index)) {
+      copy.delete(index);
+    } else {
+      copy.add(index);
+    }
+    checklistChoices = copy;
+  }
+
+  // --- Code local state ---
+
+  let codeValue = $state('');
+
+  $effect(() => {
+    const item = session?.currentItem?.item;
+    if (item && item.type === 'code') {
+      codeValue = item.initialCode ?? '';
+    }
+  });
 
   // --- Numeric input local state ---
 
@@ -428,6 +475,85 @@
             </button>
           </div>
         </article>
+
+      {:else if session.currentItem.item.type === 'checklist'}
+        <!-- Checklist -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <p class="hint">Check off each step as you complete it.</p>
+          <div class="options">
+            {#each session.currentItem.item.items as item, i}
+              <button
+                type="button"
+                class="option-button"
+                class:selected={checklistChoices.has(i)}
+                onclick={() => toggleCheck(i)}
+              >
+                <span class="checkbox">{checklistChoices.has(i) ? '☑' : '☐'}</span>
+                {item}
+              </button>
+            {/each}
+          </div>
+          <div class="actions">
+            <button
+              type="button"
+              onclick={() => handleChecklist([...checklistChoices])}
+              disabled={checklistChoices.size === 0}
+            >
+              Confirm Completion
+            </button>
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'code'}
+        <!-- Code -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <p class="hint">Language: {session.currentItem.item.language}</p>
+          <textarea
+            bind:value={codeValue}
+            placeholder="Write your code here..."
+            class="code-editor"
+            spellcheck="false"
+          ></textarea>
+          <div class="actions">
+            <button type="button" onclick={() => handleCode(codeValue)}>
+              Submit Code
+            </button>
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
+
+      {:else if session.currentItem.item.type === 'self-evaluation'}
+        <!-- Self-evaluation -->
+        <article class="question">
+          <h2>{session.currentItem.item.question}</h2>
+          <p class="hint">Rate your mastery of this task.</p>
+          <div class="options">
+            {#each session.currentItem.item.options as option, i}
+              <button
+                type="button"
+                class="option-button"
+                onclick={() => handleSelfEvaluation(i)}
+              >
+                {option}
+              </button>
+            {/each}
+          </div>
+          <div class="actions">
+            <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
+            <button type="button" class="text-button" onclick={handleReportIssue}>
+              {reportedItem ? 'Reported' : 'Report issue'}
+            </button>
+          </div>
+        </article>
       {/if}
 
     {:else if session.engineState === 'answered' && session.lastResult}
@@ -582,6 +708,31 @@
     background: #e8f0fe;
     border-color: #1a73e8;
     color: #1a73e8;
+  }
+
+  .checkbox {
+    margin-right: 0.5rem;
+    font-family: monospace;
+    font-size: 1.2rem;
+  }
+
+  .code-editor {
+    width: 100%;
+    min-height: 12rem;
+    padding: 0.75rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.95rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fafafa;
+    resize: vertical;
+    margin-bottom: 1rem;
+  }
+
+  .code-editor:focus {
+    outline: none;
+    border-color: #999;
+    background: #fff;
   }
 
   .numeric-input {

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -231,6 +231,12 @@ export class ContentGenerator {
         return this.#parseMultiSelect(obj, id, topicId, questionText);
       case 'two-stage':
         return this.#parseTwoStage(obj, id, topicId, questionText);
+      case 'checklist':
+        return this.#parseChecklist(obj, id, topicId, questionText);
+      case 'code':
+        return this.#parseCode(obj, id, topicId, questionText);
+      case 'self-evaluation':
+        return this.#parseSelfEvaluation(obj, id, topicId, questionText);
       default:
         throw new Error(`Unknown question type: ${type}`);
     }
@@ -371,6 +377,63 @@ export class ContentGenerator {
       followUp,
       followUpOptions,
       followUpCorrectIndex,
+    };
+  }
+
+  #parseChecklist(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const items = this.#requireStringArray(obj.items, 'items', 1);
+
+    return {
+      type: 'checklist',
+      id,
+      topicId,
+      question,
+      items,
+    };
+  }
+
+  #parseCode(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const language = this.#requireString(obj.language, 'language');
+    const initialCode =
+      typeof obj.initialCode === 'string' ? obj.initialCode : undefined;
+    const expectedPattern =
+      typeof obj.expectedPattern === 'string' ? obj.expectedPattern : undefined;
+
+    return {
+      type: 'code',
+      id,
+      topicId,
+      question,
+      language,
+      initialCode,
+      expectedPattern,
+    };
+  }
+
+  #parseSelfEvaluation(
+    obj: Record<string, unknown>,
+    id: string,
+    topicId: string,
+    question: string
+  ): Question {
+    const options = this.#requireStringArray(obj.options, 'options', 2);
+
+    return {
+      type: 'self-evaluation',
+      id,
+      topicId,
+      question,
+      options,
     };
   }
 

--- a/packages/engine/src/content/quality-filters.ts
+++ b/packages/engine/src/content/quality-filters.ts
@@ -125,7 +125,10 @@ function getOptions(question: Question): string[] | undefined {
     case 'multiple-choice':
     case 'multi-select':
     case 'two-stage':
+    case 'self-evaluation':
       return question.options;
+    case 'checklist':
+      return question.items;
     default:
       return undefined;
   }

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -63,12 +63,41 @@ export type TwoStageQuestion = {
   followUpCorrectIndex: number;
 };
 
+export type ChecklistQuestion = {
+  type: 'checklist';
+  id: string;
+  topicId: string;
+  question: string;
+  items: string[];
+};
+
+export type CodeQuestion = {
+  type: 'code';
+  id: string;
+  topicId: string;
+  question: string;
+  language: string;
+  initialCode?: string;
+  expectedPattern?: string; // Optional regex to check for correctness
+};
+
+export type SelfEvaluationQuestion = {
+  type: 'self-evaluation';
+  id: string;
+  topicId: string;
+  question: string;
+  options: string[]; // Options for self-evaluation, e.g., ["Need more practice", "Got it"]
+};
+
 export type Question =
   | MultipleChoiceQuestion
   | NumericInputQuestion
   | OrderingQuestion
   | MultiSelectQuestion
-  | TwoStageQuestion;
+  | TwoStageQuestion
+  | ChecklistQuestion
+  | CodeQuestion
+  | SelfEvaluationQuestion;
 
 export type QuestionType = Question['type'];
 
@@ -89,7 +118,10 @@ export type StudentAnswer =
       type: 'two-stage';
       selectedIndex: number;
       followUpSelectedIndex: number;
-    };
+    }
+  | { type: 'checklist'; checkedIndices: number[] }
+  | { type: 'code'; code: string }
+  | { type: 'self-evaluation'; selectedIndex: number };
 
 export type AnswerResult = {
   correct: boolean;

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -69,6 +69,18 @@ function copyContentItem(item: ContentItem): ContentItem {
         options: [...item.options],
         followUpOptions: [...item.followUpOptions],
       };
+    case 'checklist':
+      return {
+        ...item,
+        items: [...item.items],
+      };
+    case 'code':
+      return { ...item };
+    case 'self-evaluation':
+      return {
+        ...item,
+        options: [...item.options],
+      };
   }
 }
 
@@ -83,6 +95,12 @@ function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {
     case 'multi-select':
       return { ...answer, selectedIndices: [...answer.selectedIndices] };
     case 'two-stage':
+      return { ...answer };
+    case 'checklist':
+      return { ...answer, checkedIndices: [...answer.checkedIndices] };
+    case 'code':
+      return { ...answer };
+    case 'self-evaluation':
       return { ...answer };
   }
 }
@@ -513,6 +531,27 @@ export class CourseEngine extends EventEmitter {
           a.followUpSelectedIndex === question.followUpCorrectIndex
         );
       }
+      case 'checklist': {
+        const a = answer as { type: 'checklist'; checkedIndices: number[] };
+        // Correct if all items are checked
+        return a.checkedIndices.length === question.items.length;
+      }
+      case 'code': {
+        const a = answer as { type: 'code'; code: string };
+        if (question.expectedPattern) {
+          try {
+            const regex = new RegExp(question.expectedPattern, 's');
+            return regex.test(a.code);
+          } catch {
+            // If regex is invalid, we fallback to true (trust the student)
+            return true;
+          }
+        }
+        return true; // Trust the student if no pattern provided
+      }
+      case 'self-evaluation': {
+        return true; // Always "correct" to report completion
+      }
     }
   }
 
@@ -530,6 +569,14 @@ export class CourseEngine extends EventEmitter {
         return question.correctIndices.map((i) => question.options[i]).join(', ');
       case 'two-stage':
         return `${question.options[question.correctIndex]}, then ${question.followUpOptions[question.followUpCorrectIndex]}`;
+      case 'checklist':
+        return 'Completion of all steps';
+      case 'code':
+        return question.expectedPattern
+          ? `Code matching pattern: ${question.expectedPattern}`
+          : 'Correct implementation of the requested logic';
+      case 'self-evaluation':
+        return 'Self-assessment submitted';
     }
   }
 

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -5,7 +5,7 @@
 
 import type { PromptMessages } from './types.js';
 
-export const QUIZ_GENERATION_VERSION = '1.1';
+export const QUIZ_GENERATION_VERSION = '1.2';
 
 // --- Tool Schema ---
 
@@ -33,6 +33,9 @@ function buildQuizTool(count: number = 3) {
                   'ordering',
                   'multi-select',
                   'two-stage',
+                  'checklist',
+                  'code',
+                  'self-evaluation',
                 ],
                 description: 'The question type',
               },
@@ -40,12 +43,12 @@ function buildQuizTool(count: number = 3) {
                 type: 'string',
                 description: 'The question text',
               },
-              // Multiple choice fields
+              // Multiple choice, multi-select, two-stage, checklist, self-evaluation
               options: {
                 type: 'array',
                 items: { type: 'string' },
                 description:
-                  'Answer options (for multiple-choice, multi-select, two-stage)',
+                  'Answer options (for multiple-choice, multi-select, two-stage, self-evaluation)',
               },
               correctIndex: {
                 type: 'number',
@@ -65,11 +68,11 @@ function buildQuizTool(count: number = 3) {
                 type: 'string',
                 description: 'Unit of measurement (for numeric-input)',
               },
-              // Ordering fields
+              // Ordering, checklist
               items: {
                 type: 'array',
                 items: { type: 'string' },
-                description: 'Items to be ordered (for ordering)',
+                description: 'Items to be ordered or checked off (for ordering, checklist)',
               },
               correctOrder: {
                 type: 'array',
@@ -97,6 +100,19 @@ function buildQuizTool(count: number = 3) {
                 type: 'number',
                 description: 'Index of the correct follow-up option (for two-stage)',
               },
+              // Code fields
+              language: {
+                type: 'string',
+                description: 'Programming language (for code)',
+              },
+              initialCode: {
+                type: 'string',
+                description: 'Starter code provided to the student (for code)',
+              },
+              expectedPattern: {
+                type: 'string',
+                description: 'Regex pattern to check student code for correctness (for code)',
+              },
             },
             required: ['type', 'question'],
           },
@@ -120,6 +136,9 @@ Question type guidelines:
 - **ordering**: 3-5 items that have a natural sequence (chronological, logical steps, ranked). Provide items in a shuffled order; correctOrder gives the right sequence as indices.
 - **multi-select**: 4-6 options, 2-3 correct. Clearly ask "select ALL that apply."
 - **two-stage**: First question + follow-up. Both are multiple-choice. The follow-up probes deeper understanding.
+- **checklist**: Used for practical tasks or procedures. List 3-5 specific steps the student should perform or verify.
+- **code**: Ask the student to write a short code snippet. Provide the programming language and optionally some initial code. Use expectedPattern to provide a regex that verifies key parts of the solution.
+- **self-evaluation**: Used for open-ended or subjective practical mastery. Provide 2-4 levels of mastery as options (e.g., "I can do this reliably", "I need more practice").
 
 Quality rules:
 - Questions must be self-contained — answerable without the source material

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -80,7 +80,7 @@ describe('explanation prompt', () => {
 
 describe('quiz generation prompt', () => {
   it('exports version constant', () => {
-    expect(QUIZ_GENERATION_VERSION).toBe('1.1');
+    expect(QUIZ_GENERATION_VERSION).toBe('1.2');
   });
 
   it('builds prompt with topic and explanation context', () => {

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { CourseEngine } from '../src/index.js';
+import type { CurriculumPlan, ContentItem } from '../src/index.js';
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Practical Skills',
+    description: 'A course about practical skills',
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Guitar Basics',
+        order: 0,
+        topics: [
+          { id: 'topic-1', title: 'Setup', description: 'Setting up your guitar' },
+        ],
+      },
+    ],
+  };
+}
+
+const mockGenerator = {
+  generateTopicExplanation: () => new Promise(() => {}),
+  generateTopicQuizBurst: () => new Promise(() => {}),
+};
+
+describe('New Question Types', () => {
+  it('grades checklist correctly', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    
+    const checklistItem: ContentItem = {
+      type: 'checklist',
+      id: 'q-checklist',
+      topicId: 'topic-1',
+      question: 'Perform the following steps:',
+      items: ['Plug in guitar', 'Turn on amp', 'Tune strings'],
+    };
+    
+    engine.setSectionContent([checklistItem]);
+    
+    // Correct: all items checked
+    const resultCorrect = engine.submitAnswer({
+      type: 'checklist',
+      checkedIndices: [0, 1, 2],
+    });
+    expect(resultCorrect.correct).toBe(true);
+    
+    // Incorrect: not all items checked
+    const engine2 = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine2.loadCurriculum(mockCurriculum());
+    engine2.startSection('section-1');
+    engine2.setSectionContent([checklistItem]);
+
+    const resultIncorrect = engine2.submitAnswer({
+      type: 'checklist',
+      checkedIndices: [0, 1],
+    });
+    expect(resultIncorrect.correct).toBe(false);
+  });
+
+  it('grades code correctly with expectedPattern', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    
+    const codeItem: ContentItem = {
+      type: 'code',
+      id: 'q-code',
+      topicId: 'topic-1',
+      question: 'Write a function that returns true.',
+      language: 'javascript',
+      expectedPattern: 'return true',
+    };
+    
+    engine.setSectionContent([codeItem]);
+    
+    // Correct: matches pattern
+    const resultCorrect = engine.submitAnswer({
+      type: 'code',
+      code: 'function test() { return true; }',
+    });
+    expect(resultCorrect.correct).toBe(true);
+    
+    // Incorrect: does not match pattern
+    const engine2 = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine2.loadCurriculum(mockCurriculum());
+    engine2.startSection('section-1');
+    engine2.setSectionContent([codeItem]);
+
+    const resultIncorrect = engine2.submitAnswer({
+      type: 'code',
+      code: 'function test() { return false; }',
+    });
+    expect(resultIncorrect.correct).toBe(false);
+  });
+
+  it('grades code correctly without expectedPattern (always true)', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    
+    const codeItem: ContentItem = {
+      type: 'code',
+      id: 'q-code-no-pattern',
+      topicId: 'topic-1',
+      question: 'Write some code.',
+      language: 'javascript',
+    };
+    
+    engine.setSectionContent([codeItem]);
+    
+    const result = engine.submitAnswer({
+      type: 'code',
+      code: 'any code',
+    });
+    expect(result.correct).toBe(true);
+  });
+
+  it('grades self-evaluation correctly (always true)', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    
+    const selfEvalItem: ContentItem = {
+      type: 'self-evaluation',
+      id: 'q-self-eval',
+      topicId: 'topic-1',
+      question: 'How do you feel about your progress?',
+      options: ['Need more practice', 'Got it'],
+    };
+    
+    engine.setSectionContent([selfEvalItem]);
+    
+    const result = engine.submitAnswer({
+      type: 'self-evaluation',
+      selectedIndex: 0,
+    });
+    expect(result.correct).toBe(true);
+  });
+
+  it('round-trips new question types via serialization', () => {
+    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    
+    const items: ContentItem[] = [
+      {
+        type: 'checklist',
+        id: 'q1',
+        topicId: 'topic-1',
+        question: 'Check',
+        items: ['A', 'B'],
+      },
+      {
+        type: 'code',
+        id: 'q2',
+        topicId: 'topic-1',
+        question: 'Code',
+        language: 'ts',
+      },
+      {
+        type: 'self-evaluation',
+        id: 'q3',
+        topicId: 'topic-1',
+        question: 'Eval',
+        options: ['1', '2'],
+      }
+    ];
+    
+    engine.setSectionContent(items);
+    
+    const snapshot = engine.serialize();
+    const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
+    
+    expect(restored.currentItem?.type).toBe('checklist');
+    restored.submitAnswer({ type: 'checklist', checkedIndices: [0, 1] });
+    restored.nextItem();
+    expect(restored.currentItem?.type).toBe('code');
+    restored.submitAnswer({ type: 'code', code: 'test' });
+    restored.nextItem();
+    expect(restored.currentItem?.type).toBe('self-evaluation');
+  });
+});


### PR DESCRIPTION
Closes #55. Added support for checklist, code, and self-evaluation question types across the engine and app.