### PR TITLE
fix(engine/app): strip unknown imported snapshot fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
 - **Engine/App:** Move topic status, review flags, and course progress summary calculations behind engine-owned progress helpers so the app only formats and renders emitted progress data
 - **Engine/App:** Strip unknown fields from imported engine snapshots before persistence or re-export so stale or malicious import metadata cannot carry secrets forward
+- **Engine:** Copy imported generated-content and mastery records with own data properties so `__proto__` keys cannot mutate returned snapshot prototypes
 
 ## 0.9.0 — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
 - **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
 - **Engine/App:** Move topic status, review flags, and course progress summary calculations behind engine-owned progress helpers so the app only formats and renders emitted progress data
+- **Engine/App:** Strip unknown fields from imported engine snapshots before persistence or re-export so stale or malicious import metadata cannot carry secrets forward
 
 ## 0.9.0 — 2026-05-10
 

--- a/apps/coursequizzer/tests/unit/course-storage.test.ts
+++ b/apps/coursequizzer/tests/unit/course-storage.test.ts
@@ -10,6 +10,7 @@ import {
   type CourseRecord,
 } from '../../src/lib/storage/course-storage.js';
 import {
+  Exporter,
   SNAPSHOT_VERSION,
   type CurriculumPlan,
   type EngineSnapshot,
@@ -315,6 +316,41 @@ describe('course-storage', () => {
 
     const raw = storage.getItem(COURSES_STORAGE_KEY)!;
     expect(raw).not.toContain('sk-ant-secret');
+  });
+
+  it('strips unknown imported snapshot fields before persistence and export', () => {
+    const snapshotWithUnknownFields = {
+      ...mockSnapshot(),
+      provider: { apiKey: 'sk-ant-provider-secret' },
+      headers: { 'x-api-key': 'sk-ant-header-secret' },
+      debug: { rawApiKey: 'sk-ant-debug-secret' },
+    };
+
+    const courseId = importCourse(
+      {
+        title: 'Imported course',
+        curriculum: mockCurriculumPlan(),
+        snapshot: snapshotWithUnknownFields,
+      },
+      storage
+    );
+
+    const raw = storage.getItem(COURSES_STORAGE_KEY)!;
+    expect(raw).not.toContain('sk-ant-provider-secret');
+    expect(raw).not.toContain('sk-ant-header-secret');
+    expect(raw).not.toContain('sk-ant-debug-secret');
+
+    const stored = getCourse(courseId, storage);
+    expect(stored).not.toBeNull();
+    const storedSnapshot = stored!.snapshot as EngineSnapshot & Record<string, unknown>;
+    expect(storedSnapshot.provider).toBeUndefined();
+    expect(storedSnapshot.headers).toBeUndefined();
+    expect(storedSnapshot.debug).toBeUndefined();
+
+    const exported = new Exporter().exportToString(stored!.snapshot!);
+    expect(exported).not.toContain('sk-ant-provider-secret');
+    expect(exported).not.toContain('sk-ant-header-secret');
+    expect(exported).not.toContain('sk-ant-debug-secret');
   });
 
   // --- Defensive copies ---

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -1,16 +1,8 @@
 import { validateCurriculumPlan } from '../curriculum/SyllabusParser.js';
 import { SNAPSHOT_VERSION } from '../engine/constants.js';
 import type { CurriculumPlan, EngineSnapshot } from '../engine/types.js';
-
-function deepCopy<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function sanitizeSnapshot(snapshot: EngineSnapshot): EngineSnapshot {
-  const copy = { ...snapshot };
-  delete (copy as Record<string, unknown>)['apiKey'];
-  return copy;
-}
+import type { AnswerResult, ContentItem, StudentAnswer } from '../content/types.js';
+import type { StudentState } from '../student/types.js';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -33,7 +25,7 @@ function isValidEngineState(value: unknown): boolean {
   );
 }
 
-function isValidStudentState(value: unknown): boolean {
+function isValidStudentState(value: unknown): value is StudentState {
   if (!isPlainObject(value)) return false;
   if (!isPlainObject(value.masteryByTopic) || !isStringArray(value.gaps)) return false;
 
@@ -48,7 +40,7 @@ function isValidStudentState(value: unknown): boolean {
   });
 }
 
