### PR TITLE
fix(engine): reuse in-flight prefetch generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **Engine/App:** Strip unknown fields from imported engine snapshots before persistence or re-export so stale or malicious import metadata cannot carry secrets forward
 - **Engine:** Copy imported generated-content and mastery records with own data properties so `__proto__` keys cannot mutate returned snapshot prototypes
 - **Engine/App:** Move topic mastery display status, review flags, and snapshot progress summaries into the engine so the app only formats engine-provided progress values
+- **Engine:** Reuse in-flight prefetch generation when starting a prefetched section so the engine does not make duplicate foreground and background API calls for the same section
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/Prefetcher.ts
+++ b/packages/engine/src/content/Prefetcher.ts
@@ -8,12 +8,13 @@ import type { ContentCache } from './ContentCache.js';
 import type { CurriculumPlan } from '../curriculum/types.js';
 import type { StudentModel } from '../student/StudentModel.js';
 import { ContentManager } from './ContentManager.js';
+import type { ContentItem } from './types.js';
 
 export class Prefetcher {
   #manager: ContentManager;
   #cache: ContentCache;
   #curriculum: CurriculumPlan | null = null;
-  #inProgress = new Set<string>();
+  #inProgress = new Map<string, Promise<ContentItem[]>>();
 
   constructor(generator: TopicContentGenerator, cache: ContentCache) {
     this.#manager = new ContentManager(generator, () => {
@@ -30,6 +31,15 @@ export class Prefetcher {
   }
 
   /**
+   * Return the active prefetch promise for a section, if one exists.
+   * CourseEngine uses this to avoid generating the same section twice when
+   * the student reaches a section while its background prefetch is still running.
+   */
+  getInProgress(sectionId: string): Promise<ContentItem[]> | undefined {
+    return this.#inProgress.get(sectionId);
+  }
+
+  /**
    * Trigger prefetching of the next section.
    * This is a fire-and-forget background operation.
    */
@@ -42,14 +52,15 @@ export class Prefetcher {
     const nextSection = this.#curriculum.sections[nextIndex];
     if (this.#cache.has(nextSection.id) || this.#inProgress.has(nextSection.id)) return;
 
-    this.#inProgress.add(nextSection.id);
+    const generation = this.#manager
+      .generateSection(nextSection, this.#curriculum.title, studentModel)
+      .then((items) => {
+        this.#cache.set(nextSection.id, items);
+        return items;
+      });
+    this.#inProgress.set(nextSection.id, generation);
     try {
-      const items = await this.#manager.generateSection(
-        nextSection,
-        this.#curriculum.title,
-        studentModel
-      );
-      this.#cache.set(nextSection.id, items);
+      await generation;
     } catch (_err) {
       // Errors in the background prefetcher are ignored — the engine
       // will just fall back to its standard generation when the student
@@ -59,7 +70,9 @@ export class Prefetcher {
         `Prefetch background generation failed for section "${nextSection.id}": non-critical error during generation`
       );
     } finally {
-      this.#inProgress.delete(nextSection.id);
+      if (this.#inProgress.get(nextSection.id) === generation) {
+        this.#inProgress.delete(nextSection.id);
+      }
     }
   }
 }

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -235,6 +235,7 @@ export class CourseEngine extends EventEmitter {
     this.#lastAnswerResult = null;
 
     const section = copySection(this.#curriculum.sections[sectionIndex]);
+    const courseTitle = this.#curriculum.title;
     this.#setState('loading');
     this.emit('sectionStart', {
       section,
@@ -249,9 +250,26 @@ export class CourseEngine extends EventEmitter {
       return;
     }
 
-    // Trigger async generation
+    const inProgressPrefetch = this.#prefetcher?.getInProgress(sectionId);
+    if (inProgressPrefetch) {
+      inProgressPrefetch
+        .then((items) => {
+          this.setSectionContent(items);
+        })
+        .catch(() => {
+          // The background attempt failed; retry as foreground generation so
+          // the existing prefetch failure fallback still applies.
+          this.#generateSectionContent(section, courseTitle);
+        });
+      return;
+    }
+
+    this.#generateSectionContent(section, courseTitle);
+  }
+
+  #generateSectionContent(section: Section, courseTitle: string): void {
     this.#contentManager
-      .generateSection(section, this.#curriculum.title, this.#studentModel)
+      .generateSection(section, courseTitle, this.#studentModel)
       .then((items) => {
         this.setSectionContent(items);
       })

--- a/packages/engine/tests/prefetcher.test.ts
+++ b/packages/engine/tests/prefetcher.test.ts
@@ -9,7 +9,7 @@ import { ContentManager } from '../src/content/ContentManager.js';
 import { StudentModel } from '../src/student/StudentModel.js';
 import type { ClaudeProvider } from '../src/provider/ClaudeProvider.js';
 import type { CurriculumPlan } from '../src/curriculum/types.js';
-import type { ContentItem } from '../src/content/types.js';
+import type { ContentItem, Explanation, Question } from '../src/content/types.js';
 
 // --- Mocks & Fixtures ---
 
@@ -78,6 +78,33 @@ function mockGenerator(generator: ContentGenerator) {
   vi.spyOn(generator, 'generateTopicQuizBurst').mockResolvedValue(
     MOCK_QUESTIONS_T2 as any
   );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
 }
 
 describe('ContentCache', () => {
@@ -273,6 +300,150 @@ describe('CourseEngine + Prefetcher integration', () => {
     expect(engine.state).toBe('practicing');
     expect(contentReadySpy).toHaveBeenCalled();
     expect(engine.currentItem).toEqual(MOCK_ITEMS_S2[0]);
+  });
+
+  it('waits for in-flight prefetch instead of generating the section again', async () => {
+    const provider = mockProvider();
+    const generator = new ContentGenerator(provider);
+    const s2Explanation = deferred<Explanation>();
+    const s2Questions = deferred<Question[]>();
+
+    const expSpy = vi
+      .spyOn(generator, 'generateTopicExplanation')
+      .mockImplementation(async (topic) => {
+        if (topic.id === 't2') {
+          return s2Explanation.promise;
+        }
+
+        return {
+          type: 'explanation',
+          topicId: topic.id,
+          title: `Explanation for ${topic.id}`,
+          content: `Content for ${topic.id}`,
+        };
+      });
+
+    const quizSpy = vi
+      .spyOn(generator, 'generateTopicQuizBurst')
+      .mockImplementation(async (topic) => {
+        if (topic.id === 't2') {
+          return s2Questions.promise;
+        }
+
+        return [
+          {
+            type: 'multiple-choice',
+            id: `q-${topic.id}`,
+            topicId: topic.id,
+            question: `Q ${topic.id}`,
+            options: ['A', 'B'],
+            correctIndex: 0,
+          },
+        ];
+      });
+
+    const engine = new CourseEngine({
+      apiKey: 'test',
+      generator,
+      prefetch: { enabled: true },
+    });
+
+    engine.loadCurriculum(MOCK_PLAN);
+    engine.startSection('s1');
+
+    await waitForAssertion(() => expect(engine.state).toBe('practicing'));
+    await waitForAssertion(() =>
+      expect(expSpy.mock.calls.filter(([topic]) => topic.id === 't2')).toHaveLength(1)
+    );
+
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+    expect(engine.state).toBe('sectionComplete');
+
+    engine.startSection('s2');
+    expect(engine.state).toBe('loading');
+    expect(expSpy.mock.calls.filter(([topic]) => topic.id === 't2')).toHaveLength(1);
+
+    s2Explanation.resolve(MOCK_EXPLANATION_T2);
+    await waitForAssertion(() =>
+      expect(quizSpy.mock.calls.filter(([topic]) => topic.id === 't2')).toHaveLength(1)
+    );
+    s2Questions.resolve(MOCK_QUESTIONS_T2);
+
+    await waitForAssertion(() => expect(engine.state).toBe('practicing'));
+    expect(quizSpy.mock.calls.filter(([topic]) => topic.id === 't2')).toHaveLength(1);
+    expect(engine.currentItem).toEqual(MOCK_EXPLANATION_T2);
+  });
+
+  it('falls back to foreground generation if in-flight prefetch fails', async () => {
+    const provider = mockProvider();
+    const generator = new ContentGenerator(provider);
+    const prefetchFailure = deferred<Explanation>();
+    let t2ExplanationAttempts = 0;
+
+    const expSpy = vi
+      .spyOn(generator, 'generateTopicExplanation')
+      .mockImplementation(async (topic) => {
+        if (topic.id === 't2') {
+          t2ExplanationAttempts += 1;
+          if (t2ExplanationAttempts === 1) {
+            return prefetchFailure.promise;
+          }
+
+          return MOCK_EXPLANATION_T2;
+        }
+
+        return {
+          type: 'explanation',
+          topicId: topic.id,
+          title: `Explanation for ${topic.id}`,
+          content: `Content for ${topic.id}`,
+        };
+      });
+
+    vi.spyOn(generator, 'generateTopicQuizBurst').mockImplementation(async (topic) => {
+      if (topic.id === 't2') {
+        return MOCK_QUESTIONS_T2;
+      }
+
+      return [
+        {
+          type: 'multiple-choice',
+          id: `q-${topic.id}`,
+          topicId: topic.id,
+          question: `Q ${topic.id}`,
+          options: ['A', 'B'],
+          correctIndex: 0,
+        },
+      ];
+    });
+
+    const engine = new CourseEngine({
+      apiKey: 'test',
+      generator,
+      prefetch: { enabled: true },
+    });
+
+    engine.loadCurriculum(MOCK_PLAN);
+    engine.startSection('s1');
+
+    await waitForAssertion(() => expect(engine.state).toBe('practicing'));
+    await waitForAssertion(() => expect(t2ExplanationAttempts).toBe(1));
+
+    engine.nextItem();
+    engine.submitAnswer({ type: 'multiple-choice', selectedIndex: 0 });
+    engine.nextItem();
+
+    engine.startSection('s2');
+    expect(engine.state).toBe('loading');
+    expect(expSpy.mock.calls.filter(([topic]) => topic.id === 't2')).toHaveLength(1);
+
+    prefetchFailure.reject(new Error('prefetch failed'));
+
+    await waitForAssertion(() => expect(t2ExplanationAttempts).toBe(2));
+    await waitForAssertion(() => expect(engine.state).toBe('practicing'));
+    expect(engine.currentItem).toEqual(MOCK_EXPLANATION_T2);
   });
 
   it('triggers prefetch on startSection', async () => {


### PR DESCRIPTION
## Summary

- Track in-flight prefetch generation promises by section id.
- Make CourseEngine.startSection() wait for an active prefetch before falling back to foreground generation.
- Add regression coverage for no duplicate generation and foreground retry after prefetch failure.

## Verification

- pnpm --dir packages/engine test prefetcher
- pnpm -r test
- pnpm -r build
- pnpm format

Closes #100