### PR TITLE
fix: move mastery progress summaries into engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Engine:** Add `AdaptiveSelector` boundary and integration tests covering gap, default, and proficient quiz burst counts
 - **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
 - **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
+- **Engine/App:** Move topic status, review flags, and course progress summary calculations behind engine-owned progress helpers so the app only formats and renders emitted progress data
 
 ## 0.9.0 — 2026-05-10
 

--- a/apps/coursequizzer/src/lib/stores/course-progress.ts
+++ b/apps/coursequizzer/src/lib/stores/course-progress.ts
@@ -3,81 +3,21 @@
 // Pure logic — no Svelte, no browser APIs.
 
 import type { CourseRecord } from '../storage/course-storage.js';
-import type { EngineSnapshot, TopicMastery } from 'quizzer-engine';
+import { summarizeCourseProgress, type CourseProgressSummary } from 'quizzer-engine';
 
-export type SectionProgress = {
-  sectionId: string;
-  /** Whether the student has started or completed this section. */
-  started: boolean;
-  /** Number of topics with at least one answered question. */
-  topicsAttempted: number;
-  /** Total number of topics in the section. */
-  topicsTotal: number;
-  /** Average mastery score (0–1) across attempted topics in this section. */
-  mastery: number;
-};
-
-export type CourseProgressSummary = {
-  /** Index of the section the student was last working on (from snapshot). */
-  currentSectionIndex: number;
-  /** Total number of sections. */
-  totalSections: number;
-  /** Overall mastery score (0–1) across all attempted topics. */
-  overallMastery: number;
-  /** Total questions answered across all topics. */
-  totalQuestionsAnswered: number;
-  /** Per-section progress. */
-  sections: SectionProgress[];
-  /** Whether the course has been started (snapshot exists with answers). */
-  hasProgress: boolean;
-};
+export type { CourseProgressSummary, SectionProgressSummary } from 'quizzer-engine';
 
 /**
  * Extract a progress summary from a CourseRecord. Returns null if the course
  * has no snapshot (never started).
  */
 export function getCourseProgress(record: CourseRecord): CourseProgressSummary | null {
-  const { curriculum, snapshot } = record;
-  if (!snapshot) return null;
+  if (!record.snapshot) return null;
 
-  const masteryMap = snapshot.studentState?.masteryByTopic ?? {};
-  const sections = curriculum.sections;
-
-  const sectionProgress: SectionProgress[] = sections.map((section, index) => {
-    const topicIds = section.topics.map((t) => t.id);
-    const attempted = topicIds.filter((id) => masteryMap[id]?.questionsAnswered > 0);
-    const mastery =
-      attempted.length > 0
-        ? attempted.reduce((sum, id) => sum + (masteryMap[id]?.score ?? 0), 0) /
-          attempted.length
-        : 0;
-
-    return {
-      sectionId: section.id,
-      started: index < snapshot.currentSectionIndex || attempted.length > 0,
-      topicsAttempted: attempted.length,
-      topicsTotal: topicIds.length,
-      mastery,
-    };
+  return summarizeCourseProgress(record.curriculum, {
+    currentSectionIndex: record.snapshot.currentSectionIndex,
+    studentState: record.snapshot.studentState,
   });
-
-  const allMasteries = Object.values(masteryMap) as TopicMastery[];
-  const attemptedMasteries = allMasteries.filter((m) => m.questionsAnswered > 0);
-  const totalAnswered = allMasteries.reduce((sum, m) => sum + m.questionsAnswered, 0);
-  const overallMastery =
-    attemptedMasteries.length > 0
-      ? attemptedMasteries.reduce((sum, m) => sum + m.score, 0) /
-        attemptedMasteries.length
-      : 0;
-
-  return {
-    currentSectionIndex: snapshot.currentSectionIndex,
-    totalSections: sections.length,
-    overallMastery,
-    totalQuestionsAnswered: totalAnswered,
-    sections: sectionProgress,
-    hasProgress: totalAnswered > 0,
-  };
 }
 
 /**

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -588,32 +588,30 @@
         {#if session.currentSection}
           <p>You've finished <strong>{session.currentSection.section.title}</strong>.</p>
 
-          <div class="mastery-summary">
-            <h3>Topic Mastery</h3>
-            <ul class="topic-mastery-list">
-              {#each session.currentSection.section.topics as topic (topic.id)}
-                {@const mastery = session.studentState?.masteryByTopic?.[topic.id]}
-                {@const score = mastery?.score ?? 0}
-                {@const level =
-                  score < 0.5 ? 'struggling' : score < 0.8 ? 'gaining' : 'mastered'}
-                <li class="topic-mastery-item">
-                  <div class="topic-info">
-                    <span class="topic-title">{topic.title}</span>
-                    {#if score < 0.5}
-                      <span class="gap-badge">Review suggested</span>
-                    {/if}
-                  </div>
-                  <div class="mastery-bar-container">
-                    <div
-                      class="mastery-bar {level}"
-                      style="width: {Math.round(score * 100)}%"
-                    ></div>
-                  </div>
-                  <span class="mastery-score">{Math.round(score * 100)}%</span>
-                </li>
-              {/each}
-            </ul>
-          </div>
+          {#if session.progress?.currentSection}
+            <div class="mastery-summary">
+              <h3>Topic Mastery</h3>
+              <ul class="topic-mastery-list">
+                {#each session.progress.currentSection.topics as topic (topic.topicId)}
+                  <li class="topic-mastery-item">
+                    <div class="topic-info">
+                      <span class="topic-title">{topic.title}</span>
+                      {#if topic.needsReview}
+                        <span class="gap-badge">Review suggested</span>
+                      {/if}
+                    </div>
+                    <div class="mastery-bar-container">
+                      <div
+                        class="mastery-bar {topic.status}"
+                        style="width: {Math.round(topic.score * 100)}%"
+                      ></div>
+                    </div>
+                    <span class="mastery-score">{Math.round(topic.score * 100)}%</span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
         {/if}
 
         {#if session.progress}

--- a/apps/coursequizzer/tests/unit/section-summary.test.ts
+++ b/apps/coursequizzer/tests/unit/section-summary.test.ts
@@ -72,15 +72,26 @@ describe('section summary data', () => {
 
     expect(session.engineState).toBe('sectionComplete');
     expect(session.studentState).not.toBeNull();
+    expect(session.progress?.currentSection).not.toBeNull();
 
-    const mastery = session.studentState!.masteryByTopic;
-    expect(mastery['t1']).toBeDefined();
-    expect(mastery['t1'].score).toBeGreaterThan(0);
-    expect(mastery['t1'].questionsCorrect).toBe(1);
+    const topicProgress = session.progress!.currentSection!.topics;
+    expect(topicProgress[0]).toMatchObject({
+      topicId: 't1',
+      title: 'What is a Unit Test?',
+      score: 0.15,
+      questionsCorrect: 1,
+      status: 'struggling',
+      needsReview: true,
+    });
 
-    expect(mastery['t2']).toBeDefined();
-    expect(mastery['t2'].score).toBe(0);
-    expect(mastery['t2'].questionsCorrect).toBe(0);
+    expect(topicProgress[1]).toMatchObject({
+      topicId: 't2',
+      title: 'Test Runners',
+      score: 0,
+      questionsCorrect: 0,
+      status: 'struggling',
+      needsReview: true,
+    });
 
     // Check if we can identify topics for the current section
     const currentSectionTopics = session.currentSection!.section.topics;

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -170,6 +170,10 @@ export class CourseEngine extends EventEmitter {
       totalSections: this.#curriculum?.sections.length ?? 0,
       currentItemIndex: this.#currentItemIndex,
       totalItemsInSection: this.#sectionItems.length,
+      currentSection:
+        this.#curriculum && this.#currentSectionIndex >= 0
+          ? this.#curriculum.sections[this.#currentSectionIndex]
+          : null,
     });
   }
 

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -7,7 +7,15 @@ import type {
   Question,
   Explanation,
 } from '../content/types.js';
-import type { StudentState, SessionProgress, TopicMastery } from '../student/types.js';
+import type {
+  CourseProgressSummary,
+  MasteryStatus,
+  SectionProgressSummary,
+  StudentState,
+  SessionProgress,
+  TopicMastery,
+  TopicProgress,
+} from '../student/types.js';
 import type { ProviderClient } from '../provider/types.js';
 import type { TopicContentGenerator } from '../content/ContentGenerator.js';
 
@@ -56,4 +64,8 @@ export type {
   StudentState,
   SessionProgress,
   TopicMastery,
+  MasteryStatus,
+  TopicProgress,
+  SectionProgressSummary,
+  CourseProgressSummary,
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,6 +7,11 @@ export { RateLimiter } from './provider/rate-limiter.js';
 export { ProviderError } from './provider/types.js';
 export { StudentModel } from './student/StudentModel.js';
 export { AdaptiveSelector } from './student/AdaptiveSelector.js';
+export {
+  summarizeCourseProgress,
+  summarizeSectionProgress,
+  summarizeTopicProgress,
+} from './student/progress.js';
 export { SyllabusParser, validateCurriculumPlan } from './curriculum/SyllabusParser.js';
 export { CurriculumManager } from './curriculum/CurriculumManager.js';
 export { ContentGenerator } from './content/ContentGenerator.js';
@@ -30,7 +35,13 @@ export type {
   StudentState,
   SessionProgress,
   TopicMastery,
+  MasteryStatus,
+  TopicProgress,
+  SectionProgressSummary,
+  CourseProgressSummary,
 } from './engine/types.js';
+
+export type { CourseProgressInput } from './student/progress.js';
 
 export type {
   ApiCallEvent,

--- a/packages/engine/src/student/AdaptiveSelector.ts
+++ b/packages/engine/src/student/AdaptiveSelector.ts
@@ -1,7 +1,5 @@
 import type { StudentModel } from './StudentModel.js';
-
-const GAP_THRESHOLD = 0.5;
-const PROFICIENT_THRESHOLD = 0.8;
+import { GAP_THRESHOLD, PROFICIENT_THRESHOLD } from './mastery-policy.js';
 const GAP_QUESTION_COUNT = 5;
 const DEFAULT_QUESTION_COUNT = 3;
 const PROFICIENT_QUESTION_COUNT = 2;

--- a/packages/engine/src/student/StudentModel.ts
+++ b/packages/engine/src/student/StudentModel.ts
@@ -11,11 +11,10 @@
 // The model is serializable: getState() returns a snapshot,
 // and the constructor can restore from a prior StudentState.
 
+import { summarizeSectionProgress } from './progress.js';
+import { BASE_GAIN, BASE_LOSS, GAP_THRESHOLD } from './mastery-policy.js';
+import type { Section } from '../curriculum/types.js';
 import type { StudentState, TopicMastery, SessionProgress } from './types.js';
-
-const GAP_THRESHOLD = 0.5;
-const BASE_GAIN = 0.15;
-const BASE_LOSS = 0.1;
 
 export type MasteryUpdate = {
   topicId: string;
@@ -129,13 +128,24 @@ export class StudentModel {
     totalSections: number;
     currentItemIndex: number;
     totalItemsInSection: number;
+    currentSection?: Section | null;
   }): SessionProgress {
+    const currentSection = position.currentSection
+      ? summarizeSectionProgress(
+          position.currentSection,
+          position.currentSectionIndex,
+          position.currentSectionIndex,
+          this.getState()
+        )
+      : null;
+
     return {
       currentSectionIndex: position.currentSectionIndex,
       totalSections: position.totalSections,
       currentItemIndex: position.currentItemIndex,
       totalItemsInSection: position.totalItemsInSection,
       overallMastery: this.overallMastery,
+      currentSection,
     };
   }
 

--- a/packages/engine/src/student/mastery-policy.ts
+++ b/packages/engine/src/student/mastery-policy.ts
@@ -1,0 +1,12 @@
+import type { MasteryStatus } from './types.js';
+
+export const GAP_THRESHOLD = 0.5;
+export const PROFICIENT_THRESHOLD = 0.8;
+export const BASE_GAIN = 0.15;
+export const BASE_LOSS = 0.1;
+
+export function getMasteryStatus(score: number): MasteryStatus {
+  if (score < GAP_THRESHOLD) return 'struggling';
+  if (score < PROFICIENT_THRESHOLD) return 'gaining';
+  return 'mastered';
+}

--- a/packages/engine/src/student/progress.ts
+++ b/packages/engine/src/student/progress.ts
@@ -1,0 +1,107 @@
+import { getMasteryStatus } from './mastery-policy.js';
+import type { CurriculumPlan, Section, Topic } from '../curriculum/types.js';
+import type {
+  CourseProgressSummary,
+  SectionProgressSummary,
+  StudentState,
+  TopicMastery,
+  TopicProgress,
+} from './types.js';
+
+export type CourseProgressInput = {
+  currentSectionIndex: number;
+  studentState: StudentState;
+};
+
+function getTopicMastery(studentState: StudentState, topicId: string): TopicMastery {
+  const mastery = studentState.masteryByTopic[topicId];
+  return (
+    mastery ?? {
+      topicId,
+      score: 0,
+      questionsAnswered: 0,
+      questionsCorrect: 0,
+    }
+  );
+}
+
+export function summarizeTopicProgress(
+  topic: Topic,
+  studentState: StudentState
+): TopicProgress {
+  const mastery = getTopicMastery(studentState, topic.id);
+  const status = getMasteryStatus(mastery.score);
+
+  return {
+    topicId: topic.id,
+    title: topic.title,
+    score: mastery.score,
+    questionsAnswered: mastery.questionsAnswered,
+    questionsCorrect: mastery.questionsCorrect,
+    status,
+    needsReview: status === 'struggling',
+  };
+}
+
+export function summarizeSectionProgress(
+  section: Section,
+  sectionIndex: number,
+  currentSectionIndex: number,
+  studentState: StudentState
+): SectionProgressSummary {
+  const topics = section.topics.map((topic) =>
+    summarizeTopicProgress(topic, studentState)
+  );
+  const attemptedTopics = topics.filter((topic) => topic.questionsAnswered > 0);
+  const mastery =
+    attemptedTopics.length > 0
+      ? attemptedTopics.reduce((total, topic) => total + topic.score, 0) /
+        attemptedTopics.length
+      : 0;
+
+  return {
+    sectionId: section.id,
+    title: section.title,
+    started: sectionIndex < currentSectionIndex || attemptedTopics.length > 0,
+    topicsAttempted: attemptedTopics.length,
+    topicsTotal: topics.length,
+    mastery,
+    topics,
+  };
+}
+
+export function summarizeCourseProgress(
+  curriculum: CurriculumPlan,
+  input: CourseProgressInput
+): CourseProgressSummary {
+  const sections = curriculum.sections.map((section, index) =>
+    summarizeSectionProgress(
+      section,
+      index,
+      input.currentSectionIndex,
+      input.studentState
+    )
+  );
+  const allMasteries = Object.values(input.studentState.masteryByTopic);
+  const attemptedMasteries = allMasteries.filter(
+    (mastery) => mastery.questionsAnswered > 0
+  );
+  const totalQuestionsAnswered = allMasteries.reduce(
+    (total, mastery) => total + mastery.questionsAnswered,
+    0
+  );
+  const overallMastery =
+    attemptedMasteries.length > 0
+      ? attemptedMasteries.reduce((total, mastery) => total + mastery.score, 0) /
+        attemptedMasteries.length
+      : 0;
+
+  return {
+    currentSectionIndex: input.currentSectionIndex,
+    totalSections: curriculum.sections.length,
+    overallMastery,
+    totalQuestionsAnswered,
+    sections,
+    hasProgress: totalQuestionsAnswered > 0,
+  };
+}

--- a/packages/engine/src/student/types.ts
+++ b/packages/engine/src/student/types.ts
@@ -8,6 +8,37 @@ export type TopicMastery = {
   questionsCorrect: number;
 };
 
+export type MasteryStatus = 'struggling' | 'gaining' | 'mastered';
+
+export type TopicProgress = {
+  topicId: string;
+  title: string;
+  score: number; // 0.0 to 1.0
+  questionsAnswered: number;
+  questionsCorrect: number;
+  status: MasteryStatus;
+  needsReview: boolean;
+};
+
+export type SectionProgressSummary = {
+  sectionId: string;
+  title: string;
+  started: boolean;
+  topicsAttempted: number;
+  topicsTotal: number;
+  mastery: number; // 0.0 to 1.0, average across attempted topics
+  topics: TopicProgress[];
+};
+
+export type CourseProgressSummary = {
+  currentSectionIndex: number;
+  totalSections: number;
+  overallMastery: number; // 0.0 to 1.0, average across attempted topics
+  totalQuestionsAnswered: number;
+  sections: SectionProgressSummary[];
+  hasProgress: boolean;
+};
+
 export type StudentState = {
   masteryByTopic: Record<string, TopicMastery>;
   gaps: string[]; // topic IDs where mastery is below threshold
@@ -19,4 +50,5 @@ export type SessionProgress = {
   currentItemIndex: number;
   totalItemsInSection: number;
   overallMastery: number; // 0.0 to 1.0, average across all topics
+  currentSection: SectionProgressSummary | null;
 };

--- a/packages/engine/tests/progress-summary.test.ts
+++ b/packages/engine/tests/progress-summary.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeCourseProgress } from '../src/index.js';
+import type { CurriculumPlan, StudentState } from '../src/index.js';
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Algorithms',
+    description: 'An intro to algorithms.',
+    sections: [
+      {
+        id: 's1',
+        title: 'Sorting',
+        order: 0,
+        topics: [
+          { id: 't1', title: 'Bubble Sort', description: 'The simplest sort.' },
+          { id: 't2', title: 'Merge Sort', description: 'Divide and conquer.' },
+        ],
+      },
+      {
+        id: 's2',
+        title: 'Searching',
+        order: 1,
+        topics: [{ id: 't3', title: 'Binary Search', description: 'Log-time search.' }],
+      },
+    ],
+  };
+}
+
+function studentStateWith(
+  topics: Record<string, { score: number; answered: number; correct: number }>
+): StudentState {
+  const masteryByTopic: StudentState['masteryByTopic'] = {};
+  for (const [topicId, data] of Object.entries(topics)) {
+    masteryByTopic[topicId] = {
+      topicId,
+      score: data.score,
+      questionsAnswered: data.answered,
+      questionsCorrect: data.correct,
+    };
+  }
+
+  return { masteryByTopic, gaps: [] };
+}
+
+describe('summarizeCourseProgress', () => {
+  it('summarizes course and section progress from engine-owned student state', () => {
+    const progress = summarizeCourseProgress(mockCurriculum(), {
+      currentSectionIndex: 1,
+      studentState: studentStateWith({
+        t1: { score: 0.8, answered: 5, correct: 4 },
+        t2: { score: 0, answered: 0, correct: 0 },
+        t3: { score: 0.6, answered: 3, correct: 2 },
+      }),
+    });
+
+    expect(progress.currentSectionIndex).toBe(1);
+    expect(progress.totalSections).toBe(2);
+    expect(progress.totalQuestionsAnswered).toBe(8);
+    expect(progress.hasProgress).toBe(true);
+    expect(progress.overallMastery).toBeCloseTo(0.7);
+
+    expect(progress.sections[0]).toMatchObject({
+      sectionId: 's1',
+      title: 'Sorting',
+      started: true,
+      topicsAttempted: 1,
+      topicsTotal: 2,
+      mastery: 0.8,
+    });
+    expect(progress.sections[1]).toMatchObject({
+      sectionId: 's2',
+      title: 'Searching',
+      started: true,
+      topicsAttempted: 1,
+      topicsTotal: 1,
+      mastery: 0.6,
+    });
+  });
+
+  it('classifies topic display status and review flags using engine thresholds', () => {
+    const progress = summarizeCourseProgress(mockCurriculum(), {
+      currentSectionIndex: 0,
+      studentState: studentStateWith({
+        t1: { score: 0.4, answered: 3, correct: 1 },
+        t2: { score: 0.9, answered: 6, correct: 6 },
+        t3: { score: 0.7, answered: 4, correct: 3 },
+      }),
+    });
+
+    expect(progress.sections[0].topics[0]).toMatchObject({
+      topicId: 't1',
+      title: 'Bubble Sort',
+      score: 0.4,
+      status: 'struggling',
+      needsReview: true,
+    });
+    expect(progress.sections[0].topics[1]).toMatchObject({
+      topicId: 't2',
+      title: 'Merge Sort',
+      score: 0.9,
+      status: 'mastered',
+      needsReview: false,
+    });
+    expect(progress.sections[1].topics[0]).toMatchObject({
+      topicId: 't3',
+      title: 'Binary Search',
+      score: 0.7,
+      status: 'gaining',
+      needsReview: false,
+    });
+  });
+});

--- a/packages/engine/tests/student-model.test.ts
+++ b/packages/engine/tests/student-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { StudentModel } from '../src/index.js';
-import type { StudentState } from '../src/index.js';
+import type { Section, StudentState } from '../src/index.js';
 
 // --- Helpers ---
 
@@ -196,6 +196,64 @@ describe('session progress', () => {
     expect(progress.currentItemIndex).toBe(3);
     expect(progress.totalItemsInSection).toBe(10);
     expect(progress.overallMastery).toBe(0.15);
+  });
+
+  it('includes current section topic progress for UI display', () => {
+    const state: StudentState = {
+      masteryByTopic: {
+        'topic-1': {
+          topicId: 'topic-1',
+          score: 0.4,
+          questionsAnswered: 3,
+          questionsCorrect: 1,
+        },
+        'topic-2': {
+          topicId: 'topic-2',
+          score: 0.85,
+          questionsAnswered: 6,
+          questionsCorrect: 5,
+        },
+      },
+      gaps: ['topic-1'],
+    };
+    const model = new StudentModel(state);
+    const section: Section = {
+      id: 'section-1',
+      title: 'Unit Testing',
+      order: 0,
+      topics: [
+        { id: 'topic-1', title: 'Assertions', description: 'How to assert' },
+        { id: 'topic-2', title: 'Mocks', description: 'How to mock' },
+      ],
+    };
+
+    const progress = model.computeProgress({
+      currentSectionIndex: 0,
+      totalSections: 2,
+      currentItemIndex: 4,
+      totalItemsInSection: 8,
+      currentSection: section,
+    });
+
+    expect(progress.currentSection).toMatchObject({
+      sectionId: 'section-1',
+      title: 'Unit Testing',
+      topicsAttempted: 2,
+      topicsTotal: 2,
+      mastery: 0.625,
+    });
+    expect(progress.currentSection!.topics[0]).toMatchObject({
+      topicId: 'topic-1',
+      title: 'Assertions',
+      status: 'struggling',
+      needsReview: true,
+    });
+    expect(progress.currentSection!.topics[1]).toMatchObject({
+      topicId: 'topic-2',
+      title: 'Mocks',
+      status: 'mastered',
+      needsReview: false,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add engine-owned progress summary helpers for topic status, review flags, section progress, and course progress
- Include current-section topic progress in `SessionProgress` so the learn page renders emitted display data
- Delegate app course progress summaries to the engine helper instead of deriving mastery in app code

## Cross-package reason

This touches both packages because the engine owns mastery/gap calculations, and the Svelte app needed to consume the new engine-provided progress summaries to remove duplicated UI logic.

## Verification

- `corepack pnpm format`
- `corepack pnpm -r test`
- `corepack pnpm -r build`

Closes #96