### PR TITLE
fix(engine): retry content validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **Engine/App:** Strip unknown fields from imported engine snapshots before persistence or re-export so stale or malicious import metadata cannot carry secrets forward
 - **Engine:** Copy imported generated-content and mastery records with own data properties so `__proto__` keys cannot mutate returned snapshot prototypes
 - **Engine/App:** Move topic mastery display status, review flags, and snapshot progress summaries into the engine so the app only formats engine-provided progress values
+- **Engine:** Retry explanation and quiz generation once when tool payload parsing or content validation fails, matching the existing missing-tool retry behavior
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -16,7 +16,7 @@
 import { buildExplanationPrompt } from '../prompts/explanation.js';
 import { buildQuizGenerationPrompt } from '../prompts/quiz-generation.js';
 import { checkQuestionQuality } from './quality-filters.js';
-import type { ProviderClient, ToolUseBlock } from '../provider/types.js';
+import type { ProviderClient, ProviderRequest, ToolUseBlock } from '../provider/types.js';
 import type { Topic } from '../curriculum/types.js';
 import type { Explanation, Question, QuestionType } from './types.js';
 
@@ -59,38 +59,47 @@ export class ContentGenerator implements TopicContentGenerator {
       sectionTitle,
     });
 
-    const response = await this.#provider.sendMessage({
-      ...prompt,
-      maxTokens: EXPLANATION_MAX_TOKENS,
-    });
-
-    const toolBlock = response.content.find(
-      (block): block is ToolUseBlock =>
-        block.type === 'tool_use' && block.name === 'create_explanation'
-    );
-
-    if (!toolBlock) {
-      // Retry once
-      const retryResponse = await this.#provider.sendMessage({
+    return this.#sendAndParseToolWithRetry(
+      {
         ...prompt,
         maxTokens: EXPLANATION_MAX_TOKENS,
-      });
+      },
+      'create_explanation',
+      `Failed to generate explanation for topic "${topic.title}" after retry`,
+      (toolBlock) => this.#parseExplanation(toolBlock, topic.id)
+    );
+  }
 
-      const retryBlock = retryResponse.content.find(
+  // --- Provider Response Handling ---
+
+  async #sendAndParseToolWithRetry<T>(
+    request: ProviderRequest,
+    toolName: string,
+    failureMessage: string,
+    parse: (block: ToolUseBlock) => T
+  ): Promise<T> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await this.#provider.sendMessage(request);
+      const toolBlock = response.content.find(
         (block): block is ToolUseBlock =>
-          block.type === 'tool_use' && block.name === 'create_explanation'
+          block.type === 'tool_use' && block.name === toolName
       );
 
-      if (!retryBlock) {
-        throw new Error(
-          `Failed to generate explanation for topic "${topic.title}" after retry`
-        );
+      if (!toolBlock) {
+        lastError = new Error(failureMessage);
+        continue;
       }
 
-      return this.#parseExplanation(retryBlock, topic.id);
+      try {
+        return parse(toolBlock);
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
     }
 
-    return this.#parseExplanation(toolBlock, topic.id);
+    throw lastError ?? new Error(failureMessage);
   }
 
   #parseExplanation(block: ToolUseBlock, topicId: string): Explanation {
@@ -129,36 +138,15 @@ export class ContentGenerator implements TopicContentGenerator {
       questionCount,
     });
 
-    const response = await this.#provider.sendMessage({
-      ...prompt,
-      maxTokens: QUIZ_MAX_TOKENS,
-    });
-
-    const toolBlock = response.content.find(
-      (block): block is ToolUseBlock =>
-        block.type === 'tool_use' && block.name === 'create_quiz_questions'
-    );
-
-    if (!toolBlock) {
-      // Retry once
-      const retryResponse = await this.#provider.sendMessage({
+    return this.#sendAndParseToolWithRetry(
+      {
         ...prompt,
         maxTokens: QUIZ_MAX_TOKENS,
-      });
-
-      const retryBlock = retryResponse.content.find(
-        (block): block is ToolUseBlock =>
-          block.type === 'tool_use' && block.name === 'create_quiz_questions'
-      );
-
-      if (!retryBlock) {
-        throw new Error(`Failed to generate quiz for topic "${topic.title}" after retry`);
-      }
-
-      return this.#parseAndFilterQuestions(retryBlock, topic.id, questionCount);
-    }
-
-    return this.#parseAndFilterQuestions(toolBlock, topic.id, questionCount);
+      },
+      'create_quiz_questions',
+      `Failed to generate quiz for topic "${topic.title}" after retry`,
+      (toolBlock) => this.#parseAndFilterQuestions(toolBlock, topic.id, questionCount)
+    );
   }
 
   #parseAndFilterQuestions(

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -316,8 +316,9 @@ describe('ContentGenerator', () => {
     expect(types).toContain('two-stage');
   });
 