-function isValidStudentAnswer(value: unknown): boolean {
+function isValidStudentAnswer(value: unknown): value is StudentAnswer {
   if (!isPlainObject(value) || typeof value.type !== 'string') return false;
 
   switch (value.type) {
@@ -85,7 +77,7 @@ function isValidStudentAnswer(value: unknown): boolean {
   }
 }
 
-function isValidAnswerResult(value: unknown): boolean {
+function isValidAnswerResult(value: unknown): value is AnswerResult {
   if (!isPlainObject(value)) return false;
   return (
     typeof value.correct === 'boolean' &&
@@ -97,7 +89,7 @@ function isValidAnswerResult(value: unknown): boolean {
   );
 }
 
-function isValidContentItem(value: unknown): boolean {
+function isValidContentItem(value: unknown): value is ContentItem {
   if (!isPlainObject(value) || typeof value.type !== 'string') return false;
 
   switch (value.type) {
@@ -199,10 +191,193 @@ function isValidGeneratedContentRecord(value: unknown): boolean {
   );
 }
 
+// --- Canonical copies ---
+
+function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {
+  switch (answer.type) {
+    case 'multiple-choice':
+      return { type: answer.type, selectedIndex: answer.selectedIndex };
+    case 'numeric-input':
+      return { type: answer.type, value: answer.value };
+    case 'ordering':
+      return { type: answer.type, order: [...answer.order] };
+    case 'multi-select':
+      return { type: answer.type, selectedIndices: [...answer.selectedIndices] };
+    case 'two-stage':
+      return {
+        type: answer.type,
+        selectedIndex: answer.selectedIndex,
+        followUpSelectedIndex: answer.followUpSelectedIndex,
+      };
+    case 'checklist':
+      return { type: answer.type, checkedIndices: [...answer.checkedIndices] };
+    case 'code':
+      return { type: answer.type, code: answer.code };
+    case 'self-evaluation':
+      return { type: answer.type, selectedIndex: answer.selectedIndex };
+  }
+}
+
+function copyAnswerResult(result: AnswerResult): AnswerResult {
+  const copy: AnswerResult = {
+    correct: result.correct,
+    questionId: result.questionId,
+    topicId: result.topicId,
+    userAnswer: copyStudentAnswer(result.userAnswer),
+    correctAnswer: result.correctAnswer,
+  };
+
+  if (result.explanation !== undefined) {
+    copy.explanation = result.explanation;
+  }
+
+  return copy;
+}
+
+function copyContentItem(item: ContentItem): ContentItem {
+  switch (item.type) {
+    case 'explanation':
+      return {
+        type: item.type,
+        topicId: item.topicId,
+        title: item.title,
+        content: item.content,
+      };
+    case 'multiple-choice':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        options: [...item.options],
+        correctIndex: item.correctIndex,
+      };
+    case 'numeric-input': {
+      const copy: ContentItem = {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        correctValue: item.correctValue,
+      };
+      if (item.tolerance !== undefined) copy.tolerance = item.tolerance;
+      if (item.unit !== undefined) copy.unit = item.unit;
+      return copy;
+    }
+    case 'ordering':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        items: [...item.items],
+        correctOrder: [...item.correctOrder],
+      };
+    case 'multi-select':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        options: [...item.options],
+        correctIndices: [...item.correctIndices],
+      };
+    case 'two-stage':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        options: [...item.options],
+        correctIndex: item.correctIndex,
+        followUp: item.followUp,
+        followUpOptions: [...item.followUpOptions],
+        followUpCorrectIndex: item.followUpCorrectIndex,
+      };
+    case 'checklist':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        items: [...item.items],
+      };
+    case 'code': {
+      const copy: ContentItem = {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        language: item.language,
+      };
+      if (item.initialCode !== undefined) copy.initialCode = item.initialCode;
+      if (item.expectedPattern !== undefined) copy.expectedPattern = item.expectedPattern;
+      return copy;
+    }
+    case 'self-evaluation':
+      return {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        options: [...item.options],
+      };
+  }
+}
+
+function copyGeneratedContentRecord(
+  allGeneratedContent: Record<string, ContentItem[]> | undefined
+): Record<string, ContentItem[]> {
+  const copy: Record<string, ContentItem[]> = {};
+  if (!allGeneratedContent) return copy;
+
+  for (const [sectionId, items] of Object.entries(allGeneratedContent)) {
+    copy[sectionId] = items.map(copyContentItem);
+  }
+
+  return copy;
+}
+
+function copyStudentState(state: StudentState): StudentState {
+  const masteryByTopic: StudentState['masteryByTopic'] = {};
+
+  for (const [topicId, mastery] of Object.entries(state.masteryByTopic)) {
+    masteryByTopic[topicId] = {
+      topicId: mastery.topicId,
+      score: mastery.score,
+      questionsAnswered: mastery.questionsAnswered,
+      questionsCorrect: mastery.questionsCorrect,
+    };
+  }
+
+  return {
+    masteryByTopic,
+    gaps: [...state.gaps],
+  };
+}
+
+function copyEngineSnapshot(snapshot: EngineSnapshot): EngineSnapshot {
+  return {
+    version: snapshot.version,
+    state: snapshot.state,
+    curriculum:
+      snapshot.curriculum === null ? null : validateCurriculumPlan(snapshot.curriculum),
+    currentSectionIndex: snapshot.currentSectionIndex,
+    currentItemIndex: snapshot.currentItemIndex,
+    sectionItems: snapshot.sectionItems.map(copyContentItem),
+    allGeneratedContent: copyGeneratedContentRecord(snapshot.allGeneratedContent),
+    studentState: copyStudentState(snapshot.studentState),
+    lastAnswerResult:
+      snapshot.lastAnswerResult === null
+        ? null
+        : copyAnswerResult(snapshot.lastAnswerResult),
+  };
+}
+
 export function validateEngineSnapshot(value: unknown): EngineSnapshot | null {
   if (!isPlainObject(value)) return null;
 
-  const snapshot = sanitizeSnapshot(value as EngineSnapshot);
+  const snapshot = value as EngineSnapshot;
   const supportedVersions = [3, SNAPSHOT_VERSION];
   const hasGeneratedContent = 'allGeneratedContent' in snapshot;
 
@@ -229,5 +404,5 @@ export function validateEngineSnapshot(value: unknown): EngineSnapshot | null {
     return null;
   }
 
-  return deepCopy(snapshot);
+  return copyEngineSnapshot(snapshot);
 }

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -193,6 +193,15 @@ function isValidGeneratedContentRecord(value: unknown): boolean {
 
 // --- Canonical copies ---
 
+function setRecordEntry<T>(record: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(record, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
 function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {
   switch (answer.type) {
     case 'multiple-choice':
@@ -332,7 +341,7 @@ function copyGeneratedContentRecord(
   if (!allGeneratedContent) return copy;
 
   for (const [sectionId, items] of Object.entries(allGeneratedContent)) {
-    copy[sectionId] = items.map(copyContentItem);
+    setRecordEntry(copy, sectionId, items.map(copyContentItem));
   }
 
   return copy;
@@ -342,12 +351,12 @@ function copyStudentState(state: StudentState): StudentState {
   const masteryByTopic: StudentState['masteryByTopic'] = {};
 
   for (const [topicId, mastery] of Object.entries(state.masteryByTopic)) {
-    masteryByTopic[topicId] = {
+    setRecordEntry(masteryByTopic, topicId, {
       topicId: mastery.topicId,
       score: mastery.score,
       questionsAnswered: mastery.questionsAnswered,
       questionsCorrect: mastery.questionsCorrect,
-    };
+    });
   }
 
   return {

--- a/packages/engine/tests/export.test.ts
+++ b/packages/engine/tests/export.test.ts
@@ -185,4 +185,78 @@ describe('Exporter & Importer', () => {
     expect(exported).not.toContain('sk-ant-header-secret');
     expect(exported).not.toContain('sk-ant-debug-secret');
   });
+
+  it('copies imported generated content __proto__ keys as own data properties', () => {
+    const importer = new Importer();
+    const validSnapshot = createValidSnapshot();
+    const generatedContentWithProtoKey = {
+      ...validSnapshot.allGeneratedContent,
+      ['__proto__']: mockSectionContent(),
+    };
+
+    const importedSnapshot = importer.import(
+      JSON.stringify({
+        type: 'coursequizzer-export',
+        version: 1,
+        data: {
+          ...validSnapshot,
+          allGeneratedContent: generatedContentWithProtoKey,
+        },
+      })
+    );
+
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        importedSnapshot.allGeneratedContent,
+        '__proto__'
+      )
+    ).toBe(true);
+    expect(Object.getPrototypeOf(importedSnapshot.allGeneratedContent)).toBe(
+      Object.prototype
+    );
+    expect(importedSnapshot.allGeneratedContent['__proto__']).toEqual(
+      mockSectionContent()
+    );
+  });
+
+  it('copies imported mastery __proto__ keys as own data properties', () => {
+    const importer = new Importer();
+    const validSnapshot = createValidSnapshot();
+    const protoMastery = {
+      topicId: '__proto__',
+      score: 0.5,
+      questionsAnswered: 2,
+      questionsCorrect: 1,
+    };
+
+    const importedSnapshot = importer.import(
+      JSON.stringify({
+        type: 'coursequizzer-export',
+        version: 1,
+        data: {
+          ...validSnapshot,
+          studentState: {
+            masteryByTopic: {
+              ...validSnapshot.studentState.masteryByTopic,
+              ['__proto__']: protoMastery,
+            },
+            gaps: [],
+          },
+        },
+      })
+    );
+
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        importedSnapshot.studentState.masteryByTopic,
+        '__proto__'
+      )
+    ).toBe(true);
+    expect(Object.getPrototypeOf(importedSnapshot.studentState.masteryByTopic)).toBe(
+      Object.prototype
+    );
+    expect(importedSnapshot.studentState.masteryByTopic['__proto__']).toEqual(
+      protoMastery
+    );
+  });
 });

--- a/packages/engine/tests/export.test.ts
+++ b/packages/engine/tests/export.test.ts
@@ -155,4 +155,34 @@ describe('Exporter & Importer', () => {
 
     expect(() => importer.import(bundle)).toThrow('Invalid engine snapshot');
   });
+
+  it('strips unknown snapshot fields before re-exporting imported data', () => {
+    const exporter = new Exporter();
+    const importer = new Importer();
+    const snapshotWithUnknownFields = {
+      ...createValidSnapshot(),
+      provider: { apiKey: 'sk-ant-provider-secret' },
+      headers: { 'x-api-key': 'sk-ant-header-secret' },
+      debug: { rawApiKey: 'sk-ant-debug-secret' },
+    };
+
+    const importedSnapshot = importer.import(
+      JSON.stringify({
+        type: 'coursequizzer-export',
+        version: 1,
+        data: snapshotWithUnknownFields,
+      })
+    );
+    const importedRecord = importedSnapshot as typeof importedSnapshot &
+      Record<string, unknown>;
+
+    expect(importedRecord.provider).toBeUndefined();
+    expect(importedRecord.headers).toBeUndefined();
+    expect(importedRecord.debug).toBeUndefined();
+
+    const exported = exporter.exportToString(importedSnapshot);
+    expect(exported).not.toContain('sk-ant-provider-secret');
+    expect(exported).not.toContain('sk-ant-header-secret');
+    expect(exported).not.toContain('sk-ant-debug-secret');
+  });
 });


### PR DESCRIPTION
## Summary
- Rebuild imported engine snapshots from known schema fields instead of copying arbitrary imported objects
- Canonicalize nested content, generated-content, student-state, and answer-result data during snapshot validation
- Add engine import/export and app storage regressions proving secret-bearing unknown fields are not persisted or re-exported

## Cross-package scope
This touches the engine validator because it owns imported snapshot shape validation, and the app tests because course import persists validated snapshots and later exports them from local storage.

## Verification
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format

Closes #97