### PR TITLE
fix(scripts): author owns the merge, reviewer never merges

### DIFF
--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -16,21 +16,24 @@ For each PR (oldest first), check comments for review feedback:
 gh pr view <n> --json comments --jq '.comments[] | select(.body | contains("## Review"))'
 ```
 
-A PR needs action if it has a review comment with findings and no commits pushed after that comment. Check the **Verdict** line:
+A PR needs action if its latest review comment has not been acted on. Check the **Verdict** line:
 
-- `Clean approve — no action needed` → skip, nothing to do (reviewer already merged it)
-- `Approved with required fixes` → fix everything, then merge after pushing
+- `Clean approve — no action needed` → merge immediately (no code changes needed)
+- `Approved with required fixes` → fix everything, push, then merge
 - `Changes requested` → fix everything, push, wait for re-review (do NOT merge)
+
+The author owns the merge in every approved case. The reviewer's job is to review; the author's job is to drive the PR to merged.
 
 If a PR needs action:
 
 1. Check out the PR branch
 2. Read the review comment — the entire comment, not just the status line
-3. Address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
-4. Run `pnpm -r test`, `pnpm -r build`, `pnpm format`
-5. Commit and push
-6. If verdict was `Approved with required fixes`: merge with `gh pr merge <n> --squash --delete-branch --admin`
-7. Exit
+3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. Exit.
+4. Otherwise, address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
+5. Run `pnpm -r test`, `pnpm -r build`, `pnpm format`
+6. Commit and push
+7. If verdict was `Approved with required fixes`: merge with `gh pr merge <n> --squash --delete-branch --admin`
+8. Exit
 
 ## Priority 2: Finish an in-progress issue that has no PR
 
@@ -82,5 +85,5 @@ If none of the above apply, say "Nothing to do" and exit.
 
 - One thing per invocation. Do not start a second task.
 - Follow all Architecture Rules and Conventions in AGENTS.md.
-- Commit attribution: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
-- Never auto-merge. The reviewer handles approval; you handle code.
+- Commit attribution matches the model running: `Co-Authored-By: Codex <noreply@openai.com>`, `Co-Authored-By: Gemini <noreply@google.com>`, etc.
+- The author owns the merge after the reviewer approves. Do not wait for a human to merge. Merging without `**Status: APPROVED**` (or, for trivial PRs, without green CI) is forbidden.

--- a/scripts/prompts/reviewer.md
+++ b/scripts/prompts/reviewer.md
@@ -78,12 +78,11 @@ gh pr comment <n> --body "## Review — Reviewer Agent
 ### Important
 
 - There is no such thing as a "non-blocking" finding. If you mention it, the author must fix it. If it's truly not worth fixing, don't mention it.
-- Do NOT merge a PR that has findings. Only merge clean approves (no findings).
+- Never merge. The author owns the merge after seeing your approval comment.
 - Never edit code. Post findings; the author fixes.
 - Be specific: file, line number, what's wrong, what to do instead.
 
-5. If clean approve (no findings) AND CI is green, merge: `gh pr merge <n> --squash --delete-branch --admin`
-6. Exit
+5. Exit after posting the review comment.
 
 ## Priority 2: Nothing to review
 
@@ -93,4 +92,5 @@ If no PRs need review, say "Nothing to review" and exit.
 
 - One PR per invocation. Do not review a second PR.
 - Never edit code. Post findings; the author fixes.
-- Trivial PRs (version bumps, typos, config) can be approved and merged without deep review, but still verify CI.
+- Never merge — the author drives the PR to merged after seeing your approval.
+- Trivial PRs (version bumps, typos, config) still need an approval comment, but the review can be one line ("Trivial — approved"). The author still does the merge.


### PR DESCRIPTION
## Summary

Aligns `scripts/prompts/author.md` and `scripts/prompts/reviewer.md` with the canonical merge policy in AGENTS.md ("Branching & Pull Requests" → "Merge after approval: the coding agent merges").

- **author.md**: clean-approve PRs become a merge case (previously the prompt assumed the reviewer had already merged them). Removed the contradictory "Never auto-merge" final rule that was freezing the author on PRs with findings. Updated commit-attribution example so it doesn't hard-code Claude after PR #76.
- **reviewer.md**: removed the `gh pr merge` action. Reviewer now reviews and exits. Updated the trivial-PR rule so trivial PRs still get a one-line approval comment from the reviewer; the author still does the merge.

## Why

Real symptom: the running author agent has been logging "I did not merge the PR because the final rule says never auto-merge" while the reviewer agent was merging clean-approve PRs itself. The two scripts had diverged from AGENTS.md and from each other.

The intended (and now restored) flow:

1. Author opens PR.
2. Reviewer posts `## Review — Reviewer Agent` comment with `**Status: APPROVED**` or `**Status: CHANGES REQUESTED**`.
3. Author sees the approval, addresses findings if any, and merges.

This matches how PR merges work in normal team workflows — the person who wrote the code drives it to merged, the reviewer signs off but doesn't take ownership.

## Validation

Prompt-only diff. No script logic changes. `bash -n` not needed (no shell touched).

## Notes

- Running agents will continue using the old prompts until restarted. Plan to kill and relaunch after this merges and after the current queue drains, alongside the PR #76 cascade-reorder restart.
- AGENTS.md doesn't need an update — this PR brings the prompts back into alignment with what AGENTS.md already says.
- Trivial PR handling stays explicit: reviewer still posts a one-line comment so the author has an approval signal to detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)