### PR TITLE
chore(engine): bump quiz generation prompt version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Engine:** Pass the engine-owned `StudentModel` into background prefetch generation so cached next-section content uses adaptive quiz burst sizing instead of the default question count
 - **Engine:** Extend quality-filter length-outlier coverage to `checklist` and `self-evaluation` questions, and make all question-type switch branches explicit
 - **Engine:** Extract shared `copyContentItem` utility so `ContentCache` and `CourseEngine` cannot drift when new content item types are added
+- **Engine:** Bump `QUIZ_GENERATION_VERSION` to `1.3` to track the prompt expansion for checklist, code, and self-evaluation questions
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -5,7 +5,7 @@
 
 import type { PromptMessages } from './types.js';
 
-export const QUIZ_GENERATION_VERSION = '1.2';
+export const QUIZ_GENERATION_VERSION = '1.3';
 
 // --- Tool Schema ---
 

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -80,7 +80,7 @@ describe('explanation prompt', () => {
 
 describe('quiz generation prompt', () => {
   it('exports version constant', () => {
-    expect(QUIZ_GENERATION_VERSION).toBe('1.2');
+    expect(QUIZ_GENERATION_VERSION).toBe('1.3');
   });
 
   it('builds prompt with topic and explanation context', () => {


### PR DESCRIPTION
Closes #70

## Summary
- Bump `QUIZ_GENERATION_VERSION` from `1.2` to `1.3`
- Update the existing prompt version test assertion
- Record the metadata bump in `CHANGELOG.md`

## Verification
- `pnpm --filter quizzer-engine test -- content-generator.test.ts`
- `pnpm -r test`
- `pnpm -r build`
- `pnpm format`