### PR TITLE
test(engine): cover error-state import restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
 - **Engine/App:** Move topic status, review flags, and course progress summary calculations behind engine-owned progress helpers so the app only formats and renders emitted progress data
 - **Engine:** Tighten imported snapshot validation for mastery ranges, question counts, answer-key bounds, and state-aware section/item indices
+- **Engine:** Add import coverage for recoverable error-state snapshots so exports from generation failures restore back to `ready`
 - **Engine/App:** Strip unknown fields from imported engine snapshots before persistence or re-export so stale or malicious import metadata cannot carry secrets forward
 - **Engine:** Copy imported generated-content and mastery records with own data properties so `__proto__` keys cannot mutate returned snapshot prototypes
 - **Engine/App:** Move topic mastery display status, review flags, and snapshot progress summaries into the engine so the app only formats engine-provided progress values

--- a/packages/engine/tests/export.test.ts
+++ b/packages/engine/tests/export.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { CourseEngine } from '../src/engine/CourseEngine.js';
 import { Exporter } from '../src/export/Exporter.js';
 import { Importer } from '../src/export/Importer.js';
@@ -69,6 +69,31 @@ describe('Exporter & Importer', () => {
     expect(restoredEngine.state).toBe('practicing');
     expect(restoredEngine.curriculum?.title).toBe('Intro to Testing');
     expect(restoredEngine.currentItem?.title).toBe('Understanding Assertions');
+  });
+
+  it('imports error-state snapshots and restores them as ready', async () => {
+    const exporter = new Exporter();
+    const importer = new Importer();
+    const generator = {
+      generateTopicExplanation: vi.fn(() => Promise.reject(new Error('API Failure'))),
+      generateTopicQuizBurst: vi.fn(),
+    };
+    const engine = new CourseEngine({ apiKey: 'sk-test-key', generator });
+
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const snapshot = engine.serialize();
+    expect(snapshot.state).toBe('error');
+
+    const importedSnapshot = importer.import(exporter.exportToString(snapshot));
+    const restoredEngine = CourseEngine.restore(importedSnapshot, {
+      apiKey: 'sk-new-key',
+    });
+
+    expect(importedSnapshot.state).toBe('error');
+    expect(restoredEngine.state).toBe('ready');
   });
 
   it('maintains allGeneratedContent across sections', () => {


### PR DESCRIPTION
Closes #99

## Summary
- add regression coverage for importing an engine snapshot serialized from a recoverable generation error
- verify restored engines resume from ready while the imported snapshot preserves error state
- update CHANGELOG.md

## Verification
- corepack pnpm --dir packages/engine test -- export.test.ts
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format