### PR TITLE
fix(engine): use provider-agnostic interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Engine/App:** Add correlation ids to `apiCallStart` and `apiCallComplete` events, and keep app loading state tied to active API call ids
 - **Engine:** Add `AdaptiveSelector` boundary and integration tests covering gap, default, and proficient quiz burst counts
 - **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
+- **Engine:** Replace concrete Claude provider references outside the provider layer with provider-agnostic interfaces and a provider-layer default factory
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -8,26 +8,30 @@
 // about engine state — it just produces content.
 //
 // Flow per topic:
-//   1. Generate explanation via Claude → Explanation item
-//   2. Generate quiz burst via Claude → Question items
+//   1. Generate explanation via configured provider → Explanation item
+//   2. Generate quiz burst via configured provider → Question items
 //   3. Validate and filter questions
 // Repeat for each topic in the section.
 
 import { buildExplanationPrompt } from '../prompts/explanation.js';
 import { buildQuizGenerationPrompt } from '../prompts/quiz-generation.js';
 import { checkQuestionQuality } from './quality-filters.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ToolUseBlock } from '../provider/types.js';
+import type { ProviderClient, ToolUseBlock } from '../provider/types.js';
 import type { Topic } from '../curriculum/types.js';
-import type { Explanation, Question, QuestionType } from './types.js';
+import type {
+  ContentGeneratorClient,
+  Explanation,
+  Question,
+  QuestionType,
+} from './types.js';
 
 const EXPLANATION_MAX_TOKENS = 1024;
 const QUIZ_MAX_TOKENS = 4096;
 
