### PR TITLE
fix: validate practical answer indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **Engine/App:** Move topic mastery display status, review flags, and snapshot progress summaries into the engine so the app only formats engine-provided progress values
 - **Engine:** Retry explanation and quiz generation once when tool payload parsing or content validation fails
 - **Engine:** Reuse in-flight prefetch generation when starting a prefetched section so the engine does not make duplicate foreground and background API calls for the same section
+- **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -511,8 +511,12 @@ export class CourseEngine extends EventEmitter {
       }
       case 'checklist': {
         const a = answer as { type: 'checklist'; checkedIndices: number[] };
-        // Correct if all items are checked
-        return a.checkedIndices.length === question.items.length;
+        const checked = new Set(a.checkedIndices);
+        return (
+          a.checkedIndices.length === question.items.length &&
+          checked.size === question.items.length &&
+          question.items.every((_, index) => checked.has(index))
+        );
       }
       case 'code': {
         const a = answer as { type: 'code'; code: string };
@@ -528,7 +532,12 @@ export class CourseEngine extends EventEmitter {
         return true; // Trust the student if no pattern provided
       }
       case 'self-evaluation': {
-        return true; // Always "correct" to report completion
+        const a = answer as { type: 'self-evaluation'; selectedIndex: number };
+        return (
+          Number.isInteger(a.selectedIndex) &&
+          a.selectedIndex >= 0 &&
+          a.selectedIndex < question.options.length
+        );
       }
     }
   }

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -60,6 +60,44 @@ describe('New Question Types', () => {
     expect(resultIncorrect.correct).toBe(false);
   });
 
+  it('rejects duplicate and out-of-range checklist indices', () => {
+    const checklistItem: ContentItem = {
+      type: 'checklist',
+      id: 'q-checklist',
+      topicId: 'topic-1',
+      question: 'Perform the following steps:',
+      items: ['Plug in guitar', 'Turn on amp', 'Tune strings'],
+    };
+
+    const engineWithDuplicates = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+    });
+    engineWithDuplicates.loadCurriculum(mockCurriculum());
+    engineWithDuplicates.startSection('section-1');
+    engineWithDuplicates.setSectionContent([checklistItem]);
+
+    const duplicateResult = engineWithDuplicates.submitAnswer({
+      type: 'checklist',
+      checkedIndices: [0, 0, 0],
+    });
+    expect(duplicateResult.correct).toBe(false);
+
+    const engineWithOutOfRangeIndex = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+    });
+    engineWithOutOfRangeIndex.loadCurriculum(mockCurriculum());
+    engineWithOutOfRangeIndex.startSection('section-1');
+    engineWithOutOfRangeIndex.setSectionContent([checklistItem]);
+
+    const outOfRangeResult = engineWithOutOfRangeIndex.submitAnswer({
+      type: 'checklist',
+      checkedIndices: [0, 1, 99],
+    });
+    expect(outOfRangeResult.correct).toBe(false);
+  });
+
   it('grades code correctly with expectedPattern', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
@@ -118,7 +156,7 @@ describe('New Question Types', () => {
     expect(result.correct).toBe(true);
   });
 
-  it('grades self-evaluation correctly (always true)', () => {
+  it('grades self-evaluation correctly when a valid option is selected', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
@@ -138,6 +176,44 @@ describe('New Question Types', () => {
       selectedIndex: 0,
     });
     expect(result.correct).toBe(true);
+  });
+
+  it('rejects invalid self-evaluation selected indices', () => {
+    const selfEvalItem: ContentItem = {
+      type: 'self-evaluation',
+      id: 'q-self-eval',
+      topicId: 'topic-1',
+      question: 'How do you feel about your progress?',
+      options: ['Need more practice', 'Got it'],
+    };
+
+    const engineWithOutOfRangeIndex = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+    });
+    engineWithOutOfRangeIndex.loadCurriculum(mockCurriculum());
+    engineWithOutOfRangeIndex.startSection('section-1');
+    engineWithOutOfRangeIndex.setSectionContent([selfEvalItem]);
+
+    const outOfRangeResult = engineWithOutOfRangeIndex.submitAnswer({
+      type: 'self-evaluation',
+      selectedIndex: 2,
+    });
+    expect(outOfRangeResult.correct).toBe(false);
+
+    const engineWithFractionalIndex = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+    });
+    engineWithFractionalIndex.loadCurriculum(mockCurriculum());
+    engineWithFractionalIndex.startSection('section-1');
+    engineWithFractionalIndex.setSectionContent([selfEvalItem]);
+
+    const fractionalResult = engineWithFractionalIndex.submitAnswer({
+      type: 'self-evaluation',
+      selectedIndex: 0.5,
+    });
+    expect(fractionalResult.correct).toBe(false);
   });
 
   it('round-trips new question types via serialization', () => {


### PR DESCRIPTION
Closes #102

## Summary
- Require checklist answers to contain each valid item index exactly once
- Require self-evaluation answers to select an existing option with an integer index
- Add regression tests for duplicate, out-of-range, and fractional practical answer indices

## Verification
- corepack pnpm --filter quizzer-engine test -- new-question-types
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format