### PR TITLE
feat: migrate planner state to pinned GitHub issue (#85)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,57 +479,66 @@ Milestone reviews are a **planning agent responsibility**, not a coding or PR-re
 
 **Future automation:** Eventually, a planner script will poll for phase completion and trigger milestone reviews automatically. For now, milestone reviews happen in interactive planner sessions.
 
-### Handoff Files
+### Planner State (Cross-Session, Cross-Machine)
 
-Only the planning role maintains a handoff file now.
+The planner role's session-to-session state lives in a **pinned GitHub issue** labeled `planner-state` — not in a local file. This makes planner sessions portable across machines (laptop, Mac, future nodes). Find it with:
 
-Script-driven author and reviewer agents do **not** maintain handoff files. Their continuity comes from:
+```bash
+gh issue list --label planner-state --state open
+```
+
+Any planner session — on any machine — reads this issue first to bootstrap context, and edits the issue body in place before exiting. The issue is never closed; it is a living document.
+
+Script-driven author and reviewer agents do **not** maintain planner state. Their continuity comes from:
 
 - GitHub issues and PRs
 - review comments
 - script logs under `logs/`
 - the shell script control plane
 
-The planning role is different because it is interactive, cross-cutting, and not driven from a single issue/PR queue.
+The planner role is different because it is interactive, cross-cutting, and not driven from a single issue/PR queue.
 
-**Files:**
-
-- `PLANNER-HANDOFF.md` — Planning agent state
-
-**Format (strict — must be machine-parseable):**
+**Format (sections kept current in the issue body):**
 
 ```markdown
 ## Status
 
-Phase: 2 | Issue: #18 | Branch: feat/engine-store-wrapper | State: implementing
+Phase: N | Branch: main | State: short summary of where we are
 
-## Done
+## Done (recent)
 
-- [abc1234] Implemented store wrapper skeleton
-- [def5678] Added event forwarding tests
+- [PR #N] Short description of what shipped
+- ...
+
+## Open Issue Queue
+
+| # | Type | Summary | Notes |
+|---|---|---|---|
+| #N | type | ... | ... |
 
 ## Next
 
-1. Wire store to SvelteKit layout (specific file: src/routes/+layout.svelte)
-2. Add error propagation from engine events to store
+1. Specific, actionable next step
+2. ...
 
 ## Decisions
 
-- Chose runes over legacy stores because SvelteKit 5 default
-- Used $effect rather than onMount for engine binding — cleaner teardown
+- Non-obvious choice and the reason behind it
+- ...
 
 ## Gotchas
 
-- Engine emits 'ready' before first content is available — don't render until 'content:ready'
-- pnpm workspace protocol requires exact match on engine export names
+- Anything that would trip up a future planner session
+- ...
 ```
 
 **Rules:**
 
-- **Update before every exit.** Not optional. If the handoff file is stale, the next agent (especially Codex or Gemini) wastes credits re-deriving context.
+- **Update before every exit.** Not optional. If the issue is stale, the next planner — possibly on another machine — wastes Claude tokens re-deriving context.
 - **"Next" must be specific and actionable.** Not "continue working on the feature" — list exact files, functions, or steps.
-- **"Decisions" captures non-obvious choices.** If it's obvious from the code, don't repeat it. If a future agent would make a different choice without this context, write it down.
-- **This file is gitignored.** It lives in the worktree, not in the repo.
+- **"Decisions" captures non-obvious choices.** If it's obvious from the code, don't repeat it. If a future planner would make a different choice without this context, write it down.
+- **Re-verify before acting on what's written.** The issue is edited in place; mid-edit interruptions can leave content lagging reality. Cross-check against `gh issue list` / `gh pr list` / `git log` before relying on it.
+- **`PLANNER-HANDOFF.md` is deprecated.** It remains as a one-line redirect stub for session-start hooks that expect a `*-HANDOFF.md` file at the repo root. New planner sessions should edit the issue, not the file.
 
 ### TDD Workflow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,11 +107,11 @@ The shape we're moving toward: the **planner role becomes interactive-only** (ch
 - [x] Restore canonical merge policy: author owns merge, reviewer never merges (PR #81)
 - [x] Author script: stop fallback on non-credit agent failures (PR #78, closes #65)
 - [x] Running agents restarted on 2026-05-10 to pick up the new cascade and prompts
+- [x] Planner state migrated to pinned GitHub issue #85 (label `planner-state`); AGENTS.md updated; PLANNER-HANDOFF.md replaced with a redirect stub
 
 **Backlog (ordered by intended next move):**
 
 - [ ] First real run of `scripts/audit.sh 3` once Phase 3 cleanup queue drains
-- [ ] Migrate planner state from `PLANNER-HANDOFF.md` to a pinned GitHub issue (label `planner-state`) — the multi-machine unlock
 - [ ] Onboard the new Mac as a second factory node (clone, env vars, CLI installs)
 - [ ] `scripts/start-agents.sh` / `stop-agents.sh` / `status.sh` — quality-of-life supervisor for multi-machine ops
 - [ ] AGENTS.md catch-up: document the new cascade, `audit.sh`, and the planner-state issue
@@ -122,5 +122,6 @@ The shape we're moving toward: the **planner role becomes interactive-only** (ch
 **Future (not committed):**
 
 - Mac mini or other third node, if the two-machine setup proves out
+- Containerized agent fleet — many concurrent agents per machine via Docker, once multi-machine proves out
 - Background log-mining agent (see memory `project_log_reaper`) — mine `logs/` for insights before deletion
 - Reviewer skip-rule for script-only PRs (currently the reviewer wastes a Codex call reviewing diffs that AGENTS.md says don't need formal review)


### PR DESCRIPTION
## Summary

Moves the planner role's session-to-session state from the gitignored, laptop-local `PLANNER-HANDOFF.md` to **pinned GitHub issue #85** (label `planner-state`). Any machine running a planner reads and edits the issue directly.

- **AGENTS.md** "Handoff Files" section → "Planner State (Cross-Session, Cross-Machine)". Describes the new mechanism (find the issue via `gh issue list --label planner-state`), the format the body keeps, and the rules for keeping it trustworthy.
- **ROADMAP.md** marks the migration shipped in the Agent Factory Infrastructure section. Also adds "containerized agent fleet" to the "Future (not committed)" list per John's stated future direction.
- **`PLANNER-HANDOFF.md`** is gitignored, so it doesn't appear in this diff. On this laptop it has been replaced with a one-line redirect stub. On the Mac it won't exist at all — the Mac planner reads AGENTS.md, finds the pinned issue via the label, and proceeds.

## Why

This is the unblock for multi-machine planning. The only piece of planner context that was machine-local is now in GitHub. The remaining Mac onboarding is pure environment setup — clone, install `claude`/`codex`/`gemini` CLIs, set `CQ_WORKTREE_*` env vars, launch the scripts.

It also aligns with the "GitHub-only coordination" principle that came out of John's observation today: anything cross-agent or cross-role goes through GitHub, never through local files or signals.

## Validation

- Docs-only diff (the issue + label were created out-of-band via `gh`)
- Issue #85 exists, is labeled `planner-state`, and is pinned
- Script-driven agent guidance in AGENTS.md is unchanged — running author/reviewer agents are unaffected
- PLANNER-HANDOFF.md being gitignored is verified (not appearing in the diff)

## Notes

- This PR does not deprecate the global `*-HANDOFF.md` session-start hook in `~/.claude/CLAUDE.md`. The laptop's redirect stub keeps that hook satisfied. The hook is John's personal config; the right time to revisit it is after the Mac has been running planner sessions for a few days and we've confirmed the issue-only flow is robust.
- The first planner session on the Mac will need to be told to start by reading the pinned issue (e.g., "you're the planner agent, find the `planner-state` issue and bootstrap from it"). That instruction is documented in the updated AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)