### PR TITLE
test: add quiz prompt v1.4 fixture coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
 - **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
 - **App:** Add route-level DOM coverage for checklist, code, and self-evaluation question rendering and submitted answer payloads
+- **Engine:** Add recorded quiz-generation v1.4 fixtures for diverse topics, including checklist, code, and self-evaluation schema coverage
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/tests/fixtures/recorded/quiz-generation-v14.ts
+++ b/packages/engine/tests/fixtures/recorded/quiz-generation-v14.ts
@@ -1,0 +1,204 @@
+// --- Recorded Fixture: Quiz Generation v1.4 ---
+// Captured-format Claude responses for the expanded v1.4 quiz schema.
+// These cover quantitative, creative-practical, and programming topics.
+
+import type { QuestionType } from '../../../src/content/types.js';
+import type { Topic } from '../../../src/curriculum/types.js';
+import type { ProviderResponse } from '../../../src/provider/types.js';
+
+export type RecordedV14QuizCase = {
+  label: string;
+  courseTitle: string;
+  sectionTitle: string;
+  topic: Topic;
+  explanationContent: string;
+  expectedTypes: QuestionType[];
+  response: ProviderResponse;
+};
+
+export const RECORDED_V14_QUIZ_CASES: RecordedV14QuizCase[] = [
+  {
+    label: 'statistics confidence intervals',
+    courseTitle: 'Applied Statistics',
+    sectionTitle: 'Inference from Samples',
+    topic: {
+      id: 'confidence-intervals',
+      title: 'Confidence Intervals',
+      description:
+        'Using sample statistics, standard error, and critical values to estimate plausible population parameters.',
+    },
+    explanationContent:
+      'A confidence interval estimates a population parameter by combining a sample statistic with a margin of error. For a mean, the margin of error depends on the standard error and a critical value chosen from the confidence level. A 95% confidence interval means that the method would capture the true parameter in about 95% of repeated samples.',
+    expectedTypes: ['multiple-choice', 'numeric-input', 'multi-select'],
+    response: {
+      id: 'msg_quiz_v14_stats_01',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_quiz_v14_stats_01',
+          name: 'create_quiz_questions',
+          input: {
+            questions: [
+              {
+                type: 'multiple-choice',
+                question:
+                  'What does a 95% confidence interval describe about the estimation method?',
+                options: [
+                  'It captures the true parameter in about 95% of repeated samples',
+                  'It proves the sample mean has a 95% chance of being correct',
+                  'It guarantees 95% of observations fall inside the interval',
+                  'It makes the population standard deviation 95% smaller',
+                ],
+                correctIndex: 0,
+              },
+              {
+                type: 'numeric-input',
+                question:
+                  'A sample mean is 42 and the margin of error is 3. What is the upper end of the confidence interval?',
+                correctValue: 45,
+                tolerance: 0,
+              },
+              {
+                type: 'multi-select',
+                question:
+                  'Select ALL quantities that directly affect the margin of error for a confidence interval:',
+                options: [
+                  'The standard error of the statistic',
+                  'The chosen confidence level',
+                  'The alphabetical order of variables',
+                  'The critical value used by the method',
+                  'The color of the graph labels',
+                ],
+                correctIndices: [0, 1, 3],
+              },
+            ],
+          },
+        },
+      ],
+      model: 'claude-sonnet-4-20250514',
+      stopReason: 'tool_use',
+      usage: { inputTokens: 760, outputTokens: 430 },
+    },
+  },
+  {
+    label: 'watercolor gradient washes',
+    courseTitle: 'Beginning Watercolor',
+    sectionTitle: 'Brush Control',
+    topic: {
+      id: 'gradient-washes',
+      title: 'Gradient Washes',
+      description:
+        'Creating smooth value transitions by controlling pigment load, water, brush angle, and timing.',
+    },
+    explanationContent:
+      'A gradient wash moves from darker pigment to lighter pigment by gradually diluting the paint while the paper remains damp. Smooth transitions depend on keeping a wet edge, using consistent brush strokes, and adding clean water before hard edges form. Students should prepare paint, test the value range, and work steadily from top to bottom.',
+    expectedTypes: ['ordering', 'checklist', 'self-evaluation'],
+    response: {
+      id: 'msg_quiz_v14_watercolor_01',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_quiz_v14_watercolor_01',
+          name: 'create_quiz_questions',
+          input: {
+            questions: [
+              {
+                type: 'ordering',
+                question:
+                  'Order these actions for painting a smooth gradient wash from first to last:',
+                items: [
+                  'Pull the wet edge downward with steady strokes',
+                  'Mix a darker starting puddle of paint',
+                  'Add clean water to lighten the next strokes',
+                  'Let the wash dry without reworking it',
+                ],
+                correctOrder: [1, 0, 2, 3],
+              },
+              {
+                type: 'checklist',
+                question: 'Check each preparation step before starting a gradient wash:',
+                items: [
+                  'Tape the paper so it stays flat while damp',
+                  'Mix enough pigment for the first dark pass',
+                  'Keep clean water ready for gradual dilution',
+                  'Test the brush stroke on scrap paper first',
+                ],
+              },
+              {
+                type: 'self-evaluation',
+                question: 'How well can you control the wet edge during a gradient wash?',
+                options: [
+                  'I lose the wet edge before the wash is complete',
+                  'I can keep it moving with occasional hard edges',
+                  'I can maintain a smooth edge through the whole wash',
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      model: 'claude-sonnet-4-20250514',
+      stopReason: 'tool_use',
+      usage: { inputTokens: 720, outputTokens: 390 },
+    },
+  },
+  {
+    label: 'javascript array filtering',
+    courseTitle: 'JavaScript Fundamentals',
+    sectionTitle: 'Array Transformations',
+    topic: {
+      id: 'array-filtering',
+      title: 'Array Filtering',
+      description:
+        'Using Array.prototype.filter to create a new array containing only elements that pass a predicate function.',
+    },
+    explanationContent:
+      'Array filtering keeps items that satisfy a predicate and leaves the original array unchanged. The callback receives each element and returns true to keep it or false to discard it. A good filtering solution names the input clearly, chooses a readable predicate, and returns the filtered array rather than mutating the original collection.',
+    expectedTypes: ['checklist', 'code', 'self-evaluation'],
+    response: {
+      id: 'msg_quiz_v14_javascript_01',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_quiz_v14_javascript_01',
+          name: 'create_quiz_questions',
+          input: {
+            questions: [
+              {
+                type: 'checklist',
+                question: 'Check each step for designing a filter-based solution:',
+                items: [
+                  'Identify the input array and item shape first',
+                  'Write a predicate that returns true to keep',
+                  'Return the new array produced by filter',
+                  'Avoid mutating the original array in place',
+                ],
+              },
+              {
+                type: 'code',
+                question:
+                  'Write a JavaScript function that returns only scores greater than or equal to 70.',
+                language: 'javascript',
+                initialCode:
+                  'function passingScores(scores) {\n  // return a filtered array\n}',
+              },
+              {
+                type: 'self-evaluation',
+                question:
+                  'How confidently can you write a filter callback without changing the original array?',
+                options: [
+                  'I need help choosing the predicate',
+                  'I can do it with a reference nearby',
+                  'I can do it independently and explain why it works',
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      model: 'claude-sonnet-4-20250514',
+      stopReason: 'tool_use',
+      usage: { inputTokens: 740, outputTokens: 410 },
+    },
+  },
+];

--- a/packages/engine/tests/quiz-generation-v14-fixtures.test.ts
+++ b/packages/engine/tests/quiz-generation-v14-fixtures.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ContentGenerator } from '../src/content/ContentGenerator.js';
+import type { ProviderClient, ProviderResponse } from '../src/provider/types.js';
+import { RECORDED_V14_QUIZ_CASES } from './fixtures/recorded/quiz-generation-v14.js';
+
+function mockProvider(response: ProviderResponse): ProviderClient {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(response),
+  };
+}
+
+function getPracticalFixture() {
+  const practicalCase = RECORDED_V14_QUIZ_CASES.find((fixture) =>
+    fixture.expectedTypes.includes('code')
+  );
+
+  if (!practicalCase) {
+    throw new Error('Missing practical v1.4 quiz fixture');
+  }
+
+  return practicalCase;
+}
+
+describe('quiz generation v1.4 recorded fixtures', () => {
+  it.each(RECORDED_V14_QUIZ_CASES)(
+    'parses recorded Claude response for $label',
+    async (fixture) => {
+      const generator = new ContentGenerator(mockProvider(fixture.response));
+
+      const questions = await generator.generateTopicQuizBurst(
+        fixture.topic,
+        fixture.courseTitle,
+        fixture.sectionTitle,
+        fixture.explanationContent,
+        fixture.expectedTypes.length
+      );
+
+      expect(questions).toHaveLength(fixture.expectedTypes.length);
+      expect(questions.map((question) => question.type)).toEqual(fixture.expectedTypes);
+      expect(questions.map((question) => question.id)).toEqual(
+        fixture.expectedTypes.map((_, index) => `${fixture.topic.id}-q${index}`)
+      );
+      expect(questions.every((question) => question.topicId === fixture.topic.id)).toBe(
+        true
+      );
+    }
+  );
+
+  it('covers the practical v1.4 checklist, code, and self-evaluation schema', async () => {
+    const fixture = getPracticalFixture();
+    const generator = new ContentGenerator(mockProvider(fixture.response));
+    const questions = await generator.generateTopicQuizBurst(
+      fixture.topic,
+      fixture.courseTitle,
+      fixture.sectionTitle,
+      fixture.explanationContent,
+      fixture.expectedTypes.length
+    );
+    const checklist = questions.find((question) => question.type === 'checklist');
+    const code = questions.find((question) => question.type === 'code');
+    const selfEvaluation = questions.find(
+      (question) => question.type === 'self-evaluation'
+    );
+
+    expect(checklist).toMatchObject({
+      type: 'checklist',
+      items: expect.arrayContaining([
+        expect.stringContaining('Identify the input array'),
+      ]),
+    });
+    expect(code).toMatchObject({
+      type: 'code',
+      language: 'javascript',
+      initialCode: expect.stringContaining('function passingScores'),
+    });
+    expect(selfEvaluation).toMatchObject({
+      type: 'self-evaluation',
+      options: expect.arrayContaining([expect.stringContaining('independently')]),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add three recorded-format quiz-generation v1.4 fixtures for statistics, watercolor, and JavaScript filtering topics.
- Add engine tests that parse each fixture through `ContentGenerator` and assert the expected question types, ids, and topic ids.
- Cover the practical checklist/code/self-evaluation schema with the JavaScript filtering fixture.
- Update `CHANGELOG.md`.

## Prompt Quality / Fixture Inputs

- Applied Statistics / Confidence Intervals: parsed `multiple-choice`, `numeric-input`, and `multi-select` questions through `ContentGenerator`.
- Beginning Watercolor / Gradient Washes: parsed `ordering`, `checklist`, and `self-evaluation` questions through `ContentGenerator`.
- JavaScript Fundamentals / Array Filtering: parsed `checklist`, `code`, and `self-evaluation` questions through `ContentGenerator`, covering the practical/procedural schema path.

## Verification

- `corepack pnpm --filter quizzer-engine test -- quiz-generation-v14-fixtures.test.ts`
- `corepack pnpm -r test`
- `corepack pnpm -r build`
- `corepack pnpm format`
- `corepack pnpm format:check`

Closes #105
