### PR TITLE
chore(engine): extract shared content copy helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Scripts:** Stop cascading author/reviewer runs to fallback models after non-credit Codex failures, and pipe Gemini prompts directly from the prompt file to preserve multi-line formatting
 - **Engine:** Pass the engine-owned `StudentModel` into background prefetch generation so cached next-section content uses adaptive quiz burst sizing instead of the default question count
 - **Engine:** Extend quality-filter length-outlier coverage to `checklist` and `self-evaluation` questions, and make all question-type switch branches explicit
+- **Engine:** Extract shared `copyContentItem` utility so `ContentCache` and `CourseEngine` cannot drift when new content item types are added
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/ContentCache.ts
+++ b/packages/engine/src/content/ContentCache.ts
@@ -3,42 +3,8 @@
 // This allows the engine to retrieve content near-instantly if it
 // has been prefetched in the background.
 
+import { copyContentItem } from './copy-utils.js';
 import type { ContentItem } from './types.js';
-
-function copyContentItem(item: ContentItem): ContentItem {
-  switch (item.type) {
-    case 'explanation':
-      return { ...item };
-    case 'multiple-choice':
-      return { ...item, options: [...item.options] };
-    case 'numeric-input':
-      return { ...item };
-    case 'ordering':
-      return {
-        ...item,
-        items: [...item.items],
-        correctOrder: [...item.correctOrder],
-      };
-    case 'multi-select':
-      return {
-        ...item,
-        options: [...item.options],
-        correctIndices: [...item.correctIndices],
-      };
-    case 'two-stage':
-      return {
-        ...item,
-        options: [...item.options],
-        followUpOptions: [...item.followUpOptions],
-      };
-    case 'checklist':
-      return { ...item, items: [...item.items] };
-    case 'code':
-      return { ...item };
-    case 'self-evaluation':
-      return { ...item, options: [...item.options] };
-  }
-}
 
 export class ContentCache {
   #cache = new Map<string, ContentItem[]>();

--- a/packages/engine/src/content/copy-utils.ts
+++ b/packages/engine/src/content/copy-utils.ts
@@ -1,0 +1,49 @@
+// --- Content Copy Utilities ---
+// Defensive copies keep generated content immutable across engine boundaries.
+
+import type { ContentItem } from './types.js';
+
+export function copyContentItem(item: ContentItem): ContentItem {
+  switch (item.type) {
+    case 'explanation':
+      return { ...item };
+    case 'multiple-choice':
+      return { ...item, options: [...item.options] };
+    case 'numeric-input':
+      return { ...item };
+    case 'ordering':
+      return {
+        ...item,
+        items: [...item.items],
+        correctOrder: [...item.correctOrder],
+      };
+    case 'multi-select':
+      return {
+        ...item,
+        options: [...item.options],
+        correctIndices: [...item.correctIndices],
+      };
+    case 'two-stage':
+      return {
+        ...item,
+        options: [...item.options],
+        followUpOptions: [...item.followUpOptions],
+      };
+    case 'checklist':
+      return {
+        ...item,
+        items: [...item.items],
+      };
+    case 'code':
+      return { ...item };
+    case 'self-evaluation':
+      return {
+        ...item,
+        options: [...item.options],
+      };
+    default: {
+      const exhaustive: never = item;
+      throw new Error('Unsupported content item type');
+    }
+  }
+}

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -12,6 +12,7 @@ import { ClaudeProvider } from '../provider/ClaudeProvider.js';
 import { ContentGenerator } from '../content/ContentGenerator.js';
 import { ContentManager } from '../content/ContentManager.js';
 import { ContentCache } from '../content/ContentCache.js';
+import { copyContentItem } from '../content/copy-utils.js';
 import { Prefetcher } from '../content/Prefetcher.js';
 import type {
   CourseEngineConfig,
@@ -40,47 +41,6 @@ function copyCurriculumPlan(curriculum: CurriculumPlan): CurriculumPlan {
     ...curriculum,
     sections: curriculum.sections.map(copySection),
   };
-}
-
-function copyContentItem(item: ContentItem): ContentItem {
-  switch (item.type) {
-    case 'explanation':
-      return { ...item };
-    case 'multiple-choice':
-      return { ...item, options: [...item.options] };
-    case 'numeric-input':
-      return { ...item };
-    case 'ordering':
-      return {
-        ...item,
-        items: [...item.items],
-        correctOrder: [...item.correctOrder],
-      };
-    case 'multi-select':
-      return {
-        ...item,
-        options: [...item.options],
-        correctIndices: [...item.correctIndices],
-      };
-    case 'two-stage':
-      return {
-        ...item,
-        options: [...item.options],
-        followUpOptions: [...item.followUpOptions],
-      };
-    case 'checklist':
-      return {
-        ...item,
-        items: [...item.items],
-      };
-    case 'code':
-      return { ...item };
-    case 'self-evaluation':
-      return {
-        ...item,
-        options: [...item.options],
-      };
-  }
 }
 
 function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {

--- a/packages/engine/tests/copy-utils.test.ts
+++ b/packages/engine/tests/copy-utils.test.ts
@@ -1,0 +1,113 @@
+// --- Copy Utils Tests ---
+// Shared content-copy behavior is used by both ContentCache and CourseEngine.
+
+import { describe, expect, it } from 'vitest';
+import { copyContentItem } from '../src/content/copy-utils.js';
+import type { ContentItem } from '../src/content/types.js';
+
+const CONTENT_ITEMS: ContentItem[] = [
+  {
+    type: 'explanation',
+    topicId: 'topic-1',
+    title: 'Intro',
+    content: 'A short explanation.',
+  },
+  {
+    type: 'multiple-choice',
+    id: 'q-mc',
+    topicId: 'topic-1',
+    question: 'Pick one.',
+    options: ['A', 'B'],
+    correctIndex: 0,
+  },
+  {
+    type: 'numeric-input',
+    id: 'q-num',
+    topicId: 'topic-1',
+    question: 'What is 2+2?',
+    correctValue: 4,
+    tolerance: 0,
+    unit: 'units',
+  },
+  {
+    type: 'ordering',
+    id: 'q-order',
+    topicId: 'topic-1',
+    question: 'Sort these.',
+    items: ['First', 'Second'],
+    correctOrder: [0, 1],
+  },
+  {
+    type: 'multi-select',
+    id: 'q-ms',
+    topicId: 'topic-1',
+    question: 'Pick all that apply.',
+    options: ['A', 'B', 'C'],
+    correctIndices: [0, 2],
+  },
+  {
+    type: 'two-stage',
+    id: 'q-ts',
+    topicId: 'topic-1',
+    question: 'Stage one?',
+    options: ['Yes', 'No'],
+    correctIndex: 0,
+    followUp: 'Why?',
+    followUpOptions: ['Because', 'Otherwise'],
+    followUpCorrectIndex: 0,
+  },
+  {
+    type: 'checklist',
+    id: 'q-check',
+    topicId: 'topic-1',
+    question: 'Complete the steps.',
+    items: ['Step one', 'Step two'],
+  },
+  {
+    type: 'code',
+    id: 'q-code',
+    topicId: 'topic-1',
+    question: 'Write a function.',
+    language: 'javascript',
+    initialCode: 'function answer() {}',
+    expectedPattern: 'return',
+  },
+  {
+    type: 'self-evaluation',
+    id: 'q-self',
+    topicId: 'topic-1',
+    question: 'How confident are you?',
+    options: ['Need practice', 'Got it'],
+  },
+];
+
+describe('copyContentItem', () => {
+  it.each(CONTENT_ITEMS.map((item) => [item.type, item] as const))(
+    'copies %s content items',
+    (_type, item) => {
+      const copy = copyContentItem(item);
+
+      expect(copy).toEqual(item);
+      expect(copy).not.toBe(item);
+    }
+  );
+
+  it('copies array fields defensively', () => {
+    const itemsWithArrays = CONTENT_ITEMS.filter((item) =>
+      Object.values(item).some(Array.isArray)
+    );
+
+    for (const item of itemsWithArrays) {
+      const original = structuredClone(item) as ContentItem;
+      const copy = copyContentItem(item) as Record<string, unknown>;
+
+      for (const value of Object.values(copy)) {
+        if (Array.isArray(value)) {
+          value.push('mutated');
+        }
+      }
+
+      expect(item).toEqual(original);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Extract shared `copyContentItem` into `packages/engine/src/content/copy-utils.ts`
- Update `ContentCache` and `CourseEngine` to consume the shared helper
- Add direct helper coverage for every content item type and defensive array copying

## Verification

- `pnpm -r test`
- `pnpm -r build`
- `pnpm format`
- `rg -n "function copyContentItem" packages/engine/src packages/engine/tests`

Closes #69