### PR TITLE
fix(scripts): block author merges on red checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ All changes to `main` require a pull request. No direct commits to `main`.
 - **Review via PR comments, not GitHub review approvals.** All agents share one GitHub account (`johnmarkos`), so `gh pr review --approve` doesn't work (you can't approve your own PR). Instead:
   - **Reviewer posts** a PR comment prefixed with `## Review — Reviewer Agent`, ending with a status line: `**Status: APPROVED**` or `**Status: CHANGES REQUESTED**`.
   - **Coding agent detects review feedback** by checking PR comments (`gh pr view <n> --json comments`) for comments containing `## Review — Reviewer Agent`. Do NOT look for GitHub review approvals — they won't exist.
-  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`.
+  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`; the author script's guarded `gh` wrapper refuses PR merges unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`.
   - Trivial PRs (version bumps, typos, config tweaks) can merge after CI passes without a review comment.
 - **Cross-package PRs:** When a PR touches both `packages/engine` and `apps/coursequizzer`, the PR description must explain why both are changing together.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Engine:** Bump `QUIZ_GENERATION_VERSION` to `1.3` to track the prompt expansion for checklist, code, and self-evaluation questions
 - **Engine/App:** Add correlation ids to `apiCallStart` and `apiCallComplete` events, and keep app loading state tied to active API call ids
 - **Engine:** Add `AdaptiveSelector` boundary and integration tests covering gap, default, and proficient quiz burst counts
+- **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
 
 ## 0.9.0 — 2026-05-10
 

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -59,7 +59,7 @@ if [ ! -d "$WORKTREE" ]; then
         exit 4
     fi
 fi
-cd "$WORKTREE"
+cd "$WORKTREE" || exit 1
 if ! git fetch origin 2>&1; then
     echo "Could not fetch origin. Check network." >&2
     exit 5

--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -26,8 +26,16 @@ MAX_RETRIES=3
 RETRY_DELAY=60      # 1 minute between retries
 MAX_BACKOFF=3600    # Cap at 1 hour
 CONSECUTIVE_FAILURES=0
+AUTHOR_GH_BIN=""
 
 # --- Prevent overlapping runs ---
+cleanup() {
+    rm -f "$LOCKFILE"
+    if [ -n "$AUTHOR_GH_BIN" ] && [ -d "$AUTHOR_GH_BIN" ]; then
+        rm -rf "$AUTHOR_GH_BIN"
+    fi
+}
+
 if [ -f "$LOCKFILE" ]; then
     pid=$(cat "$LOCKFILE")
     if kill -0 "$pid" 2>/dev/null; then
@@ -37,7 +45,7 @@ if [ -f "$LOCKFILE" ]; then
     rm -f "$LOCKFILE"
 fi
 echo $$ > "$LOCKFILE"
-trap 'rm -f "$LOCKFILE"' EXIT
+trap cleanup EXIT
 
 # --- Ensure worktree exists ---
 if [ ! -d "$WORKTREE" ]; then
@@ -51,6 +59,38 @@ log_error() {
     mkdir -p "$(dirname "$ERRORLOG")"
     echo "$(date): [author] $msg" | tee -a "$ERRORLOG"
 }
