### PR TITLE
fix(engine): keep Claude provider behind provider boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Engine/App:** Add correlation ids to `apiCallStart` and `apiCallComplete` events, and keep app loading state tied to active API call ids
 - **Engine:** Add `AdaptiveSelector` boundary and integration tests covering gap, default, and proficient quiz burst counts
 - **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
+- **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -8,26 +8,40 @@
 // about engine state — it just produces content.
 //
 // Flow per topic:
-//   1. Generate explanation via Claude → Explanation item
-//   2. Generate quiz burst via Claude → Question items
+//   1. Generate explanation via provider → Explanation item
+//   2. Generate quiz burst via provider → Question items
 //   3. Validate and filter questions
 // Repeat for each topic in the section.
 
 import { buildExplanationPrompt } from '../prompts/explanation.js';
 import { buildQuizGenerationPrompt } from '../prompts/quiz-generation.js';
 import { checkQuestionQuality } from './quality-filters.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ToolUseBlock } from '../provider/types.js';
+import type { ProviderClient, ToolUseBlock } from '../provider/types.js';
 import type { Topic } from '../curriculum/types.js';
 import type { Explanation, Question, QuestionType } from './types.js';
 
 const EXPLANATION_MAX_TOKENS = 1024;
 const QUIZ_MAX_TOKENS = 4096;
 
