### PR TITLE
refactor(engine/app): add API call event correlation ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Engine:** Extend quality-filter length-outlier coverage to `checklist` and `self-evaluation` questions, and make all question-type switch branches explicit
 - **Engine:** Extract shared `copyContentItem` utility so `ContentCache` and `CourseEngine` cannot drift when new content item types are added
 - **Engine:** Bump `QUIZ_GENERATION_VERSION` to `1.3` to track the prompt expansion for checklist, code, and self-evaluation questions
+- **Engine/App:** Add correlation ids to `apiCallStart` and `apiCallComplete` events, and keep app loading state tied to active API call ids
 
 ## 0.9.0 — 2026-05-10
 

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -106,6 +106,7 @@ export function createEngineSession(config: EngineSessionConfig) {
   let studentState = $state<StudentState | null>(null);
   let progress = $state<SessionProgress | null>(null);
   let apiLoading = $state(false);
+  const activeApiCallIds = new Set<string>();
   let error = $state<ErrorInfo | null>(initialError);
 
   // If restoring successfully, sync initial state from snapshot
@@ -168,12 +169,14 @@ export function createEngineSession(config: EngineSessionConfig) {
     autoSave();
   };
 
-  const onApiCallStart: Listener<'apiCallStart'> = () => {
+  const onApiCallStart: Listener<'apiCallStart'> = (payload) => {
+    activeApiCallIds.add(payload.id);
     apiLoading = true;
   };
 
-  const onApiCallComplete: Listener<'apiCallComplete'> = () => {
-    apiLoading = false;
+  const onApiCallComplete: Listener<'apiCallComplete'> = (payload) => {
+    activeApiCallIds.delete(payload.id);
+    apiLoading = activeApiCallIds.size > 0;
   };
 
   const onError: Listener<'error'> = (payload) => {
@@ -319,6 +322,7 @@ export function createEngineSession(config: EngineSessionConfig) {
       lastResult = null;
       studentState = null;
       progress = null;
+      activeApiCallIds.clear();
       apiLoading = false;
       error = null;
     },

--- a/apps/coursequizzer/tests/unit/engine-session-api-loading.test.ts
+++ b/apps/coursequizzer/tests/unit/engine-session-api-loading.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ApiCallPayload = {
+  id: string;
+  purpose: string;
+};
+
+type EventListener = (payload: unknown) => void;
+
+let listeners: Map<string, EventListener[]>;
+
+class MockCourseEngine {
+  state = 'idle';
+  curriculum = null;
+
+  constructor(_config: unknown) {}
+
+  on(event: string, listener: EventListener): void {
+    listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+  }
+
+  off(event: string, listener: EventListener): void {
+    listeners.set(
+      event,
+      (listeners.get(event) ?? []).filter(
+        (currentListener) => currentListener !== listener
+      )
+    );
+  }
+}
+
+function emitApiEvent(
+  event: 'apiCallStart' | 'apiCallComplete',
+  payload: ApiCallPayload
+): void {
+  for (const listener of listeners.get(event) ?? []) {
+    listener(payload);
+  }
+}
+
+describe('createEngineSession API loading state', () => {
+  beforeEach(() => {
+    listeners = new Map();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock('quizzer-engine');
+  });
+
+  it('stays loading until every active API call id completes', async () => {
+    vi.doMock('quizzer-engine', () => ({
+      CourseEngine: MockCourseEngine,
+    }));
+
+    const { createEngineSession } =
+      await import('../../src/lib/stores/engine-session.svelte.js');
+
+    const session = createEngineSession({ apiKey: 'test-key' });
+
+    emitApiEvent('apiCallStart', { id: 'api-call-1', purpose: 'Explanation' });
+    emitApiEvent('apiCallStart', { id: 'api-call-2', purpose: 'Quiz' });
+    expect(session.apiLoading).toBe(true);
+
+    emitApiEvent('apiCallComplete', { id: 'api-call-1', purpose: 'Explanation' });
+    expect(session.apiLoading).toBe(true);
+
+    emitApiEvent('apiCallComplete', { id: 'api-call-2', purpose: 'Quiz' });
+    expect(session.apiLoading).toBe(false);
+  });
+});

--- a/packages/engine/src/content/ContentManager.ts
+++ b/packages/engine/src/content/ContentManager.ts
@@ -5,6 +5,7 @@ import type { ContentItem } from './types.js';
 import type { ContentGenerator } from './ContentGenerator.js';
 
 export type ApiCallEventHandler = (payload: {
+  id: string;
   purpose: string;
   status: 'start' | 'complete';
 }) => void;
@@ -16,6 +17,7 @@ export type ApiCallEventHandler = (payload: {
 export class ContentManager {
   #generator: ContentGenerator;
   #onApiCall: ApiCallEventHandler;
+  #apiCallSequence = 0;
 
   constructor(generator: ContentGenerator, onApiCall: ApiCallEventHandler) {
     this.#generator = generator;
@@ -36,49 +38,42 @@ export class ContentManager {
 
     for (const topic of section.topics) {
       // 1. Explanation
-      this.#onApiCall({
-        purpose: `Explanation for topic: ${topic.title}`,
-        status: 'start',
-      });
-      let explanation;
-      try {
-        explanation = await this.#generator.generateTopicExplanation(
-          topic,
-          courseTitle,
-          section.title
-        );
-      } finally {
-        this.#onApiCall({
-          purpose: `Explanation for topic: ${topic.title}`,
-          status: 'complete',
-        });
-      }
+      const explanation = await this.#withApiCall(
+        `Explanation for topic: ${topic.title}`,
+        () => this.#generator.generateTopicExplanation(topic, courseTitle, section.title)
+      );
       items.push(explanation);
 
       // 2. Quiz Burst
-      this.#onApiCall({
-        purpose: `Quiz for topic: ${topic.title}`,
-        status: 'start',
-      });
-      try {
+      const questions = await this.#withApiCall(`Quiz for topic: ${topic.title}`, () => {
         const questionCount =
           adaptiveSelector?.getTopicConfig(topic.id).targetQuestionCount ?? 3;
-        const questions = await this.#generator.generateTopicQuizBurst(
+        return this.#generator.generateTopicQuizBurst(
           topic,
           courseTitle,
           section.title,
           explanation.content,
           questionCount
         );
-        items.push(...questions);
-      } finally {
-        this.#onApiCall({
-          purpose: `Quiz for topic: ${topic.title}`,
-          status: 'complete',
-        });
-      }
+      });
+      items.push(...questions);
     }
 
     return items;
