### PR TITLE
docs: record sandboxed code execution as future work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,3 +125,4 @@ The shape we're moving toward: the **planner role becomes interactive-only** (ch
 - Containerized agent fleet — many concurrent agents per machine via Docker, once multi-machine proves out
 - Background log-mining agent (see memory `project_log_reaper`) — mine `logs/` for insights before deletion
 - Reviewer skip-rule for script-only PRs (currently the reviewer wastes a Codex call reviewing diffs that AGENTS.md says don't need formal review)
+- Sandboxed code execution for real code-question grading (Web Worker with strict timeouts and resource limits, no DOM access). Per the 2026-05-11 decision, v1 code questions are graded by the AI tutor (#107) with self-evaluation fallback (#103). Running student-submitted code waits for the sandbox.


### PR DESCRIPTION
## Summary

Adds "Sandboxed code execution for real code-question grading" to the **Future (not committed)** list in the Agent Factory Infrastructure section of ROADMAP.md.

## Why

Per the 2026-05-11 decision on issue #103, code questions in v1 do not execute student code or LLM-provided regex. AI-tutor evaluation (#107) is the planned v1 grading approach, with plain self-evaluation as the interim fallback shipped in #103. Running student code against real test cases requires a sandbox — Web Worker with strict timeouts and resource limits, no DOM access — which is genuine future work, not near-term scheduled work.

This entry keeps the deferral visible without scheduling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)