### PR TITLE
fix: make code questions self-evaluated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ This app handles API keys in the browser and renders LLM-generated content. The 
 - [ ] **API key transmission** — Only to `api.anthropic.com`, only in the `x-api-key` header. Verify every `fetch()` call in the codebase.
 - [ ] **XSS in rendered content** — LLM-generated text must be escaped. In Svelte, `{expression}` auto-escapes. Every use of `{@html}` must be justified and wrapped in a sanitizer. Search for `{@html` during review.
 - [ ] **No `eval()`** — No `eval()`, `new Function()`, or dynamic script injection. No exceptions.
+- [ ] **No untrusted regex execution** — Never pass generated, imported, or user-controlled strings to `new RegExp()`. Code-question regex grading is forbidden in v1; use self-evaluation or the AI tutor path instead.
 - [ ] **CORS / browser access** — Direct browser-to-Anthropic API requires the `anthropic-dangerous-direct-browser-access` header. This is documented and intentional. No other unexpected CORS usage.
 - [ ] **Export security** — Export bundles must never include the API key. Verify with a test.
 - [ ] **Import validation** — Imported JSON is untrusted input. Validate shape and types before restoring state. Never `JSON.parse()` and cast without validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Engine:** Retry explanation and quiz generation once when tool payload parsing or content validation fails
 - **Engine:** Reuse in-flight prefetch generation when starting a prefetched section so the engine does not make duplicate foreground and background API calls for the same section
 - **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
+- **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
 
 ## 0.9.0 — 2026-05-10
 

--- a/apps/coursequizzer/tests/unit/learn-flow.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-flow.test.ts
@@ -196,6 +196,34 @@ describe('learn page flow', () => {
     expect(session.lastResult!.result.correct).toBe(false);
   });
 
