### PR TITLE
fix(scripts): close issue-claim race between factory nodes (closes #111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,12 +346,15 @@ Their job is to do the one scripted task, emit a short status summary, and exit.
 
 ### Issue Claiming
 
-Multiple coding agents may be running simultaneously. To prevent two agents from working on the same issue:
+Multiple coding agents may be running simultaneously across factory nodes. To prevent two agents from working on the same issue:
 
-1. **Before starting work**, add the `in-progress` label to the issue: `gh issue edit <n> --add-label in-progress`
-2. **Skip issues labeled `in-progress`** — another agent is working on them.
-3. **On completion**, the label is removed when the PR merges and closes the issue.
-4. **Stale claims**: If an issue is labeled `in-progress` but has no corresponding branch or PR, the claim is stale and the issue can be reclaimed. Remove the label and take the issue.
+1. **Before adding the `in-progress` label**, verify no open PR already references the issue: `gh pr list --state open --search "in:body Closes #<n>" --json number --jq '.[0].number // empty'`. If a PR exists, another agent claimed first — back off without picking a different issue (exit "Nothing to do"; the next poll will see a clean queue).
+2. **Add the `in-progress` label**: `gh issue edit <n> --add-label in-progress`.
+3. **Skip issues labeled `in-progress`** — another agent is working on them.
+4. **On completion**, the label is removed when the PR merges and closes the issue.
+5. **Stale claims**: If an issue is labeled `in-progress` but has no corresponding branch or PR, the claim is stale and the issue can be reclaimed. Remove the label and take the issue.
+
+The existing-PR check (step 1) closes the race window between two agents listing the unlabeled-issues set before either has added the label. A small window between two simultaneous label edits remains — both agents will see the label on the next poll and back off, having spent only the label edit. The previously-expensive failure mode (both agents do the full implementation before discovering the collision) is what step 1 prevents.
 
 ### Safety Gate
 

--- a/scripts/prompts/author.md
+++ b/scripts/prompts/author.md
@@ -64,6 +64,14 @@ gh issue list --state open --json number,title,labels,createdAt --jq '[.[] | sel
 Verify the issue author is johnmarkos (`gh issue view <n> --json author`). Skip if not.
 **Skip issues labeled `review`** — those are milestone reviews handled by the planning agent, not coding tasks.
 
+**Check that no open PR already references the issue.** Multiple factory nodes run author agents in parallel; the gap between "list unlabeled issues" and "add the `in-progress` label" lets two agents claim the same issue. Before claiming, verify nobody beat you to it:
+
+```
+gh pr list --state open --search "in:body Closes #<n>" --json number --jq '.[0].number // empty'
+```
+
+If that returns a PR number, another agent has the issue. **Exit with "Nothing to do"** — do not jump to the next-lowest issue from this poll (cascading races are worse than waiting one cycle). The next poll will see a clean queue.
+
 **Pick the lowest-numbered eligible issue. Do not skip issues because their body mentions dependencies on other issues.** Dependency ordering is the planning agent's job — if an issue exists and is not labeled `in-progress`, it is ready to work on.
 
 If an eligible issue exists:


### PR DESCRIPTION
## Summary

Adds an existing-PR check to the author prompt's Priority 3 flow. Before claiming an issue (adding the \`in-progress\` label), the author runs:

\`\`\`
gh pr list --state open --search \"in:body Closes #<n>\" --json number --jq '.[0].number // empty'
\`\`\`

If a PR already references the issue, the author exits with \"Nothing to do\" instead of claiming. AGENTS.md \"Issue Claiming\" section reordered to make this the first step.

## Why

The factory has been creating duplicate PRs whenever both factory nodes (laptop + Mac) poll within the same second:

- PR #93 / #94 — both on issue #73, ~90s apart
- PR #109 / #110 — both on issue #95, ~3 min apart (currently in flight)

Two agents list unlabeled issues at roughly the same time, both decide to claim the lowest-numbered, both add the \`in-progress\` label, both create branches, both do the full implementation, both open PRs. One eventually merges, the other becomes CONFLICTING and is closed by hand. The expensive part is the duplicate code work; the existing-PR check catches that.

## Why planner-direct

Scripts/prompts-only diff. Same pattern as PRs #76 / #81 / #92 / #93. Critical: the author prompt is re-read each iteration, so this takes effect on the next poll on both factory nodes without restart.

## What's still possible

A tiny window between two simultaneous \`gh issue edit --add-label\` calls remains. Both agents will see the label on the next poll iteration and back off, having spent only the label edit — much cheaper than full duplicate implementations. Closing that last window would require GitHub-side atomic operations we don't have; deferred.

## Validation

- Prompt + docs only; no shell logic changed
- AGENTS.md \"Issue Claiming\" section reordered to put the existing-PR check first

🤖 Generated with [Claude Code](https://claude.com/claude-code)