### PR TITLE
fix(engine): handle new question types in ContentCache and snapshot validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.8.5 — 2026-05-10
+
+### Fixes
+
+- **Engine:** Extend `ContentCache.copyContentItem` switch to cover the `checklist`, `code`, and `self-evaluation` question types — restores `pnpm -r build` after the regression introduced by #62
+- **Engine:** Extend `snapshot-validation` to validate the new question shapes and their student-answer shapes; previously, export → import of a course containing any of the three new types would reject the snapshot as malformed
+- **Engine:** Reformat `ContentGenerator.ts`, `prompts/quiz-generation.ts`, and `tests/new-question-types.test.ts` to satisfy `pnpm format:check` (pre-existing drift from #62)
+- 35 new engine tests in `content-roundtrip.test.ts` that enumerate every member of the `Question` union and assert round-trip through both the cache and the snapshot validator — a dropped switch case in either location now breaks the suite
+
 ## 0.8.4 — 2026-04-14
 
 ### Features

--- a/packages/engine/src/content/ContentCache.ts
+++ b/packages/engine/src/content/ContentCache.ts
@@ -31,6 +31,12 @@ function copyContentItem(item: ContentItem): ContentItem {
         options: [...item.options],
         followUpOptions: [...item.followUpOptions],
       };
+    case 'checklist':
+      return { ...item, items: [...item.items] };
+    case 'code':
+      return { ...item };
+    case 'self-evaluation':
+      return { ...item, options: [...item.options] };
   }
 }
 

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -404,8 +404,7 @@ export class ContentGenerator {
     question: string
   ): Question {
     const language = this.#requireString(obj.language, 'language');
-    const initialCode =
-      typeof obj.initialCode === 'string' ? obj.initialCode : undefined;
+    const initialCode = typeof obj.initialCode === 'string' ? obj.initialCode : undefined;
     const expectedPattern =
       typeof obj.expectedPattern === 'string' ? obj.expectedPattern : undefined;
 

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -71,6 +71,15 @@ function isValidStudentAnswer(value: unknown): boolean {
         typeof value.selectedIndex === 'number' &&
         typeof value.followUpSelectedIndex === 'number'
       );
+    case 'checklist':
+      return (
+        Array.isArray(value.checkedIndices) &&
+        value.checkedIndices.every((entry) => typeof entry === 'number')
+      );
+    case 'code':
+      return typeof value.code === 'string';
+    case 'self-evaluation':
+      return typeof value.selectedIndex === 'number';
     default:
       return false;
   }
