### PR TITLE
chore: drop Claude from author/reviewer fallback cascade

### DIFF
--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -2,7 +2,8 @@
 # Author agent loop.
 # Each invocation does one thing (revise a PR or implement an issue), then exits.
 # If work was done, immediately checks for more. Only sleeps when idle.
-# Falls back through Claude → Codex → Gemini if a model runs out of credits.
+# Falls back through Codex → Gemini if a model runs out of credits.
+# Claude is intentionally excluded — it's reserved for the planner role.
 # Retries on transient errors (network, GitHub). Logs errors for later review.
 #
 # Usage: ./scripts/author.sh
@@ -129,28 +130,6 @@ run_agent() {
             echo "$(date): Codex out of credits, set 1h cooldown." | tee -a "$logfile"
         else
             log_error "Codex failed with exit code $status. Proceeding to fallback..."
-        fi
-    fi
-
-    # Try Claude
-    if check_cooldown "claude"; then
-        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
-    else
-        echo "$(date): Trying Claude..." | tee -a "$logfile"
-        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
-            status=0
-        else
-            status=$?
-        fi
-        echo "$output" | tee -a "$logfile"
-        if [ "$status" -eq 0 ]; then
-            return 0
-        fi
-        if is_out_of_credits "$output"; then
-            set_cooldown "claude"
-            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
-        else
-            log_error "Claude failed with exit code $status. Proceeding to fallback..."
         fi
     fi
 

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -2,7 +2,8 @@
 # Reviewer agent loop.
 # Each invocation reviews one PR (or exits if nothing to review).
 # If work was done, immediately checks for more. Only sleeps when idle.
-# Falls back through Claude → Codex → Gemini if a model runs out of credits.
+# Falls back through Codex → Gemini if a model runs out of credits.
+# Claude is intentionally excluded — it's reserved for the planner role.
 # Retries on transient errors (network, GitHub). Logs errors for later review.
 #
 # Usage: ./scripts/reviewer.sh
@@ -129,28 +130,6 @@ run_agent() {
             echo "$(date): Codex out of credits, set 1h cooldown." | tee -a "$logfile"
         else
             log_error "Codex failed with exit code $status. Proceeding to fallback..."
-        fi
-    fi
-
-    # Try Claude
-    if check_cooldown "claude"; then
-        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
-    else
-        echo "$(date): Trying Claude..." | tee -a "$logfile"
-        if output=$(claude -p "$prompt" --dangerously-skip-permissions --verbose 2>&1); then
-            status=0
-        else
-            status=$?
-        fi
-        echo "$output" | tee -a "$logfile"
-        if [ "$status" -eq 0 ]; then
-            return 0
-        fi
-        if is_out_of_credits "$output"; then
-            set_cooldown "claude"
-            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
-        else
-            log_error "Claude failed with exit code $status. Proceeding to fallback..."
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Removes the Claude block from `run_agent` in `scripts/author.sh` and `scripts/reviewer.sh`. New cascade: **Codex → Gemini**.
- Updates the header comments to note that Claude is intentionally excluded and reserved for the planner role.

## Why

The author/reviewer scripts are the high-volume task loop. Letting them fall back to Claude was chewing through the Anthropic Pro plan (currently 88% consumed before any agent tasks shipped this cycle, mostly from interactive planning and milestone review). Reserving Claude for the planner — which is interactive, context-heavy, and low-volume — keeps the Pro plan available for the work where it earns its cost.

Codex remains primary (10x promo active per #75), Gemini stays as the free-tier fallback. Both author and reviewer keep their cooldown logic.

Follows the precedent set by #75: scripts-only diff, planner-approved per AGENTS.md "Script Standards" (no formal reviewer-agent pass required).

## Validation

- `bash -n scripts/author.sh && bash -n scripts/reviewer.sh` — passes
- `shellcheck` not run locally (not installed on this machine). Diff is pure deletion of a block that passed `shellcheck` when #75 merged it; no new code paths introduced. Happy to install + rerun if reviewer prefers.

## Notes

- `main` is still broken until #64 lands (per PLANNER-HANDOFF.md). CI will inherit that failure on this PR. Plan to merge with `--admin` per #75 precedent unless reviewer objects.
- Running author/reviewer agents (currently in flight) will keep using the old in-memory cascade until restarted. No action needed — next launch picks up the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)