### PR TITLE
feat: add planner-triggered milestone audit script

### DIFF
--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Milestone-audit one-shot.
+# Planner-triggered. Reads a phase from ROADMAP.md, runs Codex once to audit
+# the phase's code against AGENTS.md checklists, instructs Codex to file one
+# GitHub issue per finding, and exits.
+#
+# Differences from author.sh / reviewer.sh:
+#   - Single shot. No poll loop, no backoff.
+#   - Codex only. No fallback cascade. If Codex fails, the planner reruns
+#     manually (or escalates to Gemini by hand).
+#   - No cooldown handling. The planner decides when to retry.
+#
+# Usage: ./scripts/audit.sh <phase-number>
+# Example: ./scripts/audit.sh 3
+
+# Fail on unset variables, but NOT on command errors — we handle those ourselves.
+set -uo pipefail
+
+# --- Argument parsing ---
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <phase-number>" >&2
+    exit 2
+fi
+PHASE="$1"
+if ! [[ "$PHASE" =~ ^[0-9]+$ ]]; then
+    echo "Phase must be a non-negative integer (got: '$PHASE')" >&2
+    exit 2
+fi
+
+# --- Paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Worktree path is configurable so the script works on multiple machines.
+WORKTREE="${CQ_WORKTREE_AUDIT:-$REPO_ROOT/../cq-audit}"
+PROMPT_FILE="$SCRIPT_DIR/prompts/audit.md"
+LOGDIR="$REPO_ROOT/logs/audit"
+LOCKFILE="/tmp/cq-audit.lock"
+
+# --- Prevent overlapping runs ---
+# The script is one-shot, but a planner could accidentally launch it twice.
+if [ -f "$LOCKFILE" ]; then
+    pid=$(cat "$LOCKFILE")
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "Audit already running (pid $pid). Exiting." >&2
+        exit 1
+    fi
+    rm -f "$LOCKFILE"
+fi
+echo $$ > "$LOCKFILE"
+trap 'rm -f "$LOCKFILE"' EXIT
+
+# --- Ensure worktree exists, fetch latest, detach to origin/main ---
+# The auditor reads code, so it needs a clean view of origin/main rather than
+# whatever the planner happens to have checked out.
+if [ ! -d "$WORKTREE" ]; then
+    echo "Creating audit worktree at $WORKTREE"
+    if ! git -C "$REPO_ROOT" worktree add "$WORKTREE" --detach origin/main; then
+        echo "Failed to create worktree at $WORKTREE" >&2
+        exit 4
+    fi
+fi
+cd "$WORKTREE"
+if ! git fetch origin 2>&1; then
+    echo "Could not fetch origin. Check network." >&2
+    exit 5
+fi
+git checkout --detach origin/main 2>/dev/null || true
+
+# --- Extract Phase N section from ROADMAP.md ---
+# Phase headers look like "## Phase N: ...". A section ends at the next
+# "## Phase" header or end-of-file.
+PHASE_SCOPE=$(awk -v p="$PHASE" '
+    BEGIN { in_phase = 0 }
+    /^## Phase / {
+        if (in_phase) { exit }
+        if ($0 ~ ("^## Phase " p ":")) { in_phase = 1 }
+    }
+    in_phase
+' ROADMAP.md)
+
+if [ -z "$PHASE_SCOPE" ]; then
+    echo "Could not find 'Phase $PHASE:' header in ROADMAP.md" >&2
+    exit 3
+fi
+
+# --- Build prompt: template + phase scope ---
+PROMPT=$(cat "$PROMPT_FILE")
+PROMPT+="
+
+---
+
+## Phase $PHASE scope (from ROADMAP.md)
+
+$PHASE_SCOPE"
+
+# --- Log setup ---
+mkdir -p "$LOGDIR"
+LOGFILE="$LOGDIR/$(date +%Y%m%d-%H%M%S)-phase-$PHASE.log"
+
+{
+    echo "$(date): Starting milestone audit for Phase $PHASE"
+    echo "Worktree: $WORKTREE"
+    echo "Log file: $LOGFILE"
+    echo "---"
+} | tee "$LOGFILE"
+
+# --- Run Codex once ---
+# No fallback. If Codex fails (credits, network, refusal), the planner reruns.
+if codex exec "$PROMPT" --yolo 2>&1 | tee -a "$LOGFILE"; then
+    echo "$(date): Audit completed" | tee -a "$LOGFILE"
+    exit 0
+else
+    status=$?
+    echo "$(date): Audit failed with exit code $status" | tee -a "$LOGFILE"
+    exit "$status"
+fi