@@ -143,6 +152,29 @@ function isValidContentItem(value: unknown): boolean {
         typeof value.followUp === 'string' &&
         isStringArray(value.followUpOptions) &&
         typeof value.followUpCorrectIndex === 'number'
+      );
+    case 'checklist':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.items)
+      );
+    case 'code':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        typeof value.language === 'string' &&
+        (value.initialCode === undefined || typeof value.initialCode === 'string') &&
+        (value.expectedPattern === undefined || typeof value.expectedPattern === 'string')
+      );
+    case 'self-evaluation':
+      return (
+        typeof value.id === 'string' &&
+        typeof value.topicId === 'string' &&
+        typeof value.question === 'string' &&
+        isStringArray(value.options)
       );
     default:
       return false;

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -72,7 +72,8 @@ function buildQuizTool(count: number = 3) {
               items: {
                 type: 'array',
                 items: { type: 'string' },
-                description: 'Items to be ordered or checked off (for ordering, checklist)',
+                description:
+                  'Items to be ordered or checked off (for ordering, checklist)',
               },
               correctOrder: {
                 type: 'array',
@@ -111,7 +112,8 @@ function buildQuizTool(count: number = 3) {
               },
               expectedPattern: {
                 type: 'string',
-                description: 'Regex pattern to check student code for correctness (for code)',
+                description:
+                  'Regex pattern to check student code for correctness (for code)',
               },
             },
             required: ['type', 'question'],

--- a/packages/engine/tests/content-roundtrip.test.ts
+++ b/packages/engine/tests/content-roundtrip.test.ts
@@ -1,0 +1,321 @@
+// --- Content Round-Trip Tests ---
+// Verify every supported content item and student-answer type round-trips through:
+//   1. ContentCache (deep copy on set/get)
+//   2. validateEngineSnapshot (shape validation on import)
+//
+// Failing one of these tests means a switch somewhere has fallen out of sync
+// with the Question union in `content/types.ts`.
+
+import { describe, it, expect } from 'vitest';
+import { ContentCache } from '../src/content/ContentCache.js';
+import { validateEngineSnapshot } from '../src/export/snapshot-validation.js';
+import { SNAPSHOT_VERSION } from '../src/engine/constants.js';
+import type {
+  ContentItem,
+  Question,
+  QuestionType,
+  StudentAnswer,
+} from '../src/content/types.js';
+import type { EngineSnapshot } from '../src/engine/types.js';
+
+// --- Fixtures ---
+// Every member of the Question union has a fixture below. Plus an explanation.
+// If a new question type is added without updating these maps, the test that
+// asserts the keyset matches `QuestionType` will fail.
+
+const EXPLANATION: ContentItem = {
+  type: 'explanation',
+  topicId: 'topic-1',
+  title: 'Intro',
+  content: 'An explanation paragraph.',
+};
+
+const QUESTION_FIXTURES: Record<QuestionType, Question> = {
+  'multiple-choice': {
+    type: 'multiple-choice',
+    id: 'q-mc',
+    topicId: 'topic-1',
+    question: 'Pick one.',
+    options: ['A', 'B', 'C'],
+    correctIndex: 1,
+  },
+  'numeric-input': {
+    type: 'numeric-input',
+    id: 'q-num',
+    topicId: 'topic-1',
+    question: 'What is 2+2?',
+    correctValue: 4,
+    tolerance: 0,
+    unit: 'units',
+  },
+  ordering: {
+    type: 'ordering',
+    id: 'q-ord',
+    topicId: 'topic-1',
+    question: 'Sort these.',
+    items: ['First', 'Second', 'Third'],
+    correctOrder: [0, 1, 2],
+  },
+  'multi-select': {
+    type: 'multi-select',
+    id: 'q-ms',
+    topicId: 'topic-1',
+    question: 'Pick all that apply.',
+    options: ['A', 'B', 'C'],
+    correctIndices: [0, 2],
+  },
+  'two-stage': {
+    type: 'two-stage',
+    id: 'q-ts',
+    topicId: 'topic-1',
+    question: 'Stage one?',
+    options: ['Yes', 'No'],
+    correctIndex: 0,
+    followUp: 'Why?',
+    followUpOptions: ['Because', 'Otherwise'],
+    followUpCorrectIndex: 0,
+  },
+  checklist: {
+    type: 'checklist',
+    id: 'q-cl',
+    topicId: 'topic-1',
+    question: 'Complete each step.',
+    items: ['Step one', 'Step two', 'Step three'],
+  },
+  code: {
+    type: 'code',
+    id: 'q-code',
+    topicId: 'topic-1',
+    question: 'Write a function.',
+    language: 'javascript',
+    initialCode: 'function noop() {}',
+    expectedPattern: 'return',
+  },
+  'self-evaluation': {
+    type: 'self-evaluation',
+    id: 'q-se',
+    topicId: 'topic-1',
+    question: 'How confident are you?',
+    options: ['Not at all', 'Somewhat', 'Very'],
+  },
+};
+
+const ANSWER_FIXTURES: Record<QuestionType, StudentAnswer> = {
+  'multiple-choice': { type: 'multiple-choice', selectedIndex: 1 },
+  'numeric-input': { type: 'numeric-input', value: 4 },
+  ordering: { type: 'ordering', order: [0, 1, 2] },
+  'multi-select': { type: 'multi-select', selectedIndices: [0, 2] },
+  'two-stage': { type: 'two-stage', selectedIndex: 0, followUpSelectedIndex: 0 },
+  checklist: { type: 'checklist', checkedIndices: [0, 1, 2] },
+  code: { type: 'code', code: 'function answer() { return 42; }' },
+  'self-evaluation': { type: 'self-evaluation', selectedIndex: 2 },
+};
+
+const ALL_QUESTION_TYPES = Object.keys(QUESTION_FIXTURES) as QuestionType[];
+
+// --- Snapshot helpers ---
+
+function baseSnapshot(sectionItems: ContentItem[]): EngineSnapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    state: 'practicing',
+    curriculum: {
+      title: 'Test Course',
+      description: 'A course used by content round-trip tests',
+      sections: [
+        {
+          id: 'section-1',
+          title: 'Section 1',
+          order: 0,
+          topics: [{ id: 'topic-1', title: 'Topic 1', description: 'Topic description' }],
+        },
+      ],
+    },
+    currentSectionIndex: 0,
+    currentItemIndex: 0,
+    sectionItems,
+    allGeneratedContent: { 'section-1': sectionItems },
+    studentState: { masteryByTopic: {}, gaps: [] },
+    lastAnswerResult: null,
+  };
+}
+
+// --- Fixture-keyset guard ---
+
+describe('Question type fixture coverage', () => {
+  it('covers every member of QuestionType', () => {
+    // This test forces fixture updates whenever the Question union grows.
+    // The expected set should be updated only via QuestionType in types.ts.
+    const expected: QuestionType[] = [
+      'multiple-choice',
+      'numeric-input',
+      'ordering',
+      'multi-select',
+      'two-stage',
+      'checklist',
+      'code',
+      'self-evaluation',
+    ];
+    expect(new Set(ALL_QUESTION_TYPES)).toEqual(new Set(expected));
+    expect(new Set(Object.keys(ANSWER_FIXTURES))).toEqual(new Set(expected));
+  });
+});
+
+// --- ContentCache round-trip ---
+
+describe('ContentCache round-trip', () => {
+  it('round-trips explanations', () => {
+    const cache = new ContentCache();
+    cache.set('section-1', [EXPLANATION]);
+    const restored = cache.get('section-1');
+    expect(restored).toEqual([EXPLANATION]);
+  });
+
+  it.each(ALL_QUESTION_TYPES)('round-trips %s questions through ContentCache', (type) => {
+    const cache = new ContentCache();
+    const item = QUESTION_FIXTURES[type];
+    cache.set('section-1', [item]);
+
+    const restored = cache.get('section-1');
+    expect(restored).toBeDefined();
+    expect(restored).toHaveLength(1);
+    expect(restored![0]).toEqual(item);
+  });
+
+  it('returns defensive copies — mutating get() output does not poison the cache', () => {
+    const cache = new ContentCache();
+    cache.set('section-1', [QUESTION_FIXTURES.checklist]);
+
+    const first = cache.get('section-1')!;
+    expect(first[0].type).toBe('checklist');
+    if (first[0].type === 'checklist') {
+      first[0].items.push('mutated');
+      first[0].items[0] = 'altered';
+    }
+
+    const second = cache.get('section-1')!;
+    expect(second[0]).toEqual(QUESTION_FIXTURES.checklist);
+  });
+
+  it('also returns defensive copies for arrays on every other question type', () => {
+    const cache = new ContentCache();
+    const itemsWithArrays: Question[] = [
+      QUESTION_FIXTURES['multiple-choice'],
+      QUESTION_FIXTURES.ordering,
+      QUESTION_FIXTURES['multi-select'],
+      QUESTION_FIXTURES['two-stage'],
+      QUESTION_FIXTURES['self-evaluation'],
+    ];
+
+    for (const item of itemsWithArrays) {
+      cache.set('section-1', [item]);
+      const restored = cache.get('section-1')!;
+      // Mutate any string[] field on the restored copy by pushing a sentinel
+      const restoredItem = restored[0] as Record<string, unknown>;
+      for (const key of Object.keys(restoredItem)) {
+        const value = restoredItem[key];
+        if (Array.isArray(value)) {
+          (value as unknown[]).push('SENTINEL');
+        }
+      }
+
+      const second = cache.get('section-1')!;
+      expect(second[0]).toEqual(item);
+    }
+  });
+});
+
+// --- Snapshot validation ---
+
+describe('validateEngineSnapshot — content items', () => {
+  it('accepts a snapshot containing an explanation', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    expect(validateEngineSnapshot(snapshot)).not.toBeNull();
+  });
+
+  it.each(ALL_QUESTION_TYPES)('accepts a snapshot containing a %s question', (type) => {
+    const snapshot = baseSnapshot([QUESTION_FIXTURES[type]]);
+    expect(validateEngineSnapshot(snapshot)).not.toBeNull();
+  });
+
+  it('rejects a snapshot containing a malformed checklist (missing items array)', () => {
+    const broken = { ...QUESTION_FIXTURES.checklist } as Record<string, unknown>;
+    delete broken.items;
+    const snapshot = baseSnapshot([broken as unknown as ContentItem]);
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+
+  it('rejects a snapshot containing a malformed code item (missing language)', () => {
+    const broken = { ...QUESTION_FIXTURES.code } as Record<string, unknown>;
+    delete broken.language;
+    const snapshot = baseSnapshot([broken as unknown as ContentItem]);
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+
+  it('rejects a snapshot containing a malformed self-evaluation (options not strings)', () => {
+    const broken = {
+      ...QUESTION_FIXTURES['self-evaluation'],
+      options: [1, 2, 3],
+    } as unknown as ContentItem;
+    const snapshot = baseSnapshot([broken]);
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+});
+
+// --- Snapshot validation — student answers via lastAnswerResult ---
+
+describe('validateEngineSnapshot — student answers', () => {
+  it.each(ALL_QUESTION_TYPES)(
+    'accepts a snapshot with a %s answer in lastAnswerResult',
+    (type) => {
+      const snapshot = baseSnapshot([EXPLANATION]);
+      snapshot.lastAnswerResult = {
+        correct: true,
+        questionId: 'q-test',
+        topicId: 'topic-1',
+        userAnswer: ANSWER_FIXTURES[type],
+        correctAnswer: 'human-readable description',
+      };
+      expect(validateEngineSnapshot(snapshot)).not.toBeNull();
+    }
+  );
+
+  it('rejects a snapshot with a malformed checklist answer (checkedIndices not numbers)', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    snapshot.lastAnswerResult = {
+      correct: true,
+      questionId: 'q-test',
+      topicId: 'topic-1',
+      userAnswer: {
+        type: 'checklist',
+        checkedIndices: ['nope'] as unknown as number[],
+      },
+      correctAnswer: 'desc',
+    };
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+
+  it('rejects a snapshot with a malformed code answer (code not a string)', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    snapshot.lastAnswerResult = {
+      correct: true,
+      questionId: 'q-test',
+      topicId: 'topic-1',
+      userAnswer: { type: 'code', code: 42 as unknown as string },
+      correctAnswer: 'desc',
+    };
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+
+  it('rejects a snapshot with a malformed self-evaluation answer (selectedIndex missing)', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    snapshot.lastAnswerResult = {
+      correct: true,
+      questionId: 'q-test',
+      topicId: 'topic-1',
+      userAnswer: { type: 'self-evaluation' } as unknown as StudentAnswer,
+      correctAnswer: 'desc',
+    };
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+});

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -29,7 +29,7 @@ describe('New Question Types', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
-    
+
     const checklistItem: ContentItem = {
       type: 'checklist',
       id: 'q-checklist',
@@ -37,16 +37,16 @@ describe('New Question Types', () => {
       question: 'Perform the following steps:',
       items: ['Plug in guitar', 'Turn on amp', 'Tune strings'],
     };
-    
+
     engine.setSectionContent([checklistItem]);
-    
+
     // Correct: all items checked
     const resultCorrect = engine.submitAnswer({
       type: 'checklist',
       checkedIndices: [0, 1, 2],
     });
     expect(resultCorrect.correct).toBe(true);
-    
+
     // Incorrect: not all items checked
     const engine2 = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine2.loadCurriculum(mockCurriculum());
@@ -64,7 +64,7 @@ describe('New Question Types', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
-    
+
     const codeItem: ContentItem = {
       type: 'code',
       id: 'q-code',
@@ -73,16 +73,16 @@ describe('New Question Types', () => {
       language: 'javascript',
       expectedPattern: 'return true',
     };
-    
+
     engine.setSectionContent([codeItem]);
-    
+
     // Correct: matches pattern
     const resultCorrect = engine.submitAnswer({
       type: 'code',
       code: 'function test() { return true; }',
     });
     expect(resultCorrect.correct).toBe(true);
-    
+
     // Incorrect: does not match pattern
     const engine2 = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine2.loadCurriculum(mockCurriculum());
@@ -100,7 +100,7 @@ describe('New Question Types', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
-    
+
     const codeItem: ContentItem = {
       type: 'code',
       id: 'q-code-no-pattern',
@@ -108,9 +108,9 @@ describe('New Question Types', () => {
       question: 'Write some code.',
       language: 'javascript',
     };
-    
+
     engine.setSectionContent([codeItem]);
-    
+
     const result = engine.submitAnswer({
       type: 'code',
       code: 'any code',
@@ -122,7 +122,7 @@ describe('New Question Types', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
-    
+
     const selfEvalItem: ContentItem = {
       type: 'self-evaluation',
       id: 'q-self-eval',
@@ -130,9 +130,9 @@ describe('New Question Types', () => {
       question: 'How do you feel about your progress?',
       options: ['Need more practice', 'Got it'],
     };
-    
+
     engine.setSectionContent([selfEvalItem]);
-    
+
     const result = engine.submitAnswer({
       type: 'self-evaluation',
       selectedIndex: 0,
@@ -144,7 +144,7 @@ describe('New Question Types', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
-    
+
     const items: ContentItem[] = [
       {
         type: 'checklist',
@@ -166,14 +166,14 @@ describe('New Question Types', () => {
         topicId: 'topic-1',
         question: 'Eval',
         options: ['1', '2'],
-      }
+      },
     ];
-    
+
     engine.setSectionContent(items);
-    
+
     const snapshot = engine.serialize();
     const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
-    
+
     expect(restored.currentItem?.type).toBe('checklist');
     restored.submitAnswer({ type: 'checklist', checkedIndices: [0, 1] });
     restored.nextItem();


### PR DESCRIPTION
## Summary

- Restore `pnpm -r build` and snapshot import/export for the `checklist`, `code`, and `self-evaluation` question types added in #62.
- Extend `ContentCache.copyContentItem` to deep-copy the new shapes.
- Extend `isValidContentItem` and `isValidStudentAnswer` in `snapshot-validation.ts` to validate the new content + answer shapes.
- New test file `tests/content-roundtrip.test.ts` enumerates every member of the `Question` union and asserts round-trip through both the cache and the snapshot validator.
- Also includes `pnpm format` fixes to three files (drift left over from #62 that was blocking `pnpm format:check`).

Quality-filter coverage for the new types is **out of scope** here — tracked in #68.

## Test plan

- [x] `pnpm -r build` — green (was failing on `main` with `error TS2366: Function lacks ending return statement`)
- [x] `pnpm -r test` — engine 227/227, app 124/124
- [x] `pnpm format:check` — green
- [x] New test file enumerates all 8 question types; deleting a `case` from `copyContentItem` or `isValidContentItem` breaks the round-trip assertions
- [x] Snapshot validation rejects each new type with a malformed shape (missing `items`, `language`; non-string `options`)

Closes #64