+  }
+
+  async #withApiCall<T>(purpose: string, generate: () => Promise<T>): Promise<T> {
+    const id = this.#nextApiCallId();
+    this.#onApiCall({ id, purpose, status: 'start' });
+    try {
+      return await generate();
+    } finally {
+      this.#onApiCall({ id, purpose, status: 'complete' });
+    }
+  }
+
+  #nextApiCallId(): string {
+    this.#apiCallSequence += 1;
+    return `api-call-${this.#apiCallSequence}`;
   }
 }

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -120,9 +120,9 @@ export class CourseEngine extends EventEmitter {
 
     this.#contentManager = new ContentManager(generator, (payload) => {
       if (payload.status === 'start') {
-        this.emit('apiCallStart', { purpose: payload.purpose });
+        this.emit('apiCallStart', { id: payload.id, purpose: payload.purpose });
       } else {
-        this.emit('apiCallComplete', { purpose: payload.purpose });
+        this.emit('apiCallComplete', { id: payload.id, purpose: payload.purpose });
       }
     });
 

--- a/packages/engine/src/engine/events.ts
+++ b/packages/engine/src/engine/events.ts
@@ -13,6 +13,11 @@ import type {
 import type { StudentState, SessionProgress } from '../student/types.js';
 import type { EngineState } from './types.js';
 
+export type ApiCallEvent = {
+  id: string;
+  purpose: string;
+};
+
 export type EngineEventMap = {
   stateChange: { from: EngineState; to: EngineState };
   error: { message: string; recoverable: boolean };
@@ -44,8 +49,8 @@ export type EngineEventMap = {
   };
 
   // --- API activity (for loading indicators) ---
-  apiCallStart: { purpose: string };
-  apiCallComplete: { purpose: string };
+  apiCallStart: ApiCallEvent;
+  apiCallComplete: ApiCallEvent;
 };
 
 export type EngineEvent = keyof EngineEventMap;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -31,7 +31,12 @@ export type {
   TopicMastery,
 } from './engine/types.js';
 
-export type { EngineEvent, EngineEventMap, Listener } from './engine/events.js';
+export type {
+  ApiCallEvent,
+  EngineEvent,
+  EngineEventMap,
+  Listener,
+} from './engine/events.js';
 
 export type { Topic } from './curriculum/types.js';
 

--- a/packages/engine/tests/content-manager.test.ts
+++ b/packages/engine/tests/content-manager.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ContentManager } from '../src/content/ContentManager.js';
+import {
+  ContentManager,
+  type ApiCallEventHandler,
+} from '../src/content/ContentManager.js';
 import { StudentModel } from '../src/student/StudentModel.js';
 import type { ContentGenerator } from '../src/content/ContentGenerator.js';
 import type { Section, Topic } from '../src/curriculum/types.js';
