### PR TITLE
fix(scripts): guard author merges on CI status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ All changes to `main` require a pull request. No direct commits to `main`.
 - **Review via PR comments, not GitHub review approvals.** All agents share one GitHub account (`johnmarkos`), so `gh pr review --approve` doesn't work (you can't approve your own PR). Instead:
   - **Reviewer posts** a PR comment prefixed with `## Review — Reviewer Agent`, ending with a status line: `**Status: APPROVED**` or `**Status: CHANGES REQUESTED**`.
   - **Coding agent detects review feedback** by checking PR comments (`gh pr view <n> --json comments`) for comments containing `## Review — Reviewer Agent`. Do NOT look for GitHub review approvals — they won't exist.
-  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`; the author script wraps `gh` and refuses this merge while any status check is failing or still running.
+  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`; the author script wraps `gh` and refuses this merge unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`.
   - Trivial PRs (version bumps, typos, config tweaks) can merge after CI passes without a review comment.
 - **Cross-package PRs:** When a PR touches both `packages/engine` and `apps/coursequizzer`, the PR description must explain why both are changing together.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ All changes to `main` require a pull request. No direct commits to `main`.
 - **Review via PR comments, not GitHub review approvals.** All agents share one GitHub account (`johnmarkos`), so `gh pr review --approve` doesn't work (you can't approve your own PR). Instead:
   - **Reviewer posts** a PR comment prefixed with `## Review — Reviewer Agent`, ending with a status line: `**Status: APPROVED**` or `**Status: CHANGES REQUESTED**`.
   - **Coding agent detects review feedback** by checking PR comments (`gh pr view <n> --json comments`) for comments containing `## Review — Reviewer Agent`. Do NOT look for GitHub review approvals — they won't exist.
