### PR TITLE
chore: try Codex before Claude in agent fallback cascade

### DIFF
--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -110,28 +110,6 @@ run_agent() {
     local output
     local status
 
-    # Try Claude
-    if check_cooldown "claude"; then
-        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
-    else
-        echo "$(date): Trying Claude..." | tee -a "$logfile"
-        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
-            status=0
-        else
-            status=$?
-        fi
-        echo "$output" | tee -a "$logfile"
-        if [ "$status" -eq 0 ]; then
-            return 0
-        fi
-        if is_out_of_credits "$output"; then
-            set_cooldown "claude"
-            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
-        else
-            log_error "Claude failed with exit code $status. Proceeding to fallback..."
-        fi
-    fi
-
     # Try Codex
     if check_cooldown "codex"; then
         echo "$(date): Skipping Codex (cooldown active)..." | tee -a "$logfile"
@@ -151,6 +129,28 @@ run_agent() {
             echo "$(date): Codex out of credits, set 1h cooldown." | tee -a "$logfile"
         else
             log_error "Codex failed with exit code $status. Proceeding to fallback..."
+        fi
+    fi
+
+    # Try Claude
+    if check_cooldown "claude"; then
+        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
+    else
+        echo "$(date): Trying Claude..." | tee -a "$logfile"
+        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
+            status=0
+        else
+            status=$?
+        fi
+        echo "$output" | tee -a "$logfile"
+        if [ "$status" -eq 0 ]; then
+            return 0
+        fi
+        if is_out_of_credits "$output"; then
+            set_cooldown "claude"
+            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
+        else
+            log_error "Claude failed with exit code $status. Proceeding to fallback..."
         fi
     fi
 

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -110,28 +110,6 @@ run_agent() {
     local output
     local status
 
-    # Try Claude
-    if check_cooldown "claude"; then
-        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
-    else
-        echo "$(date): Trying Claude..." | tee -a "$logfile"
-        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
-            status=0
-        else
-            status=$?
-        fi
-        echo "$output" | tee -a "$logfile"
-        if [ "$status" -eq 0 ]; then
-            return 0
-        fi
-        if is_out_of_credits "$output"; then
-            set_cooldown "claude"
-            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
-        else
-            log_error "Claude failed with exit code $status. Proceeding to fallback..."
-        fi
-    fi
-
     # Try Codex
     if check_cooldown "codex"; then
         echo "$(date): Skipping Codex (cooldown active)..." | tee -a "$logfile"
@@ -151,6 +129,28 @@ run_agent() {
             echo "$(date): Codex out of credits, set 1h cooldown." | tee -a "$logfile"
         else
             log_error "Codex failed with exit code $status. Proceeding to fallback..."
+        fi
+    fi
+
+    # Try Claude
+    if check_cooldown "claude"; then
+        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
+    else
+        echo "$(date): Trying Claude..." | tee -a "$logfile"
+        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
+            status=0
+        else
+            status=$?
+        fi
+        echo "$output" | tee -a "$logfile"
+        if [ "$status" -eq 0 ]; then
+            return 0
+        fi
+        if is_out_of_credits "$output"; then
+            set_cooldown "claude"
+            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
+        else
+            log_error "Claude failed with exit code $status. Proceeding to fallback..."
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Reorders the fallback cascade in `scripts/author.sh` and `scripts/reviewer.sh` so Codex is tried before Claude
- Gemini stays last
- Per-model cooldowns, credit detection, and all other behavior unchanged — this is purely a reorder

## Why

John has 10x Codex credits for the next few weeks (promo). Codex-first means each task tries the cheaper-to-John tier before burning Claude credits. After the promo expires we can revisit.

## Test plan

- [x] `bash -n scripts/author.sh` and `bash -n scripts/reviewer.sh` pass (no syntax errors)
- [x] Diff is a clean swap — no other logic changes
- [ ] Smoke test on the next agent run: author.sh log shows "Trying Codex..." before "Trying Claude..."

Per AGENTS.md "Script Standards" — script-only changes require a quick planner read rather than a formal reviewer pass. Merging via planner authority.