-export class ContentGenerator {
-  #provider: ClaudeProvider;
+export type TopicContentGenerator = {
+  generateTopicExplanation(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string
+  ): Promise<Explanation>;
+  generateTopicQuizBurst(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string,
+    explanationContent: string,
+    questionCount?: number
+  ): Promise<Question[]>;
+};
 
-  constructor(provider: ClaudeProvider) {
+export class ContentGenerator implements TopicContentGenerator {
+  #provider: ProviderClient;
+
+  constructor(provider: ProviderClient) {
     this.#provider = provider;
   }
 

--- a/packages/engine/src/content/ContentManager.ts
+++ b/packages/engine/src/content/ContentManager.ts
@@ -2,7 +2,7 @@ import type { Section } from '../curriculum/types.js';
 import { AdaptiveSelector } from '../student/AdaptiveSelector.js';
 import type { StudentModel } from '../student/StudentModel.js';
 import type { ContentItem } from './types.js';
-import type { ContentGenerator } from './ContentGenerator.js';
+import type { TopicContentGenerator } from './ContentGenerator.js';
 
 export type ApiCallEventHandler = (payload: {
   id: string;
@@ -15,11 +15,11 @@ export type ApiCallEventHandler = (payload: {
  * Acts as the bridge between CourseEngine and the generator/provider.
  */
 export class ContentManager {
-  #generator: ContentGenerator;
+  #generator: TopicContentGenerator;
   #onApiCall: ApiCallEventHandler;
   #apiCallSequence = 0;
 
-  constructor(generator: ContentGenerator, onApiCall: ApiCallEventHandler) {
+  constructor(generator: TopicContentGenerator, onApiCall: ApiCallEventHandler) {
     this.#generator = generator;
     this.#onApiCall = onApiCall;
   }

--- a/packages/engine/src/content/Prefetcher.ts
+++ b/packages/engine/src/content/Prefetcher.ts
@@ -3,7 +3,7 @@
 // This hides the LLM latency by pre-generating content while the student
 // is working on the current section.
 
-import type { ContentGenerator } from './ContentGenerator.js';
+import type { TopicContentGenerator } from './ContentGenerator.js';
 import type { ContentCache } from './ContentCache.js';
 import type { CurriculumPlan } from '../curriculum/types.js';
 import type { StudentModel } from '../student/StudentModel.js';
@@ -15,7 +15,7 @@ export class Prefetcher {
   #curriculum: CurriculumPlan | null = null;
   #inProgress = new Set<string>();
 
-  constructor(generator: ContentGenerator, cache: ContentCache) {
+  constructor(generator: TopicContentGenerator, cache: ContentCache) {
     this.#manager = new ContentManager(generator, () => {
       // No-op for prefetch background generation (silences UI events)
     });

--- a/packages/engine/src/curriculum/SyllabusParser.ts
+++ b/packages/engine/src/curriculum/SyllabusParser.ts
@@ -1,7 +1,7 @@
 // --- SyllabusParser ---
 // Orchestrates the syllabus → CurriculumPlan pipeline:
 //   1. Build the prompt from raw syllabus text
-//   2. Send to Claude via ClaudeProvider
+//   2. Send to the configured provider
 //   3. Parse and validate the response
 //   4. Retry once on malformed response
 //
@@ -10,16 +10,19 @@
 // ProviderRequest/ProviderResponse types.
 
 import { buildSyllabusAnalysisPrompt } from '../prompts/syllabus-analysis.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ProviderResponse, ToolUseBlock } from '../provider/types.js';
+import type {
+  ProviderClient,
+  ProviderResponse,
+  ToolUseBlock,
+} from '../provider/types.js';
 import type { CurriculumPlan, Section, Topic } from './types.js';
 
 const MAX_TOKENS = 4096;
 
 export class SyllabusParser {
-  #provider: ClaudeProvider;
+  #provider: ProviderClient;
 
-  constructor(provider: ClaudeProvider) {
+  constructor(provider: ProviderClient) {
     this.#provider = provider;
   }
 

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from './events.js';
 import { InvalidTransitionError } from './errors.js';
 import { SNAPSHOT_VERSION } from './constants.js';
 import { StudentModel } from '../student/StudentModel.js';
-import { ClaudeProvider } from '../provider/ClaudeProvider.js';
+import { createDefaultProvider } from '../provider/factory.js';
 import { ContentGenerator } from '../content/ContentGenerator.js';
 import { ContentManager } from '../content/ContentManager.js';
 import { ContentCache } from '../content/ContentCache.js';
@@ -111,7 +111,7 @@ export class CourseEngine extends EventEmitter {
 
     const provider =
       config.provider ||
-      new ClaudeProvider({
+      createDefaultProvider({
         apiKey: config.apiKey,
         model: config.model,
       });

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -8,8 +8,8 @@ import type {
   Explanation,
 } from '../content/types.js';
 import type { StudentState, SessionProgress, TopicMastery } from '../student/types.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ContentGenerator } from '../content/ContentGenerator.js';
+import type { ProviderClient } from '../provider/types.js';
+import type { TopicContentGenerator } from '../content/ContentGenerator.js';
 
 export type EngineState =
   | 'idle' // no syllabus loaded
@@ -25,11 +25,11 @@ export type EngineState =
 export type CourseEngineConfig = {
   apiKey: string;
   model?: string;
-  provider?: ClaudeProvider;
-  generator?: ContentGenerator;
+  provider?: ProviderClient;
+  generator?: TopicContentGenerator;
   prefetch?: {
     enabled: boolean;
-    generator?: ContentGenerator;
+    generator?: TopicContentGenerator;
   };
 };
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,6 +2,7 @@ export { CourseEngine } from './engine/CourseEngine.js';
 export { SNAPSHOT_VERSION } from './engine/constants.js';
 export { InvalidTransitionError, EngineError } from './engine/errors.js';
 export { ClaudeProvider } from './provider/ClaudeProvider.js';
+export { createDefaultProvider } from './provider/factory.js';
 export { RateLimiter } from './provider/rate-limiter.js';
 export { ProviderError } from './provider/types.js';
 export { StudentModel } from './student/StudentModel.js';
@@ -64,6 +65,7 @@ export type {
 
 export type {
   ProviderConfig,
+  ProviderClient,
   ProviderRequest,
   ProviderResponse,
   ProviderErrorType,
@@ -77,5 +79,6 @@ export type {
 } from './provider/types.js';
 
 export type { QualityIssue } from './content/quality-filters.js';
+export type { TopicContentGenerator } from './content/ContentGenerator.js';
 export type { ClaudeProviderConfig } from './provider/ClaudeProvider.js';
 export type { RateLimiterConfig } from './provider/rate-limiter.js';

--- a/packages/engine/src/prompts/syllabus-analysis.ts
+++ b/packages/engine/src/prompts/syllabus-analysis.ts
@@ -120,7 +120,7 @@ ${syllabusText}
 
 /**
  * Build the complete prompt for syllabus analysis.
- * Returns PromptMessages ready to be sent via ClaudeProvider
+ * Returns PromptMessages ready to be sent via a provider client
  * (caller adds maxTokens).
  */
 export function buildSyllabusAnalysisPrompt(syllabusText: string): PromptMessages {

--- a/packages/engine/src/prompts/types.ts
+++ b/packages/engine/src/prompts/types.ts
@@ -6,7 +6,7 @@ import type { ProviderRequest } from '../provider/types.js';
 /**
  * A prompt builder returns the ProviderRequest fields needed
  * for a specific feature. The caller (e.g., SyllabusParser)
- * adds maxTokens and sends it via ClaudeProvider.
+ * adds maxTokens and sends it via a provider client.
  */
 export type PromptMessages = Pick<
   ProviderRequest,

--- a/packages/engine/src/provider/ClaudeProvider.ts
+++ b/packages/engine/src/provider/ClaudeProvider.ts
@@ -13,6 +13,7 @@ import type { RateLimiterConfig } from './rate-limiter.js';
 import {
   ProviderError,
   type ProviderConfig,
+  type ProviderClient,
   type ProviderRequest,
   type ProviderResponse,
   type ContentBlock,
@@ -68,7 +69,7 @@ export type ClaudeProviderConfig = ProviderConfig & {
   rateLimiter?: Partial<RateLimiterConfig>;
 };
 
-export class ClaudeProvider {
+export class ClaudeProvider implements ProviderClient {
   #apiKey: string;
   #model: string;
   #rateLimiter: RateLimiter;

--- a/packages/engine/src/provider/factory.ts
+++ b/packages/engine/src/provider/factory.ts
@@ -1,0 +1,7 @@
+import { ClaudeProvider } from './ClaudeProvider.js';
+import type { ClaudeProviderConfig } from './ClaudeProvider.js';
+import type { ProviderClient } from './types.js';
+
+export function createDefaultProvider(config: ClaudeProviderConfig): ProviderClient {
+  return new ClaudeProvider(config);
+}

--- a/packages/engine/src/provider/types.ts
+++ b/packages/engine/src/provider/types.ts
@@ -76,6 +76,10 @@ export type ProviderResponse = {
   };
 };
 
+export interface ProviderClient {
+  sendMessage(request: ProviderRequest): Promise<ProviderResponse>;
+}
+
 // --- Errors ---
 
 export type ProviderErrorType =

--- a/packages/engine/tests/provider-boundary.test.ts
+++ b/packages/engine/tests/provider-boundary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const sourceRoot = fileURLToPath(new URL('../src/', import.meta.url));
+
+function collectSourceFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function sourcePath(filePath: string): string {
+  return relative(sourceRoot, filePath).split(sep).join('/');
+}
+
+describe('provider boundary', () => {
+  it('keeps concrete Claude provider usage inside the provider layer', () => {
+    const concreteProviderPatterns = [
+      /from ['"].*provider\/ClaudeProvider\.js['"]/,
+      /new ClaudeProvider\s*\(/,
+    ];
+
+    const violations = collectSourceFiles(sourceRoot)
+      .filter((filePath) => {
+        const path = sourcePath(filePath);
+        return !path.startsWith('provider/') && path !== 'index.ts';
+      })
+      .filter((filePath) => {
+        const contents = readFileSync(filePath, 'utf8');
+        return concreteProviderPatterns.some((pattern) => pattern.test(contents));
+      })
+      .map(sourcePath);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a ProviderClient interface and default provider factory inside the provider layer
- type SyllabusParser, ContentGenerator, ContentManager, Prefetcher, and CourseEngineConfig against provider/generator interfaces
- add an architecture test that catches concrete ClaudeProvider usage outside src/provider

## Verification

- pnpm -r test
- pnpm -r build
- pnpm format

Closes #95