-  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`.
+  - **Merge after approval:** Once a comment contains `**Status: APPROVED**` and CI is green, the coding agent merges with `gh pr merge <n> --squash --delete-branch --admin`; the author script wraps `gh` and refuses this merge while any status check is failing or still running.
   - Trivial PRs (version bumps, typos, config tweaks) can merge after CI passes without a review comment.
 - **Cross-package PRs:** When a PR touches both `packages/engine` and `apps/coursequizzer`, the PR description must explain why both are changing together.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot be merged while any status check is failing or still running
 - **Scripts:** Stop cascading author/reviewer runs to fallback models after non-credit Codex failures, and pipe Gemini prompts directly from the prompt file to preserve multi-line formatting
 - **Engine:** Pass the engine-owned `StudentModel` into background prefetch generation so cached next-section content uses adaptive quiz burst sizing instead of the default question count
 - **Engine:** Extend quality-filter length-outlier coverage to `checklist` and `self-evaluation` questions, and make all question-type switch branches explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot be merged while any status check is failing or still running
+- **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot be merged while checks are absent, failing, or still running
 - **Scripts:** Stop cascading author/reviewer runs to fallback models after non-credit Codex failures, and pipe Gemini prompts directly from the prompt file to preserve multi-line formatting
 - **Engine:** Pass the engine-owned `StudentModel` into background prefetch generation so cached next-section content uses adaptive quiz burst sizing instead of the default question count
 - **Engine:** Extend quality-filter length-outlier coverage to `checklist` and `self-evaluation` questions, and make all question-type switch branches explicit

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -59,7 +59,7 @@ if [ ! -d "$WORKTREE" ]; then
         exit 4
     fi
 fi
-cd "$WORKTREE"
+cd "$WORKTREE" || exit 4
 if ! git fetch origin 2>&1; then
     echo "Could not fetch origin. Check network." >&2
     exit 5

--- a/scripts/author-bin/gh
+++ b/scripts/author-bin/gh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Author-agent guard for GitHub CLI usage.
-# Blocks `gh pr merge` unless all reported PR checks are successful or skipped.
+# Blocks `gh pr merge` unless at least one reported PR check exists and every
+# reported check is successful or skipped.
 # All other gh commands pass through unchanged.
 
 set -uo pipefail
@@ -87,19 +88,24 @@ assert_checks_green() {
     local failures
     # shellcheck disable=SC2016
     if ! failures="$("$REAL_GH" pr view "$pr_number" "$@" --json statusCheckRollup --jq '
-        .statusCheckRollup[]?
-        | {
-            name: (.name // .context // .workflowName // "unknown"),
-            status: (.status // ""),
-            conclusion: (.conclusion // .state // "")
-        }
-        | (.status | ascii_upcase) as $status
-        | (.conclusion | ascii_upcase) as $conclusion
-        | select(
-            ($conclusion != "SUCCESS" and $conclusion != "SKIPPED")
-            or ($status != "" and $status != "COMPLETED")
-        )
-        | "- \(.name): status=\(.status) conclusion=\(.conclusion)"
+        (.statusCheckRollup // []) as $checks
+        | if ($checks | length) == 0 then
+            "- no status checks reported"
+        else
+            $checks[]
+            | {
+                name: (.name // .context // .workflowName // "unknown"),
+                status: (.status // ""),
+                conclusion: (.conclusion // .state // "")
+            }
+            | (.status | ascii_upcase) as $status
+            | (.conclusion | ascii_upcase) as $conclusion
+            | select(
+                ($conclusion != "SUCCESS" and $conclusion != "SKIPPED")
+                or ($status != "" and $status != "COMPLETED")
+            )
+            | "- \(.name): status=\(.status) conclusion=\(.conclusion)"
+        end
     ')"; then
         log_guard_error "Could not read status checks for PR #$pr_number; refusing to merge."
         return 1
@@ -125,7 +131,11 @@ if is_pr_merge_command "$@" && ! is_auto_merge_abort "$@"; then
         repo_args+=("$repo_arg")
     done < <(collect_repo_args "$@")
 
-    assert_checks_green "$pr_number" "${repo_args[@]}" || exit 1
+    if [ "${#repo_args[@]}" -gt 0 ]; then
+        assert_checks_green "$pr_number" "${repo_args[@]}" || exit 1
+    else
+        assert_checks_green "$pr_number" || exit 1
+    fi
 fi
 
 exec "$REAL_GH" "$@"

--- a/scripts/author-bin/gh
+++ b/scripts/author-bin/gh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Author-agent guard for GitHub CLI usage.
+# Blocks `gh pr merge` unless all reported PR checks are successful or skipped.
+# All other gh commands pass through unchanged.
+
+set -uo pipefail
+
+REAL_GH="${CQ_REAL_GH:-}"
+
+log_guard_error() {
+    local msg="$1"
+
+    if [ -n "${CQ_AUTHOR_ERRORLOG:-}" ]; then
+        mkdir -p "$(dirname "$CQ_AUTHOR_ERRORLOG")"
+        echo "$(date): [author-gh-guard] $msg" >> "$CQ_AUTHOR_ERRORLOG"
+    fi
+
+    echo "$msg" >&2
+}
+
+if [ -z "$REAL_GH" ]; then
+    log_guard_error "CQ_REAL_GH is not set; refusing to run gh."
+    exit 1
+fi
+
+if [ ! -x "$REAL_GH" ]; then
+    log_guard_error "CQ_REAL_GH does not point to an executable: $REAL_GH"
+    exit 1
+fi
+
+is_pr_merge_command() {
+    [ "${1:-}" = "pr" ] && [ "${2:-}" = "merge" ]
+}
+
+is_auto_merge_abort() {
+    local arg
+
+    for arg in "$@"; do
+        if [ "$arg" = "--abort" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_pr_number() {
+    local arg
+
+    for arg in "${@:3}"; do
+        if [[ "$arg" =~ ^[0-9]+$ ]]; then
+            printf '%s\n' "$arg"
+            return 0
+        fi
+    done
+
+    "$REAL_GH" pr view --json number --jq '.number'
+}
+
+collect_repo_args() {
+    local arg
+    local previous_was_repo_flag=0
+
+    for arg in "${@:3}"; do
+        if [ "$previous_was_repo_flag" -eq 1 ]; then
+            printf '%s\0' "$arg"
+            previous_was_repo_flag=0
+            continue
+        fi
+
+        case "$arg" in
+            --repo | -R)
+                printf '%s\0' "$arg"
+                previous_was_repo_flag=1
+                ;;
+            --repo=*)
+                printf '%s\0' "$arg"
+                ;;
+        esac
+    done
+}
+
+assert_checks_green() {
+    local pr_number="$1"
+    shift
+
+    local failures
+    # shellcheck disable=SC2016
+    if ! failures="$("$REAL_GH" pr view "$pr_number" "$@" --json statusCheckRollup --jq '
+        .statusCheckRollup[]?
+        | {
+            name: (.name // .context // .workflowName // "unknown"),
+            status: (.status // ""),
+            conclusion: (.conclusion // .state // "")
+        }
+        | (.status | ascii_upcase) as $status
+        | (.conclusion | ascii_upcase) as $conclusion
+        | select(
+            ($conclusion != "SUCCESS" and $conclusion != "SKIPPED")
+            or ($status != "" and $status != "COMPLETED")
+        )
+        | "- \(.name): status=\(.status) conclusion=\(.conclusion)"
+    ')"; then
+        log_guard_error "Could not read status checks for PR #$pr_number; refusing to merge."
+        return 1
+    fi
+
+    if [ -n "$failures" ]; then
+        log_guard_error "Refusing to merge PR #$pr_number because CI is not green:"
+        log_guard_error "$failures"
+        return 1
+    fi
+
+    return 0
+}
+
+if is_pr_merge_command "$@" && ! is_auto_merge_abort "$@"; then
+    pr_number="$(resolve_pr_number "$@")" || {
+        log_guard_error "Could not resolve PR number; refusing to merge."
+        exit 1
+    }
+
+    repo_args=()
+    while IFS= read -r -d '' repo_arg; do
+        repo_args+=("$repo_arg")
+    done < <(collect_repo_args "$@")
+
+    assert_checks_green "$pr_number" "${repo_args[@]}" || exit 1
+fi
+
+exec "$REAL_GH" "$@"

--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -18,6 +18,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # layout on a second factory node, etc.).
 WORKTREE="${CQ_WORKTREE_AUTHOR:-$REPO_ROOT/../cq-author}"
 PROMPT_FILE="$SCRIPT_DIR/prompts/author.md"
+GH_GUARD_DIR="$SCRIPT_DIR/author-bin"
 LOGDIR="$REPO_ROOT/logs/author"
 ERRORLOG="$REPO_ROOT/logs/author-errors.log"
 LOCKFILE="/tmp/cq-author.lock"
@@ -50,6 +51,22 @@ log_error() {
     local msg="$1"
     mkdir -p "$(dirname "$ERRORLOG")"
     echo "$(date): [author] $msg" | tee -a "$ERRORLOG"
+}
+
+# --- Guard author-initiated PR merges ---
+# Agent subprocesses inherit this PATH entry, so even direct `gh pr merge`
+# calls must pass the CI status gate before the real GitHub CLI runs.
+configure_gh_merge_guard() {
+    local real_gh
+
+    if ! real_gh="$(command -v gh)"; then
+        log_error "GitHub CLI not found; author agent cannot run safely."
+        return 1
+    fi
+
+    export CQ_REAL_GH="$real_gh"
+    export CQ_AUTHOR_ERRORLOG="$ERRORLOG"
+    export PATH="$GH_GUARD_DIR:$PATH"
 }
 
 # --- Retry a command up to MAX_RETRIES times ---
@@ -175,12 +192,16 @@ backoff_sleep() {
     sleep "$delay"
 }
 
+if ! configure_gh_merge_guard; then
+    exit 1
+fi
+
 # --- Main loop ---
 while true; do
     mkdir -p "$LOGDIR"
     LOGFILE="$LOGDIR/$(date +%Y%m%d-%H%M%S).log"
 
-    cd "$WORKTREE"
+    cd "$WORKTREE" || exit 1
 
     # Fetch and reset — retry on network failures
     if ! retry "git fetch origin 2>&1"; then

--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -28,11 +28,11 @@ If a PR needs action:
 
 1. Check out the PR branch
 2. Read the review comment — the entire comment, not just the status line
-3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. Exit.
+3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script also guards this command and will refuse the merge if any status check is failing or still running. Exit.
 4. Otherwise, address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
 5. Run `pnpm -r test`, `pnpm -r build`, `pnpm format`
 6. Commit and push
-7. If verdict was `Approved with required fixes`: merge with `gh pr merge <n> --squash --delete-branch --admin`
+7. If verdict was `Approved with required fixes`: verify CI is green, then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script will refuse the merge if any status check is failing or still running.
 8. Exit
 
 ## Priority 2: Finish an in-progress issue that has no PR

--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -28,11 +28,11 @@ If a PR needs action:
 
 1. Check out the PR branch
 2. Read the review comment — the entire comment, not just the status line
-3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script also guards this command and will refuse the merge if any status check is failing or still running. Exit.
+3. If verdict is `Clean approve`: verify CI is green (`gh pr checks <n>`), then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script also guards this command and will refuse the merge unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`. Exit.
 4. Otherwise, address **every finding**. No exceptions. If the reviewer mentioned it, fix it.
 5. Run `pnpm -r test`, `pnpm -r build`, `pnpm format`
 6. Commit and push