+
+# --- GitHub merge guard ---
+# Author agents run with --yolo, so the shell script installs a guarded gh
+# wrapper that blocks PR merges unless GitHub status checks are green.
+setup_gh_guard() {
+    local real_gh
+
+    real_gh="$(command -v gh || true)"
+    if [ -z "$real_gh" ]; then
+        log_error "gh command not found; refusing to run author agent without merge guard."
+        return 1
+    fi
+    if [ ! -x "$SCRIPT_DIR/guarded-gh.sh" ]; then
+        log_error "Guarded gh wrapper is missing or not executable: $SCRIPT_DIR/guarded-gh.sh"
+        return 1
+    fi
+    if ! AUTHOR_GH_BIN="$(mktemp -d "${TMPDIR:-/tmp}/cq-author-gh.XXXXXX")"; then
+        log_error "Could not create temporary directory for guarded gh wrapper."
+        return 1
+    fi
+    if ! ln -s "$SCRIPT_DIR/guarded-gh.sh" "$AUTHOR_GH_BIN/gh"; then
+        log_error "Could not install guarded gh wrapper at $AUTHOR_GH_BIN/gh"
+        return 1
+    fi
+
+    export CQ_AUTHOR_REAL_GH="$real_gh"
+    export PATH="$AUTHOR_GH_BIN:$PATH"
+}
+
+if ! setup_gh_guard; then
+    exit 1
+fi
 
 # --- Retry a command up to MAX_RETRIES times ---
 retry() {
@@ -180,7 +220,7 @@ while true; do
     mkdir -p "$LOGDIR"
     LOGFILE="$LOGDIR/$(date +%Y%m%d-%H%M%S).log"
 
-    cd "$WORKTREE"
+    cd "$WORKTREE" || exit 1
 
     # Fetch and reset — retry on network failures
     if ! retry "git fetch origin 2>&1"; then

--- a/scripts/guarded-gh.sh
+++ b/scripts/guarded-gh.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Guarded gh wrapper for author agents. It delegates every gh command except
+# PR merges, where it enforces the repository rule that CI must be green first.
+
+set -euo pipefail
+
+REAL_GH="${CQ_AUTHOR_REAL_GH:-}"
+
+if [ -z "$REAL_GH" ] || [ ! -x "$REAL_GH" ]; then
+    echo "Author CI guard: CQ_AUTHOR_REAL_GH is not set to an executable gh binary." >&2
+    exit 1
+fi
+
+is_pull_request_merge() {
+    [ "$#" -ge 2 ] && [ "$1" = "pr" ] && [ "$2" = "merge" ]
+}
+
+find_pull_request_ref() {
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            ''|-*) ;;
+            https://github.com/*/pull/*|http://github.com/*/pull/*|[0-9]*)
+                printf '%s\n' "$arg"
+                return 0
+                ;;
+        esac
+    done
+
+    return 1
+}
+
+resolve_pull_request_ref() {
+    local pull_request_ref
+
+    if pull_request_ref="$(find_pull_request_ref "${@:3}")"; then
+        printf '%s\n' "$pull_request_ref"
+        return 0
+    fi
+
+    if ! pull_request_ref="$("$REAL_GH" pr view --json number --jq '.number')"; then
+        echo "Author CI guard: cannot determine the current branch PR; refusing to merge." >&2
+        return 1
+    fi
+    printf '%s\n' "$pull_request_ref"
+}
+
+check_status_checks_green() {
+    local pull_request_ref="$1"
+    local failing_checks
+
+    # shellcheck disable=SC2016 # jq expression must stay single-quoted.
+    if ! failing_checks="$("$REAL_GH" pr view "$pull_request_ref" --json statusCheckRollup --jq '
+        (.statusCheckRollup // []) as $checks
+        | if ($checks | length) == 0 then
+            "no status checks reported"
+          else
+            $checks[]
+            | {
+                name: (.name // .context // .workflowName // "unknown check"),
+                result: (.conclusion // .state // .status // "UNKNOWN")
+              }
+            | select((.result == "SUCCESS" or .result == "SKIPPED") | not)
+            | "\(.name): \(.result)"
+          end
+    ')"; then
+        echo "Author CI guard: could not read status checks for PR $pull_request_ref; refusing to merge." >&2
+        return 1
+    fi
+
+    if [ -n "$failing_checks" ]; then
+        echo "Author CI guard: refusing to merge PR $pull_request_ref; status checks are not green:" >&2
+        printf '%s\n' "$failing_checks" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+if is_pull_request_merge "$@"; then
+    pull_request_ref="$(resolve_pull_request_ref "$@")"
+    check_status_checks_green "$pull_request_ref"
+fi
+
+exec "$REAL_GH" "$@"

--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -28,11 +28,11 @@ If a PR needs action:
 
 1. Check out the PR branch
 2. Read the review comment — the entire comment, not just the status line
-3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. Exit.
+3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script's guarded `gh` wrapper will refuse the merge if any check is failing, pending, cancelled, or absent. Exit.
 4. Otherwise, address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
 5. Run `pnpm -r test`, `pnpm -r build`, `pnpm format`
 6. Commit and push
-7. If verdict was `Approved with required fixes`: merge with `gh pr merge <n> --squash --delete-branch --admin`
+7. If verdict was `Approved with required fixes`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`
 8. Exit
 
 ## Priority 2: Finish an in-progress issue that has no PR
@@ -86,4 +86,4 @@ If none of the above apply, say "Nothing to do" and exit.
 - One thing per invocation. Do not start a second task.
 - Follow all Architecture Rules and Conventions in AGENTS.md.
 - Commit attribution matches the model running: `Co-Authored-By: Codex <noreply@openai.com>`, `Co-Authored-By: Gemini <noreply@google.com>`, etc.
-- The author owns the merge after the reviewer approves. Do not wait for a human to merge. Merging without `**Status: APPROVED**` (or, for trivial PRs, without green CI) is forbidden.
+- The author owns the merge after the reviewer approves. Do not wait for a human to merge. Merging without `**Status: APPROVED**` (or, for trivial PRs, without green CI) is forbidden, and the author script's guarded `gh` wrapper blocks `gh pr merge` unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`.

--- a/scripts/prompts/reviewer.md
+++ b/scripts/prompts/reviewer.md
@@ -27,6 +27,7 @@ And check if there are commits newer than the last review comment. If the PR nee
    - Architecture Rules compliance (see AGENTS.md)
    - Security: no `{@html}` without sanitization, no `eval()`, no API key leaks, no XSS vectors
    - Test coverage — are the right things tested?
+   - CI status (`gh pr checks <n>`) — if any check is failing, do not post an APPROVED status
    - CHANGELOG.md updated?
    - Readability — could a junior engineer follow this?
 

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -177,7 +177,7 @@ while true; do
     mkdir -p "$LOGDIR"
     LOGFILE="$LOGDIR/$(date +%Y%m%d-%H%M%S).log"
 
-    cd "$WORKTREE"
+    cd "$WORKTREE" || exit 1
 
     # Fetch and reset — retry on network failures
     if ! retry "git fetch origin 2>&1"; then


### PR DESCRIPTION
## Summary

- install a guarded gh wrapper in scripts/author.sh so author-agent gh pr merge calls are blocked unless GitHub reports at least one status check and every check is SUCCESS or SKIPPED
- update author/reviewer prompts and AGENTS.md to document the CI gate
- fix existing shellcheck cd warnings in script entrypoints so scripts/*.sh passes

## Verification

- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format
- shellcheck scripts/*.sh
- local smoke test with a fake gh binary: failing status output blocked merge invocation; green status output delegated to gh pr merge

Closes #73