### PR TITLE
chore: clean stale question type comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
 - **App:** Add route-level DOM coverage for checklist, code, and self-evaluation question rendering and submitted answer payloads
 - **Engine:** Add recorded quiz-generation v1.4 fixtures for diverse topics, including checklist, code, and self-evaluation schema coverage
+- **Engine:** Clean up stale Phase 3 question-type comments so source comments match the current eight-format v1 set
 
 ## 0.9.0 — 2026-05-10
 

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -1,6 +1,6 @@
 // --- Content Types ---
 // Represents generated learning content: explanations and questions.
-// Question types match OpenQuizzer's proven set.
+// Question types include OpenQuizzer-style recall checks plus practical tasks.
 
 // --- Explanations ---
 
@@ -12,7 +12,7 @@ export type Explanation = {
 };
 
 // --- Question Types ---
-// These mirror OpenQuizzer's 5 question types.
+// The v1 set supports eight question formats for recall, practice, and reflection.
 
 export type MultipleChoiceQuestion = {
   type: 'multiple-choice';

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -28,8 +28,6 @@ import type { StudentAnswer, Question } from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
 function copySection(section: Section): Section {
-  // ... (omitting for brevity in this thought but I'll provide full in the call)
-
   return {
     ...section,
     topics: section.topics.map((topic) => ({ ...topic })),

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -1,7 +1,6 @@
 // --- Quiz Generation Prompt ---
 // Generates a burst of quiz questions for one topic.
-// Uses all 5 OpenQuizzer question types: MCQ, numeric input,
-// ordering, multi-select, two-stage.
+// Supports the full v1 question set, including practical and self-evaluation prompts.
 
 import type { PromptMessages } from './types.js';
 


### PR DESCRIPTION
Closes #106

## Summary
- Removed stale model scratch text from CourseEngine copy helper
- Updated engine question-type comments to describe the current eight-format v1 set
- Added a 0.9.1 changelog entry

## Verification
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format

Note: local pnpm is not on PATH in this shell, so checks were run through corepack with the repo-pinned pnpm 10.33.0.