+  it('handles code questions through the self-evaluation grading path', () => {
+    const session = createEngineSession({ apiKey: 'test-key' });
+    session.loadCurriculum(mockCurriculumPlan());
+    session.startSection('s1');
+    session.setSectionContent([
+      {
+        type: 'code',
+        id: 'q-code',
+        topicId: 't1',
+        question: 'Write a function that returns true.',
+        language: 'typescript',
+        initialCode: 'function answer() {}',
+        expectedPattern: 'return true',
+      } as unknown as ContentItem,
+    ]);
+
+    expect(session.currentItem!.item.type).toBe('code');
+
+    const result = session.submitAnswer({
+      type: 'code',
+      code: 'function answer() { return false; }',
+    });
+
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Self-assessment submitted');
+    expect(session.lastResult!.result.correct).toBe(true);
+  });
+
   it('can skip a question and continue', () => {
     const session = createEngineSession({ apiKey: 'test-key' });
     session.loadCurriculum(mockCurriculumPlan());

--- a/packages/engine/src/content/ContentGenerator.ts
+++ b/packages/engine/src/content/ContentGenerator.ts
@@ -415,8 +415,6 @@ export class ContentGenerator implements TopicContentGenerator {
   ): Question {
     const language = this.#requireString(obj.language, 'language');
     const initialCode = typeof obj.initialCode === 'string' ? obj.initialCode : undefined;
-    const expectedPattern =
-      typeof obj.expectedPattern === 'string' ? obj.expectedPattern : undefined;
 
     return {
       type: 'code',
@@ -425,7 +423,6 @@ export class ContentGenerator implements TopicContentGenerator {
       question,
       language,
       initialCode,
-      expectedPattern,
     };
   }
 

--- a/packages/engine/src/content/copy-utils.ts
+++ b/packages/engine/src/content/copy-utils.ts
@@ -34,8 +34,17 @@ export function copyContentItem(item: ContentItem): ContentItem {
         ...item,
         items: [...item.items],
       };
-    case 'code':
-      return { ...item };
+    case 'code': {
+      const copy: ContentItem = {
+        type: item.type,
+        id: item.id,
+        topicId: item.topicId,
+        question: item.question,
+        language: item.language,
+      };
+      if (item.initialCode !== undefined) copy.initialCode = item.initialCode;
+      return copy;
+    }
     case 'self-evaluation':
       return {
         ...item,

--- a/packages/engine/src/content/quality-filters.ts
+++ b/packages/engine/src/content/quality-filters.ts
@@ -207,7 +207,7 @@ function getCorrectIndices(question: Question): number[] | undefined {
     case 'ordering':
       return undefined; // Ordering is graded by sequence, not a single option index.
     case 'code':
-      return undefined; // Code is graded by pattern matching, not an option index.
+      return undefined; // Code is self-evaluated, not graded by an option index.
     default:
       return assertNever(question);
   }

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -78,7 +78,6 @@ export type CodeQuestion = {
   question: string;
   language: string;
   initialCode?: string;
-  expectedPattern?: string; // Optional regex to check for correctness
 };
 
 export type SelfEvaluationQuestion = {

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -519,6 +519,7 @@ export class CourseEngine extends EventEmitter {
         );
       }
       case 'code':
+        return true;
       case 'self-evaluation': {
         const a = answer as { type: 'self-evaluation'; selectedIndex: number };
         return (

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -518,19 +518,7 @@ export class CourseEngine extends EventEmitter {
           question.items.every((_, index) => checked.has(index))
         );
       }
-      case 'code': {
-        const a = answer as { type: 'code'; code: string };
-        if (question.expectedPattern) {
-          try {
-            const regex = new RegExp(question.expectedPattern, 's');
-            return regex.test(a.code);
-          } catch {
-            // If regex is invalid, we fallback to true (trust the student)
-            return true;
-          }
-        }
-        return true; // Trust the student if no pattern provided
-      }
+      case 'code':
       case 'self-evaluation': {
         const a = answer as { type: 'self-evaluation'; selectedIndex: number };
         return (
@@ -559,9 +547,6 @@ export class CourseEngine extends EventEmitter {
       case 'checklist':
         return 'Completion of all steps';
       case 'code':
-        return question.expectedPattern
-          ? `Code matching pattern: ${question.expectedPattern}`
-          : 'Correct implementation of the requested logic';
       case 'self-evaluation':
         return 'Self-assessment submitted';
     }

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -198,8 +198,7 @@ function isValidContentItem(value: unknown): value is ContentItem {
         typeof value.topicId === 'string' &&
         typeof value.question === 'string' &&
         typeof value.language === 'string' &&
-        (value.initialCode === undefined || typeof value.initialCode === 'string') &&
-        (value.expectedPattern === undefined || typeof value.expectedPattern === 'string')
+        (value.initialCode === undefined || typeof value.initialCode === 'string')
       );
     case 'self-evaluation':
       return (
@@ -413,7 +412,6 @@ function copyContentItem(item: ContentItem): ContentItem {
         language: item.language,
       };
       if (item.initialCode !== undefined) copy.initialCode = item.initialCode;
-      if (item.expectedPattern !== undefined) copy.expectedPattern = item.expectedPattern;
       return copy;
     }
     case 'self-evaluation':

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -5,7 +5,7 @@
 
 import type { PromptMessages } from './types.js';
 
-export const QUIZ_GENERATION_VERSION = '1.3';
+export const QUIZ_GENERATION_VERSION = '1.4';
 
 // --- Tool Schema ---
 
@@ -110,11 +110,6 @@ function buildQuizTool(count: number = 3) {
                 type: 'string',
                 description: 'Starter code provided to the student (for code)',
               },
-              expectedPattern: {
-                type: 'string',
-                description:
-                  'Regex pattern to check student code for correctness (for code)',
-              },
             },
             required: ['type', 'question'],
           },
@@ -139,7 +134,7 @@ Question type guidelines:
 - **multi-select**: 4-6 options, 2-3 correct. Clearly ask "select ALL that apply."
 - **two-stage**: First question + follow-up. Both are multiple-choice. The follow-up probes deeper understanding.
 - **checklist**: Used for practical tasks or procedures. List 3-5 specific steps the student should perform or verify.
-- **code**: Ask the student to write a short code snippet. Provide the programming language and optionally some initial code. Use expectedPattern to provide a regex that verifies key parts of the solution.
+- **code**: Ask the student to write a short code snippet. Provide the programming language and optionally some initial code. Do not provide automatic grading fields; code questions are self-evaluated in this version.
 - **self-evaluation**: Used for open-ended or subjective practical mastery. Provide 2-4 levels of mastery as options (e.g., "I can do this reliably", "I need more practice").
 
 Quality rules:

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -80,7 +80,7 @@ describe('explanation prompt', () => {
 
 describe('quiz generation prompt', () => {
   it('exports version constant', () => {
-    expect(QUIZ_GENERATION_VERSION).toBe('1.3');
+    expect(QUIZ_GENERATION_VERSION).toBe('1.4');
   });
 
   it('builds prompt with topic and explanation context', () => {
@@ -110,6 +110,23 @@ describe('quiz generation prompt', () => {
     expect(prompt.system).toContain('self-contained');
     expect(prompt.system).toContain('similar in length');
     expect(prompt.system).toContain('metadata');
+  });
+
+  it('does not ask Claude for regex-based code grading patterns', () => {
+    const prompt = buildQuizGenerationPrompt({
+      topicTitle: 'T',
+      topicDescription: 'D',
+      courseTitle: 'C',
+      sectionTitle: 'S',
+      explanationContent: 'E',
+    });
+
+    const questionProperties =
+      prompt.tools![0].inputSchema.properties.questions.items.properties;
+
+    expect(questionProperties).not.toHaveProperty('expectedPattern');
+    expect(prompt.system).not.toContain('expectedPattern');
+    expect(prompt.system).not.toContain('regex');
   });
 });
 
@@ -217,7 +234,6 @@ describe('quality filters', () => {
       question: 'Write a guard clause.',
       language: 'typescript',
       initialCode: 'function isReady(value: unknown) {}',
-      expectedPattern: 'return\\s+false',
     };
     const original = structuredClone(q);
 
@@ -291,6 +307,33 @@ describe('ContentGenerator', () => {
     expect(questions[0].type).toBe('multiple-choice');
     expect(questions[1].type).toBe('numeric-input');
     expect(questions[0].topicId).toBe('binary-search');
+  });
+
+  it('strips legacy expectedPattern fields from generated code questions', async () => {
+    const provider = mockProvider(
+      quizResponse([
+        {
+          type: 'code',
+          question: 'Write a guard clause.',
+          language: 'typescript',
+          initialCode: 'function isReady(value: unknown) {}',
+          expectedPattern: 'return\\s+false',
+        },
+      ])
+    );
+    const gen = new ContentGenerator(provider);
+
+    const [question] = await gen.generateTopicQuizBurst(TOPIC, 'C', 'S', 'E', 1);
+
+    expect(question).toEqual({
+      type: 'code',
+      id: 'binary-search-q0',
+      topicId: 'binary-search',
+      question: 'Write a guard clause.',
+      language: 'typescript',
+      initialCode: 'function isReady(value: unknown) {}',
+    });
+    expect(question).not.toHaveProperty('expectedPattern');
   });
 
   it('parses all 5 question types', async () => {

--- a/packages/engine/tests/content-roundtrip.test.ts
+++ b/packages/engine/tests/content-roundtrip.test.ts
@@ -89,7 +89,6 @@ const QUESTION_FIXTURES: Record<QuestionType, Question> = {
     question: 'Write a function.',
     language: 'javascript',
     initialCode: 'function noop() {}',
-    expectedPattern: 'return',
   },
   'self-evaluation': {
     type: 'self-evaluation',
@@ -236,6 +235,22 @@ describe('validateEngineSnapshot — content items', () => {
   it.each(ALL_QUESTION_TYPES)('accepts a snapshot containing a %s question', (type) => {
     const snapshot = baseSnapshot([QUESTION_FIXTURES[type]]);
     expect(validateEngineSnapshot(snapshot)).not.toBeNull();
+  });
+
+  it('accepts and strips legacy expectedPattern data from imported code items', () => {
+    const legacyCode = {
+      ...QUESTION_FIXTURES.code,
+      expectedPattern: 'return\\s+true',
+    } as unknown as ContentItem;
+    const snapshot = baseSnapshot([legacyCode]);
+
+    const restored = validateEngineSnapshot(snapshot);
+
+    expect(restored).not.toBeNull();
+    expect(restored!.sectionItems[0]).not.toHaveProperty('expectedPattern');
+    expect(restored!.allGeneratedContent['section-1'][0]).not.toHaveProperty(
+      'expectedPattern'
+    );
   });
 
   it('rejects a snapshot containing a malformed checklist (missing items array)', () => {

--- a/packages/engine/tests/copy-utils.test.ts
+++ b/packages/engine/tests/copy-utils.test.ts
@@ -70,7 +70,6 @@ const CONTENT_ITEMS: ContentItem[] = [
     question: 'Write a function.',
     language: 'javascript',
     initialCode: 'function answer() {}',
-    expectedPattern: 'return',
   },
   {
     type: 'self-evaluation',

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -98,43 +98,31 @@ describe('New Question Types', () => {
     expect(outOfRangeResult.correct).toBe(false);
   });
 
-  it('grades code correctly with expectedPattern', () => {
+  it('grades code as self-evaluation and ignores legacy expectedPattern', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
 
-    const codeItem: ContentItem = {
+    const codeItem = {
       type: 'code',
       id: 'q-code',
       topicId: 'topic-1',
       question: 'Write a function that returns true.',
       language: 'javascript',
       expectedPattern: 'return true',
-    };
+    } as unknown as ContentItem;
 
     engine.setSectionContent([codeItem]);
 
-    // Correct: matches pattern
-    const resultCorrect = engine.submitAnswer({
-      type: 'code',
-      code: 'function test() { return true; }',
-    });
-    expect(resultCorrect.correct).toBe(true);
-
-    // Incorrect: does not match pattern
-    const engine2 = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
-    engine2.loadCurriculum(mockCurriculum());
-    engine2.startSection('section-1');
-    engine2.setSectionContent([codeItem]);
-
-    const resultIncorrect = engine2.submitAnswer({
+    const result = engine.submitAnswer({
       type: 'code',
       code: 'function test() { return false; }',
     });
-    expect(resultIncorrect.correct).toBe(false);
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Self-assessment submitted');
   });
 
-  it('grades code correctly without expectedPattern (always true)', () => {
+  it('grades code submissions as complete', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');


### PR DESCRIPTION
## Summary
- remove regex-based expected-pattern grading for code questions and treat code submissions like self-evaluation completion in v1
- strip legacy expectedPattern data from generated/imported/copied code items
- bump quiz-generation prompt to v1.4 and update AGENTS/CHANGELOG with the no-untrusted-regex policy

## Cross-package note
This primarily changes packages/engine behavior. The app change is unit coverage confirming CourseQuizzer receives code-question results through the self-evaluation grading path.

## Prompt quality verification
Ran `buildQuizGenerationPrompt` locally against three diverse inputs:
- Algorithms / code topic: Binary Search Guard Clauses in a TypeScript algorithms course
- Informal cooking / practical task: Dice an Onion Safely in a home-cooking course
- WWII history / concept recall: The Yalta Conference in a history course

Results:
- Topic text stayed in the user message and did not enter the system prompt for all three inputs.
- The tool schema excluded `expectedPattern` for all three inputs.
- The system prompt excluded `expectedPattern` and `regex`, and stated that code questions are self-evaluated.
- Requested question counts propagated to the tool schema min/max item counts.

Note: no live Anthropic call was run in this author environment because `ANTHROPIC_API_KEY` is unset.

## Verification
- pnpm -r test
- pnpm -r build
- pnpm format
- git diff --check

Closes #103