--- a/scripts/prompts/audit.md
+++ b/scripts/prompts/audit.md
@@ -1,0 +1,69 @@
+You are the **milestone-audit agent** for CourseQuizzer. You are running under the planning role. Read AGENTS.md and ROADMAP.md before doing anything else.
+
+Your job: audit the code shipped during the phase named below against the project's standards, and file one GitHub issue per finding. You do not write code. You do not open PRs. You do not claim issues. You exit when you are done filing issues.
+
+The phase scope (extracted from ROADMAP.md) is appended at the bottom of this prompt. It lists the issues and PRs that shipped during this phase.
+
+## What to audit
+
+For every source file touched during this phase (use the issue list + `git log` to identify them), evaluate against:
+
+1. **Security checklist** (AGENTS.md → "Security Review"). Pay particular attention to: API key handling, `{@html}` usage, import-data validation, `eval`/`Function`, network destinations.
+2. **Architecture rules** (AGENTS.md → "Architecture Rules"). Engine has zero browser deps. All LLM calls go through `packages/engine/src/provider/`. Prompts live in `packages/engine/src/prompts/`. Engine emits events; app consumes via events only.
+3. **Readability** (AGENTS.md → "Conventions"). Descriptive names, no `any`, defensive copies on engine boundaries, comments where the why is non-obvious. The bar is: a competent junior engineer can read the file and build a mental model.
+4. **Test coverage** (AGENTS.md → "Testing Philosophy"). Every meaningful behavior tested. No trivial tests. Prompt tests use recorded fixtures. Component tests cover state-to-render, not CSS.
+5. **CHANGELOG.md** accuracy — every shipped PR represented, no stale entries.
+
+## How to file findings
+
+**One issue per finding.** This is the granularity rule from AGENTS.md. If you find six things, file six issues — never one "fix these six things" issue.
+
+For each finding:
+
+```
+gh issue create \
+  --title "<short, action-oriented title>" \
+  --body "<what was found, where (file:line), why it matters, suggested fix>"
+```
+
+Issue body should include:
+
+- **What:** the specific problem (file path + line numbers where applicable)
+- **Why:** which AGENTS.md rule or principle this violates, and the concrete risk if left unfixed
+- **Suggested fix:** the smallest change that would resolve it
+- **Scope:** which package(s) the fix touches
+
+**Do not apply the `review` label.** Per AGENTS.md, the `review` label is reserved for the milestone review tracking issue (which we are not creating). Findings are regular issues that the author agent will pick up in number order.
+
+**Do not apply the `in-progress` label.** Findings are filed for the author agent to claim later.
+
+## Safety gate
+
+These behaviors are forbidden. They belong to other roles or to John:
+
+- Do not modify code, edit files, or open PRs
+- Do not call `gh pr merge` or `gh pr review`
+- Do not claim issues (`gh issue edit --add-label in-progress`)
+- Do not close issues or PRs
+- Do not write to `PLANNER-HANDOFF.md`, `AUTHOR-HANDOFF.md`, or `REVIEWER-HANDOFF.md`
+- Do not perform planning, dispatching, or coding work — your only output is `gh issue create` calls
+
+If you discover something that needs John's judgment (architectural change, scope question, conflicting requirements), file it as an issue with the body prefixed `**Needs John's decision:**` — do not stop to ask.
+
+## What to do if nothing is wrong
+
+If the phase code passes every check cleanly, say so explicitly: `No findings. Phase N audit clean.` Exit zero.
+
+## Final summary
+
+After filing all issues, print a summary block:
+
+```
+=== Milestone audit summary ===
+Phase: <N>
+Findings filed: <count>
+Issue numbers: #<a>, #<b>, #<c>, ...
+Needs-John flagged: <count, or 0>
+```
+
+Then exit.


### PR DESCRIPTION
## Summary

- Adds `scripts/audit.sh` and `scripts/prompts/audit.md`. The planner runs `./scripts/audit.sh <phase-number>` to kick off a milestone review.
- The script extracts the phase block from `ROADMAP.md`, invokes Codex once against the audit prompt in a fresh worktree at `origin/main`, logs to `logs/audit/`, and exits.
- No poll loop, no fallback cascade, no cooldown logic. One-shot, planner-triggered, deterministic.
- The prompt instructs Codex to file one GitHub issue per finding (granularity rule) with full safety-gate language: no code edits, no PR opens, no issue claims, no cross-role work.

## Why

Milestone reviews were the largest single consumer of the Anthropic Pro plan this cycle — the planner ran them as sub-agents in interactive Claude sessions, reading every phase file in one shot. Moving the audit to a Codex-backed script:

1. Shifts the read-heavy audit work onto the 10x Codex promo (paired with PR #76's cascade change, keeps Claude entirely off the high-volume loops).
2. Lets the planner stay in chat-with-John mode instead of disappearing into a long sub-agent run.
3. Makes the audit reproducible — same script, same prompt, same scope, run from any machine.

## Design choices

- **One model, no fallback.** If Codex fails, the planner reruns or escalates by hand. Matches the answer in our dispatch discussion ("Codex matches author/reviewer").
- **Dedicated worktree** (`$CQ_WORKTREE_AUDIT`, default `../cq-audit`). Keeps the audit decoupled from the planner's current branch state and matches the worktree pattern used by author.sh / reviewer.sh.
- **Configurable worktree path** via env var so the script ports cleanly to a Mac without code change.
- **Phase scope extraction via awk.** Headers like `## Phase 3:` are stable markers; the script captures everything up to the next `## Phase`.

## Validation

- `bash -n scripts/audit.sh` passes
- Bad-arg paths: missing arg → exit 2 with usage; non-integer → exit 2 with explanation; missing phase header → exit 3
- Phase-extraction awk verified for the current ROADMAP.md (Phases 0–5)
- `shellcheck` not run locally (not installed). Happy to install + rerun if reviewer prefers.

## Notes

- `main` is still broken until #64 lands. CI will inherit that on this PR. Plan to merge with `--admin` per the #75 precedent for script-only diffs.
- Worktree is created lazily on first run; the next planner who runs the script generates it.
- This PR does not modify AGENTS.md's "Milestone Reviews" section. Once we've used the script once or twice and the workflow feels right, I'll send a separate PR that points the docs at `./scripts/audit.sh` and removes the "Future automation" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)