@@ -7,6 +10,7 @@ import type { Section, Topic } from '../src/curriculum/types.js';
 describe('ContentManager', () => {
   const TOPIC: Topic = { id: 't1', title: 'Topic 1', description: 'Desc 1' };
   const SECTION: Section = { id: 's1', title: 'Section 1', order: 0, topics: [TOPIC] };
+  type ApiCallEvent = Parameters<ApiCallEventHandler>[0];
 
   it('orchestrates generation and emits events', async () => {
     const generator = {
@@ -28,8 +32,8 @@ describe('ContentManager', () => {
       ]),
     } as unknown as ContentGenerator;
 
-    const events: any[] = [];
-    const onApiCall = (payload: any) => events.push(payload);
+    const events: ApiCallEvent[] = [];
+    const onApiCall: ApiCallEventHandler = (payload) => events.push(payload);
 
     const manager = new ContentManager(generator, onApiCall);
     const items = await manager.generateSection(SECTION, 'Course');
@@ -44,12 +48,46 @@ describe('ContentManager', () => {
 
     expect(events).toHaveLength(4); // Start/Complete for explanation, Start/Complete for quiz
     expect(events[0]).toEqual({
+      id: 'api-call-1',
       purpose: 'Explanation for topic: Topic 1',
       status: 'start',
     });
     expect(events[1].status).toBe('complete');
     expect(events[2].purpose).toContain('Quiz');
     expect(events[2].status).toBe('start');
+  });
+
+  it('emits matching ids for each start and complete event pair', async () => {
+    const generator = {
+      generateTopicExplanation: vi.fn().mockResolvedValue({
+        type: 'explanation',
+        topicId: 't1',
+        title: 'Exp',
+        content: 'Content',
+      }),
+      generateTopicQuizBurst: vi.fn().mockResolvedValue([]),
+    } as unknown as ContentGenerator;
+
+    const events: ApiCallEvent[] = [];
+    const onApiCall: ApiCallEventHandler = (payload) => events.push(payload);
+
+    const manager = new ContentManager(generator, onApiCall);
+    await manager.generateSection(SECTION, 'Course');
+
+    const eventsById = new Map<string, ApiCallEvent[]>();
+    for (const event of events) {
+      eventsById.set(event.id, [...(eventsById.get(event.id) ?? []), event]);
+    }
+
+    expect(eventsById.size).toBe(2);
+    for (const relatedEvents of eventsById.values()) {
+      expect(relatedEvents).toHaveLength(2);
+      expect(relatedEvents.map((event) => event.status).sort()).toEqual([
+        'complete',
+        'start',
+      ]);
+      expect(new Set(relatedEvents.map((event) => event.purpose)).size).toBe(1);
+    }
   });
 
   it('passes adaptive question counts into quiz generation', async () => {
@@ -92,8 +130,8 @@ describe('ContentManager', () => {
       generateTopicExplanation: vi.fn().mockRejectedValue(new Error('API Failure')),
     } as unknown as ContentGenerator;
 
-    const events: any[] = [];
-    const onApiCall = (payload: any) => events.push(payload);
+    const events: ApiCallEvent[] = [];
+    const onApiCall: ApiCallEventHandler = (payload) => events.push(payload);
 
     const manager = new ContentManager(generator, onApiCall);
     await expect(manager.generateSection(SECTION, 'Course')).rejects.toThrow(
@@ -103,5 +141,6 @@ describe('ContentManager', () => {
     expect(events).toHaveLength(2);
     expect(events[0].status).toBe('start');
     expect(events[1].status).toBe('complete');
+    expect(events[1].id).toBe(events[0].id);
   });
 });

--- a/packages/engine/tests/engine.test.ts
+++ b/packages/engine/tests/engine.test.ts
@@ -684,6 +684,7 @@ describe('async lifecycle and events', () => {
 
     // Should have started explanation for first topic
     expect(apiEvents).toHaveLength(1);
+    expect(apiEvents[0].id).toBe('api-call-1');
     expect(apiEvents[0].purpose).toContain('Explanation');
 
     // Resolve explanation
@@ -696,7 +697,10 @@ describe('async lifecycle and events', () => {
     await new Promise((r) => setTimeout(r, 0)); // let microtasks run
 
     expect(completeEvents).toHaveLength(1);
+    expect(completeEvents[0].id).toBe(apiEvents[0].id);
     expect(apiEvents).toHaveLength(2); // Should have started quiz
+    expect(apiEvents[1].id).toBe('api-call-2');
+    expect(apiEvents[1].id).not.toBe(apiEvents[0].id);
     expect(apiEvents[1].purpose).toContain('Quiz');
 
     // Resolve quiz
@@ -704,6 +708,7 @@ describe('async lifecycle and events', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(completeEvents).toHaveLength(2);
+    expect(completeEvents[1].id).toBe(apiEvents[1].id);
   });
 
   it('transitions to error state and emits error on generation failure', async () => {


### PR DESCRIPTION
Closes #72

## Summary
- add stable ids to engine apiCallStart/apiCallComplete event payloads
- centralize ContentManager API event pairing so complete events reuse the start id
- track active API call ids in the app session store so loading stays true until all calls finish

## Verification
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format