-7. If verdict was `Approved with required fixes`: verify CI is green, then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script will refuse the merge if any status check is failing or still running.
+7. If verdict was `Approved with required fixes`: verify CI is green, then merge with `gh pr merge <n> --squash --delete-branch --admin`. The author script will refuse the merge unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`.
 8. Exit
 
 ## Priority 2: Finish an in-progress issue that has no PR
@@ -86,4 +86,4 @@ If none of the above apply, say "Nothing to do" and exit.
 - One thing per invocation. Do not start a second task.
 - Follow all Architecture Rules and Conventions in AGENTS.md.
 - Commit attribution matches the model running: `Co-Authored-By: Codex <noreply@openai.com>`, `Co-Authored-By: Gemini <noreply@google.com>`, etc.
-- The author owns the merge after the reviewer approves. Do not wait for a human to merge. Merging without `**Status: APPROVED**` (or, for trivial PRs, without green CI) is forbidden.
+- The author owns the merge after the reviewer approves. Do not wait for a human to merge. Merging without `**Status: APPROVED**` (or, for trivial PRs, without at least one reported green CI check) is forbidden, and the author script's guarded `gh` wrapper blocks `gh pr merge` unless every reported check is `SUCCESS` or `SKIPPED`.

--- a/scripts/prompts/reviewer.md
+++ b/scripts/prompts/reviewer.md
@@ -27,6 +27,7 @@ And check if there are commits newer than the last review comment. If the PR nee
    - Architecture Rules compliance (see AGENTS.md)
    - Security: no `{@html}` without sanitization, no `eval()`, no API key leaks, no XSS vectors
    - Test coverage — are the right things tested?
+   - CI status — inspect `gh pr checks <n>` and do not post `**Status: APPROVED**` while any required check is failing or still running
    - CHANGELOG.md updated?
    - Readability — could a junior engineer follow this?
 

--- a/scripts/prompts/reviewer.md
+++ b/scripts/prompts/reviewer.md
@@ -27,7 +27,7 @@ And check if there are commits newer than the last review comment. If the PR nee
    - Architecture Rules compliance (see AGENTS.md)
    - Security: no `{@html}` without sanitization, no `eval()`, no API key leaks, no XSS vectors
    - Test coverage — are the right things tested?
-   - CI status — inspect `gh pr checks <n>` and do not post `**Status: APPROVED**` while any required check is failing or still running
+   - CI status — inspect `gh pr checks <n>` and do not post `**Status: APPROVED**` unless at least one status check is reported and every check is `SUCCESS` or `SKIPPED`
    - CHANGELOG.md updated?
    - Readability — could a junior engineer follow this?
 

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -177,7 +177,7 @@ while true; do
     mkdir -p "$LOGDIR"
     LOGFILE="$LOGDIR/$(date +%Y%m%d-%H%M%S).log"
 
-    cd "$WORKTREE"
+    cd "$WORKTREE" || exit 1
 
     # Fetch and reset — retry on network failures
     if ! retry "git fetch origin 2>&1"; then


### PR DESCRIPTION
## Summary

- add an author-agent gh wrapper that blocks `gh pr merge` unless every reported PR check is SUCCESS or SKIPPED
- wire the wrapper into `scripts/author.sh` and document the behavior in AGENTS.md and prompts
- make script cd handling ShellCheck-clean while touching the automation scripts

## Verification

- `pnpm -r test`
- `pnpm -r build`
- `pnpm format`
- `docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable scripts/*.sh scripts/author-bin/gh`
- simulated failing-check guard smoke test blocked merge
- simulated green/no-failure guard smoke test allowed merge delegation

Closes #73