### PR TITLE
fix(scripts): portable worktree paths for author/reviewer (Mac unblock)

### DIFF
--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -13,7 +13,10 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKTREE="/home/nhoj/Documents/learning/cq-author"
+# Default: a sibling directory of the repo (e.g., $REPO_ROOT/../cq-author).
+# Override via CQ_WORKTREE_AUTHOR when the default doesn't fit (different
+# layout on a second factory node, etc.).
+WORKTREE="${CQ_WORKTREE_AUTHOR:-$REPO_ROOT/../cq-author}"
 PROMPT_FILE="$SCRIPT_DIR/prompts/author.md"
 LOGDIR="$REPO_ROOT/logs/author"
 ERRORLOG="$REPO_ROOT/logs/author-errors.log"

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -13,7 +13,10 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKTREE="/home/nhoj/Documents/learning/cq-reviewer"
+# Default: a sibling directory of the repo (e.g., $REPO_ROOT/../cq-reviewer).
+# Override via CQ_WORKTREE_REVIEWER when the default doesn't fit (different
+# layout on a second factory node, etc.).
+WORKTREE="${CQ_WORKTREE_REVIEWER:-$REPO_ROOT/../cq-reviewer}"
 PROMPT_FILE="$SCRIPT_DIR/prompts/reviewer.md"
 LOGDIR="$REPO_ROOT/logs/reviewer"
 ERRORLOG="$REPO_ROOT/logs/reviewer-errors.log"


### PR DESCRIPTION
## Summary

`scripts/author.sh` and `scripts/reviewer.sh` hardcoded a Linux-specific worktree path:

```bash
WORKTREE=\"/home/nhoj/Documents/learning/cq-author\"
```

On the Mac that path doesn't exist, so `git worktree add` fails, `cd` fails, and the script just spins logging \"no such file or directory\" each iteration. `set -uo pipefail` without `-e` means the agent doesn't die — it just does no useful work.

This PR makes the path computed from `$REPO_ROOT`, overridable via env var (`CQ_WORKTREE_AUTHOR`, `CQ_WORKTREE_REVIEWER`). Matches the pattern `audit.sh` already uses with `CQ_WORKTREE_AUDIT`.

## Why this is safe

- **Linux laptop:** `$REPO_ROOT` = `/home/nhoj/Documents/learning/course-quizzer`, so the default `$REPO_ROOT/../cq-author` resolves to the exact path that was previously hardcoded. Computed value is identical to the literal it replaces — running laptop agents are unaffected.
- **Mac:** `$REPO_ROOT` = wherever the user cloned the repo, so the worktree lands as a sibling directory automatically. No env var needed for typical layouts.
- **Other layouts:** the env vars are the escape hatch (multiple checkouts on the same host, shared drives, etc.).

## Validation

- `bash -n` passes on both files
- Diff is the WORKTREE assignment only

## Mac restart instructions

After this merges, on the Mac:

```bash
# In the Mac's main repo clone:
git pull
# Kill the broken agents:
kill \$(cat /tmp/cq-author.lock) \$(cat /tmp/cq-reviewer.lock) 2>/dev/null
# Relaunch — the new script will create the cq-author / cq-reviewer worktrees
# as siblings of the repo automatically:
nohup ./scripts/author.sh > /tmp/cq-author.log 2>&1 &
nohup ./scripts/reviewer.sh > /tmp/cq-reviewer.log 2>&1 &
```

The Linux laptop agents do **not** need to restart — the computed default is identical to the old hardcoded value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)