-  it('rejects quiz bursts when validation drops below the requested count', async () => {
+  it('rejects quiz bursts when validation still drops below the requested count after retry', async () => {
     const provider = mockProvider(
+      quizResponse([GOOD_MCQ, LENGTH_OUTLIER_MCQ, GOOD_NUMERIC]),
       quizResponse([GOOD_MCQ, LENGTH_OUTLIER_MCQ, GOOD_NUMERIC])
     );
     const gen = new ContentGenerator(provider);
@@ -325,6 +326,7 @@ describe('ContentGenerator', () => {
     await expect(gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 3)).rejects.toThrow(
       'Expected exactly 3 questions for topic "binary-search", got 2 after validation'
     );
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
   it('retries explanation on malformed response', async () => {
@@ -340,6 +342,19 @@ describe('ContentGenerator', () => {
     expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
+  it('retries explanation when tool payload validation fails', async () => {
+    const provider = mockProvider(
+      explanationResponse('Binary Search', ''),
+      explanationResponse('Binary Search', 'Content...')
+    );
+    const gen = new ContentGenerator(provider);
+
+    const item = await gen.generateTopicExplanation(TOPIC, 'C', 'S');
+
+    expect(item.content).toBe('Content...');
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
   it('retries quiz on malformed response', async () => {
     const provider = mockProvider(
       textOnlyResponse(), // first quiz attempt fails
@@ -350,6 +365,38 @@ describe('ContentGenerator', () => {
     const questions = await gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 1);
 
     expect(questions).toHaveLength(1);
+  });
+
+  it('retries quiz when validation drops below the requested count', async () => {
+    const provider = mockProvider(
+      quizResponse([GOOD_MCQ, LENGTH_OUTLIER_MCQ, GOOD_NUMERIC]),
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const questions = await gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 3);
+
+    expect(questions).toHaveLength(3);
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
+  it('retries quiz when the raw response has the wrong question count', async () => {
+    const provider = mockProvider(
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING]),
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const questions = await gen.generateTopicQuizBurst(
+      TOPIC,
+      'Algorithms',
+      'Search',
+      'Content...',
+      2
+    );
+
+    expect(questions).toHaveLength(2);
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
   it('throws after retry if explanation still fails', async () => {
@@ -372,21 +419,29 @@ describe('ContentGenerator', () => {
 
   it('rejects numeric-input with negative tolerance', async () => {
     const negTolerance = { ...GOOD_NUMERIC, tolerance: -1 };
-    const provider = mockProvider(quizResponse([negTolerance]));
+    const provider = mockProvider(
+      quizResponse([negTolerance]),
+      quizResponse([negTolerance])
+    );
     const gen = new ContentGenerator(provider);
 
     await expect(gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 1)).rejects.toThrow(
       'failed validation'
     );
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
   it('throws if all questions fail validation', async () => {
-    const provider = mockProvider(quizResponse([LENGTH_OUTLIER_MCQ, FRONT_MATTER_MCQ]));
+    const provider = mockProvider(
+      quizResponse([LENGTH_OUTLIER_MCQ, FRONT_MATTER_MCQ]),
+      quizResponse([LENGTH_OUTLIER_MCQ, FRONT_MATTER_MCQ])
+    );
     const gen = new ContentGenerator(provider);
 
     await expect(gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 2)).rejects.toThrow(
       'failed validation'
     );
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
   it('assigns unique IDs to questions', async () => {
@@ -414,11 +469,15 @@ describe('ContentGenerator', () => {
   });
 
   it('rejects quiz bursts that do not return the requested question count', async () => {
-    const provider = mockProvider(quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING]));
+    const provider = mockProvider(
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING]),
+      quizResponse([GOOD_MCQ, GOOD_NUMERIC, GOOD_ORDERING])
+    );
     const gen = new ContentGenerator(provider);
 
     await expect(
       gen.generateTopicQuizBurst(TOPIC, 'Algorithms', 'Search', 'Content...', 2)
     ).rejects.toThrow('Expected exactly 2 questions for topic "binary-search", got 3');
+    expect((provider.sendMessage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- route explanation and quiz tool parsing through a shared one-retry helper
- retry once when explanation payloads, quiz counts, or quality validation fail
- update content-generator tests for retry success and retry-exhausted validation failures

## Tests
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format

Closes #101