-export class ContentGenerator {
-  #provider: ClaudeProvider;
+export class ContentGenerator implements ContentGeneratorClient {
+  #provider: ProviderClient;
 
-  constructor(provider: ClaudeProvider) {
+  constructor(provider: ProviderClient) {
     this.#provider = provider;
   }
 

--- a/packages/engine/src/content/ContentManager.ts
+++ b/packages/engine/src/content/ContentManager.ts
@@ -1,8 +1,7 @@
 import type { Section } from '../curriculum/types.js';
 import { AdaptiveSelector } from '../student/AdaptiveSelector.js';
 import type { StudentModel } from '../student/StudentModel.js';
-import type { ContentItem } from './types.js';
-import type { ContentGenerator } from './ContentGenerator.js';
+import type { ContentGeneratorClient, ContentItem } from './types.js';
 
 export type ApiCallEventHandler = (payload: {
   id: string;
@@ -15,11 +14,11 @@ export type ApiCallEventHandler = (payload: {
  * Acts as the bridge between CourseEngine and the generator/provider.
  */
 export class ContentManager {
-  #generator: ContentGenerator;
+  #generator: ContentGeneratorClient;
   #onApiCall: ApiCallEventHandler;
   #apiCallSequence = 0;
 
-  constructor(generator: ContentGenerator, onApiCall: ApiCallEventHandler) {
+  constructor(generator: ContentGeneratorClient, onApiCall: ApiCallEventHandler) {
     this.#generator = generator;
     this.#onApiCall = onApiCall;
   }

--- a/packages/engine/src/content/Prefetcher.ts
+++ b/packages/engine/src/content/Prefetcher.ts
@@ -3,8 +3,8 @@
 // This hides the LLM latency by pre-generating content while the student
 // is working on the current section.
 
-import type { ContentGenerator } from './ContentGenerator.js';
 import type { ContentCache } from './ContentCache.js';
+import type { ContentGeneratorClient } from './types.js';
 import type { CurriculumPlan } from '../curriculum/types.js';
 import type { StudentModel } from '../student/StudentModel.js';
 import { ContentManager } from './ContentManager.js';
@@ -15,7 +15,7 @@ export class Prefetcher {
   #curriculum: CurriculumPlan | null = null;
   #inProgress = new Set<string>();
 
-  constructor(generator: ContentGenerator, cache: ContentCache) {
+  constructor(generator: ContentGeneratorClient, cache: ContentCache) {
     this.#manager = new ContentManager(generator, () => {
       // No-op for prefetch background generation (silences UI events)
     });

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -2,6 +2,8 @@
 // Represents generated learning content: explanations and questions.
 // Question types match OpenQuizzer's proven set.
 
+import type { Topic } from '../curriculum/types.js';
+
 // --- Explanations ---
 
 export type Explanation = {
@@ -106,6 +108,21 @@ export type QuestionType = Question['type'];
 // The engine emits these in the content/quiz loop order.
 
 export type ContentItem = Explanation | Question;
+
+export type ContentGeneratorClient = {
+  generateTopicExplanation(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string
+  ): Promise<Explanation>;
+  generateTopicQuizBurst(
+    topic: Topic,
+    courseTitle: string,
+    sectionTitle: string,
+    explanationContent: string,
+    questionCount?: number
+  ): Promise<Question[]>;
+};
 
 // --- Answers ---
 

--- a/packages/engine/src/curriculum/SyllabusParser.ts
+++ b/packages/engine/src/curriculum/SyllabusParser.ts
@@ -1,7 +1,7 @@
 // --- SyllabusParser ---
 // Orchestrates the syllabus → CurriculumPlan pipeline:
 //   1. Build the prompt from raw syllabus text
-//   2. Send to Claude via ClaudeProvider
+//   2. Send to the configured provider
 //   3. Parse and validate the response
 //   4. Retry once on malformed response
 //
@@ -10,16 +10,19 @@
 // ProviderRequest/ProviderResponse types.
 
 import { buildSyllabusAnalysisPrompt } from '../prompts/syllabus-analysis.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ProviderResponse, ToolUseBlock } from '../provider/types.js';
+import type {
+  ProviderClient,
+  ProviderResponse,
+  ToolUseBlock,
+} from '../provider/types.js';
 import type { CurriculumPlan, Section, Topic } from './types.js';
 
 const MAX_TOKENS = 4096;
 
 export class SyllabusParser {
-  #provider: ClaudeProvider;
+  #provider: ProviderClient;
 
-  constructor(provider: ClaudeProvider) {
+  constructor(provider: ProviderClient) {
     this.#provider = provider;
   }
 

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from './events.js';
 import { InvalidTransitionError } from './errors.js';
 import { SNAPSHOT_VERSION } from './constants.js';
 import { StudentModel } from '../student/StudentModel.js';
-import { ClaudeProvider } from '../provider/ClaudeProvider.js';
+import { createDefaultProvider } from '../provider/factory.js';
 import { ContentGenerator } from '../content/ContentGenerator.js';
 import { ContentManager } from '../content/ContentManager.js';
 import { ContentCache } from '../content/ContentCache.js';
@@ -26,10 +26,9 @@ import type {
 } from './types.js';
 import type { StudentAnswer, Question } from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
+import type { ProviderClient } from '../provider/types.js';
 
 function copySection(section: Section): Section {
-  // ... (omitting for brevity in this thought but I'll provide full in the call)
-
   return {
     ...section,
     topics: section.topics.map((topic) => ({ ...topic })),
@@ -91,9 +90,25 @@ function isValidGeneratedContentRecord(
   );
 }
 
+function createProviderFromConfig(config: CourseEngineConfig): ProviderClient {
+  if (config.provider) {
+    return config.provider;
+  }
+
+  if (!config.apiKey) {
+    throw new Error(
+      'CourseEngine requires an apiKey when no provider or generator is supplied'
+    );
+  }
+
+  return createDefaultProvider({
+    apiKey: config.apiKey,
+    model: config.model,
+  });
+}
+
 export class CourseEngine extends EventEmitter {
   #state: EngineState = 'idle';
-  #config: CourseEngineConfig;
   #curriculum: CurriculumPlan | null = null;
   #currentSectionIndex = -1;
   #currentItemIndex = -1;
@@ -107,16 +122,8 @@ export class CourseEngine extends EventEmitter {
 
   constructor(config: CourseEngineConfig) {
     super();
-    this.#config = { ...config };
-
-    const provider =
-      config.provider ||
-      new ClaudeProvider({
-        apiKey: config.apiKey,
-        model: config.model,
-      });
-
-    const generator = config.generator || new ContentGenerator(provider);
+    const generator =
+      config.generator || new ContentGenerator(createProviderFromConfig(config));
 
     this.#contentManager = new ContentManager(generator, (payload) => {
       if (payload.status === 'start') {

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -4,12 +4,12 @@ import type { CurriculumPlan, Section } from '../curriculum/types.js';
 import type {
   AnswerResult,
   ContentItem,
+  ContentGeneratorClient,
   Question,
   Explanation,
 } from '../content/types.js';
 import type { StudentState, SessionProgress, TopicMastery } from '../student/types.js';
-import type { ClaudeProvider } from '../provider/ClaudeProvider.js';
-import type { ContentGenerator } from '../content/ContentGenerator.js';
+import type { ProviderClient } from '../provider/types.js';
 
 export type EngineState =
   | 'idle' // no syllabus loaded
@@ -23,13 +23,13 @@ export type EngineState =
   | 'error'; // content generation failed
 
 export type CourseEngineConfig = {
-  apiKey: string;
+  apiKey?: string;
   model?: string;
-  provider?: ClaudeProvider;
-  generator?: ContentGenerator;
+  provider?: ProviderClient;
+  generator?: ContentGeneratorClient;
   prefetch?: {
     enabled: boolean;
-    generator?: ContentGenerator;
+    generator?: ContentGeneratorClient;
   };
 };
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -54,6 +54,7 @@ export type { MasteryUpdate } from './student/StudentModel.js';
 
 export type {
   StudentAnswer,
+  ContentGeneratorClient,
   QuestionType,
   MultipleChoiceQuestion,
   NumericInputQuestion,
@@ -64,6 +65,7 @@ export type {
 
 export type {
   ProviderConfig,
+  ProviderClient,
   ProviderRequest,
   ProviderResponse,
   ProviderErrorType,

--- a/packages/engine/src/prompts/syllabus-analysis.ts
+++ b/packages/engine/src/prompts/syllabus-analysis.ts
@@ -120,7 +120,7 @@ ${syllabusText}
 
 /**
  * Build the complete prompt for syllabus analysis.
- * Returns PromptMessages ready to be sent via ClaudeProvider
+ * Returns PromptMessages ready to be sent via the configured provider
  * (caller adds maxTokens).
  */
 export function buildSyllabusAnalysisPrompt(syllabusText: string): PromptMessages {

--- a/packages/engine/src/prompts/types.ts
+++ b/packages/engine/src/prompts/types.ts
@@ -6,7 +6,7 @@ import type { ProviderRequest } from '../provider/types.js';
 /**
  * A prompt builder returns the ProviderRequest fields needed
  * for a specific feature. The caller (e.g., SyllabusParser)
- * adds maxTokens and sends it via ClaudeProvider.
+ * adds maxTokens and sends it via the configured provider.
  */
 export type PromptMessages = Pick<
   ProviderRequest,

--- a/packages/engine/src/provider/ClaudeProvider.ts
+++ b/packages/engine/src/provider/ClaudeProvider.ts
@@ -12,6 +12,7 @@ import { RateLimiter } from './rate-limiter.js';
 import type { RateLimiterConfig } from './rate-limiter.js';
 import {
   ProviderError,
+  type ProviderClient,
   type ProviderConfig,
   type ProviderRequest,
   type ProviderResponse,
@@ -68,7 +69,7 @@ export type ClaudeProviderConfig = ProviderConfig & {
   rateLimiter?: Partial<RateLimiterConfig>;
 };
 
-export class ClaudeProvider {
+export class ClaudeProvider implements ProviderClient {
   #apiKey: string;
   #model: string;
   #rateLimiter: RateLimiter;

--- a/packages/engine/src/provider/factory.ts
+++ b/packages/engine/src/provider/factory.ts
@@ -1,0 +1,8 @@
+import { ClaudeProvider, type ClaudeProviderConfig } from './ClaudeProvider.js';
+import type { ProviderClient } from './types.js';
+
+export type DefaultProviderConfig = ClaudeProviderConfig;
+
+export function createDefaultProvider(config: DefaultProviderConfig): ProviderClient {
+  return new ClaudeProvider(config);
+}

--- a/packages/engine/src/provider/types.ts
+++ b/packages/engine/src/provider/types.ts
@@ -76,6 +76,10 @@ export type ProviderResponse = {
   };
 };
 
+export type ProviderClient = {
+  sendMessage(request: ProviderRequest): Promise<ProviderResponse>;
+};
+
 // --- Errors ---
 
 export type ProviderErrorType =

--- a/packages/engine/tests/provider-agnostic-interfaces.test.ts
+++ b/packages/engine/tests/provider-agnostic-interfaces.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  ContentGenerator,
+  CourseEngine,
+  SyllabusParser,
+  type CourseEngineConfig,
+  type ProviderClient,
+  type ProviderResponse,
+} from '../src/index.js';
+
+function mockResponse(): ProviderResponse {
+  return {
+    id: 'msg-1',
+    content: [],
+    model: 'test-model',
+    stopReason: 'end_turn',
+    usage: {
+      inputTokens: 1,
+      outputTokens: 1,
+    },
+  };
+}
+
+function mockProvider(): ProviderClient {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(mockResponse()),
+  };
+}
+
+function readSource(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), 'utf8');
+}
+
+describe('provider-agnostic interfaces', () => {
+  it('accepts structural provider clients outside the provider layer', () => {
+    const provider = mockProvider();
+    const generator = new ContentGenerator(provider);
+    const parser = new SyllabusParser(provider);
+    const config: CourseEngineConfig = { provider, generator };
+
+    const engine = new CourseEngine(config);
+
+    expect(engine.state).toBe('idle');
+    expect(parser).toBeInstanceOf(SyllabusParser);
+  });
+
+  it('keeps Claude-specific types inside the provider layer', () => {
+    const nonProviderSources = [
+      'content/ContentGenerator.ts',
+      'curriculum/SyllabusParser.ts',
+      'engine/CourseEngine.ts',
+      'engine/types.ts',
+    ];
+
+    for (const path of nonProviderSources) {
+      expect(readSource(path), path).not.toContain('ClaudeProvider');
+    }
+  });
+});


### PR DESCRIPTION
Closes #95

## Approach
- Add a narrow `ProviderClient` interface and use it in `ContentGenerator`, `SyllabusParser`, and `CourseEngineConfig.provider`.
- Add a `ContentGeneratorClient` interface for engine/content orchestration injection points.
- Move default Claude construction behind `provider/factory.ts` so non-provider layers no longer import `ClaudeProvider`.
- Add an engine regression test that accepts structural provider clients and guards against concrete Claude references in non-provider sources.

## Verification
- `corepack pnpm -r test`
- `corepack pnpm -r build`
- `corepack pnpm format`