### PR TITLE
feat: add AI tutor code evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **Engine:** Reuse in-flight prefetch generation when starting a prefetched section so the engine does not make duplicate foreground and background API calls for the same section
 - **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
 - **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
+- **Engine/App:** Add AI tutor evaluation for code questions, with provider-backed verdicts, escaped tutor feedback in the learn flow, and self-evaluation fallback when grading is unavailable
 - **App:** Add route-level DOM coverage for checklist, code, and self-evaluation question rendering and submitted answer payloads
 - **Engine:** Add recorded quiz-generation v1.4 fixtures for diverse topics, including checklist, code, and self-evaluation schema coverage
 - **Engine:** Clean up stale Phase 3 question-type comments so source comments match the current eight-format v1 set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
 - **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
 - **Engine/App:** Add AI tutor evaluation for code questions, with provider-backed verdicts, escaped tutor feedback in the learn flow, and self-evaluation fallback when grading is unavailable
+- **Engine/App:** Require `submitAnswerAsync()` for code questions and guard against duplicate in-flight tutor grading submissions
 - **App:** Add route-level DOM coverage for checklist, code, and self-evaluation question rendering and submitted answer payloads
 - **Engine:** Add recorded quiz-generation v1.4 fixtures for diverse topics, including checklist, code, and self-evaluation schema coverage
 - **Engine:** Clean up stale Phase 3 question-type comments so source comments match the current eight-format v1 set

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -51,6 +51,7 @@ export type EngineSessionConfig = {
   snapshot?: EngineSnapshot;
   courseId?: string;
   storage?: Storage;
+  codeEvaluator?: CourseEngineConfig['codeEvaluator'];
 };
 
 export type EngineSession = ReturnType<typeof createEngineSession>;
@@ -60,6 +61,7 @@ export type EngineSession = ReturnType<typeof createEngineSession>;
 export function createEngineSession(config: EngineSessionConfig) {
   const engineConfig: CourseEngineConfig = {
     apiKey: config.apiKey,
+    codeEvaluator: config.codeEvaluator,
     prefetch: {
       enabled: true,
     },

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -288,6 +288,11 @@ export function createEngineSession(config: EngineSessionConfig) {
       return engine.submitAnswer(answer);
     },
 
+    async submitAnswerAsync(answer: StudentAnswer): Promise<AnswerResult> {
+      if (!engine) throw new Error('Session is disposed');
+      return engine.submitAnswerAsync(answer);
+    },
+
     nextItem(): void {
       if (!engine) throw new Error('Session is disposed');
       engine.nextItem();

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -89,9 +89,9 @@
     session.submitAnswer({ type: 'checklist', checkedIndices: indices });
   }
 
-  function handleCode(code: string) {
+  async function handleCode(code: string) {
     if (!session) return;
-    session.submitAnswer({ type: 'code', code });
+    await session.submitAnswerAsync({ type: 'code', code });
   }
 
   function handleSelfEvaluation(selectedIndex: number) {
@@ -231,6 +231,14 @@
   // --- Derived helpers ---
 
   const hasApiKey = $derived(getApiKey(localStorage) !== null);
+
+  function resultTitle(result: NonNullable<EngineSession['lastResult']>['result']) {
+    if (result.evaluation?.verdict === 'partial') {
+      return 'Partially correct';
+    }
+
+    return result.correct ? 'Correct!' : 'Incorrect';
+  }
 </script>
 
 <svelte:head>
@@ -280,8 +288,16 @@
       {#if session.currentSection}
         <h2>{session.currentSection.section.title}</h2>
       {/if}
-      <p class="loading">Generating learning content...</p>
-      <p>This may take a minute as content is generated for each topic.</p>
+      <p class="loading">
+        {session.engineState === 'loading'
+          ? 'Generating learning content...'
+          : 'Checking your answer...'}
+      </p>
+      <p>
+        {session.engineState === 'loading'
+          ? 'This may take a minute as content is generated for each topic.'
+          : 'The tutor is reviewing your code.'}
+      </p>
       {#if session.error}
         <p role="alert" class="error">{session.error.message}</p>
         <button type="button" onclick={handleBackToOverview}>Back to Course</button>
@@ -525,8 +541,12 @@
             spellcheck="false"
           ></textarea>
           <div class="actions">
-            <button type="button" onclick={() => handleCode(codeValue)}>
-              Submit Code
+            <button
+              type="button"
+              onclick={() => handleCode(codeValue)}
+              disabled={session.apiLoading}
+            >
+              {session.apiLoading ? 'Checking Code' : 'Submit Code'}
             </button>
             <button type="button" class="secondary" onclick={handleSkip}>Skip</button>
             <button type="button" class="text-button" onclick={handleReportIssue}>
@@ -573,11 +593,13 @@
       {/if}
 
       <article class="result" class:correct={session.lastResult.result.correct} class:incorrect={!session.lastResult.result.correct}>
-        <h2>{session.lastResult.result.correct ? 'Correct!' : 'Incorrect'}</h2>
-        {#if !session.lastResult.result.correct}
+        <h2>{resultTitle(session.lastResult.result)}</h2>
+        {#if !session.lastResult.result.correct && !session.lastResult.result.evaluation}
           <p><strong>Correct answer:</strong> {session.lastResult.result.correctAnswer}</p>
         {/if}
-        {#if session.lastResult.result.explanation}
+        {#if session.lastResult.result.evaluation}
+          <p class="tutor-feedback">{session.lastResult.result.evaluation.feedback}</p>
+        {:else if session.lastResult.result.explanation}
           <p>{session.lastResult.result.explanation}</p>
         {/if}
         <div class="actions">

--- a/apps/coursequizzer/tests/unit/learn-flow.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-flow.test.ts
@@ -4,7 +4,12 @@ import {
   type EngineSession,
 } from '../../src/lib/stores/engine-session.svelte.js';
 import { createCourse, getCourse } from '../../src/lib/storage/course-storage.js';
-import type { CurriculumPlan, ContentItem, StudentAnswer } from 'quizzer-engine';
+import type {
+  CodeEvaluationClient,
+  CurriculumPlan,
+  ContentItem,
+  StudentAnswer,
+} from 'quizzer-engine';
 
 // --- Test fixtures ---
 
@@ -196,8 +201,15 @@ describe('learn page flow', () => {
     expect(session.lastResult!.result.correct).toBe(false);
   });
 
-  it('handles code questions through the self-evaluation grading path', () => {
-    const session = createEngineSession({ apiKey: 'test-key' });
+  it('handles code questions through async tutor grading', async () => {
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockResolvedValue({
+        verdict: 'incorrect',
+        correct: false,
+        feedback: 'The implementation returns false instead of true.',
+      }),
+    };
+    const session = createEngineSession({ apiKey: 'test-key', codeEvaluator });
     session.loadCurriculum(mockCurriculumPlan());
     session.startSection('s1');
     session.setSectionContent([
@@ -214,14 +226,21 @@ describe('learn page flow', () => {
 
     expect(session.currentItem!.item.type).toBe('code');
 
-    const result = session.submitAnswer({
+    const result = await session.submitAnswerAsync({
       type: 'code',
       code: 'function answer() { return false; }',
     });
 
-    expect(result.correct).toBe(true);
-    expect(result.correctAnswer).toBe('Self-assessment submitted');
-    expect(session.lastResult!.result.correct).toBe(true);
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'q-code' }),
+      'function answer() { return false; }'
+    );
+    expect(result.correct).toBe(false);
+    expect(result.evaluation).toEqual({
+      verdict: 'incorrect',
+      feedback: 'The implementation returns false instead of true.',
+    });
+    expect(session.lastResult!.result.correct).toBe(false);
   });
 
   it('can skip a question and continue', () => {

--- a/apps/coursequizzer/tests/unit/learn-route-question-types.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-route-question-types.test.ts
@@ -79,6 +79,9 @@ function answerResult(answer: StudentAnswer, item: ContentItem): AnswerResult {
 function createPracticingSession(item: ContentItem) {
   const curriculum = mockCurriculumPlan();
   const submitAnswer = vi.fn((answer: StudentAnswer) => answerResult(answer, item));
+  const submitAnswerAsync = vi.fn(async (answer: StudentAnswer) =>
+    answerResult(answer, item)
+  );
   const session: EngineSession = {
     engineState: 'practicing',
     curriculum,
@@ -102,6 +105,7 @@ function createPracticingSession(item: ContentItem) {
     startSection: vi.fn(),
     setSectionContent: vi.fn(),
     submitAnswer,
+    submitAnswerAsync,
     nextItem: vi.fn(),
     skipQuestion: vi.fn(),
     nextSection: vi.fn(),
@@ -109,14 +113,14 @@ function createPracticingSession(item: ContentItem) {
     dispose: vi.fn(),
   };
 
-  return { session, submitAnswer };
+  return { session, submitAnswer, submitAnswerAsync };
 }
 
 async function renderLearnPageWithItem(item: ContentItem) {
   const curriculum = mockCurriculumPlan();
   storeCourse(curriculum);
 
-  const { session, submitAnswer } = createPracticingSession(item);
+  const { session, submitAnswer, submitAnswerAsync } = createPracticingSession(item);
   createEngineSessionMock.mockReturnValue(session);
 
   render(LearnPage);
@@ -124,7 +128,7 @@ async function renderLearnPageWithItem(item: ContentItem) {
     name: item.type === 'explanation' ? item.title : item.question,
   });
 
-  return { session, submitAnswer };
+  return { session, submitAnswer, submitAnswerAsync };
 }
 
 // --- Tests ---
@@ -171,7 +175,7 @@ describe('learn route new question types', () => {
   });
 
   it('renders a code prompt with starter code and submits edited code', async () => {
-    const { submitAnswer } = await renderLearnPageWithItem({
+    const { submitAnswerAsync } = await renderLearnPageWithItem({
       type: 'code',
       id: 'code-1',
       topicId: 't1',
@@ -195,10 +199,63 @@ describe('learn route new question types', () => {
     });
     await fireEvent.click(screen.getByRole('button', { name: 'Submit Code' }));
 
-    expect(submitAnswer).toHaveBeenCalledWith({
+    expect(submitAnswerAsync).toHaveBeenCalledWith({
       type: 'code',
       code: 'function first<T>(items: T[]): T | undefined {\n  return items[0];\n}',
     });
+  });
+
+  it('renders AI tutor feedback as escaped text in the answer result', async () => {
+    const curriculum = mockCurriculumPlan();
+    storeCourse(curriculum);
+    const session: EngineSession = {
+      engineState: 'answered',
+      curriculum,
+      currentSection: {
+        section: curriculum.sections[0],
+        sectionIndex: 0,
+        totalSections: curriculum.sections.length,
+      },
+      currentItem: null,
+      lastResult: {
+        result: {
+          correct: false,
+          questionId: 'code-1',
+          topicId: 't1',
+          userAnswer: { type: 'code', code: 'alert(1)' },
+          correctAnswer: 'Tutor marked this submission incorrect',
+          evaluation: {
+            verdict: 'incorrect',
+            feedback: '<img src=x onerror=alert(1)> Use filter instead of map.',
+          },
+        },
+        studentState: null as never,
+        progress: null as never,
+      },
+      studentState: null,
+      progress: null,
+      apiLoading: false,
+      error: null,
+      restoreFailed: false,
+      loadCurriculum: vi.fn(),
+      startSection: vi.fn(),
+      setSectionContent: vi.fn(),
+      submitAnswer: vi.fn(),
+      submitAnswerAsync: vi.fn(),
+      nextItem: vi.fn(),
+      skipQuestion: vi.fn(),
+      nextSection: vi.fn(),
+      serialize: vi.fn((): EngineSnapshot | null => null),
+      dispose: vi.fn(),
+    };
+    createEngineSessionMock.mockReturnValue(session);
+
+    render(LearnPage);
+
+    expect(
+      await screen.findByText('<img src=x onerror=alert(1)> Use filter instead of map.')
+    ).toBeTruthy();
+    expect(document.querySelector('img')).toBeNull();
   });
 
   it('renders self-evaluation options and submits the selected index', async () => {

--- a/packages/engine/src/content/CodeEvaluator.ts
+++ b/packages/engine/src/content/CodeEvaluator.ts
@@ -1,0 +1,89 @@
+// --- CodeEvaluator ---
+// Uses the provider stack to grade code questions without executing code.
+
+import { buildCodeEvaluationPrompt } from '../prompts/code-evaluation.js';
+import type { ProviderClient, ToolUseBlock } from '../provider/types.js';
+import type {
+  CodeEvaluation,
+  CodeEvaluationClient,
+  CodeEvaluationVerdict,
+  CodeQuestion,
+} from './types.js';
+
+const CODE_EVALUATION_MAX_TOKENS = 1024;
+const VALID_VERDICTS = new Set<CodeEvaluationVerdict>([
+  'correct',
+  'partial',
+  'incorrect',
+]);
+
+function isCodeEvaluationVerdict(value: unknown): value is CodeEvaluationVerdict {
+  return typeof value === 'string' && VALID_VERDICTS.has(value as CodeEvaluationVerdict);
+}
+
+export class CodeEvaluator implements CodeEvaluationClient {
+  #provider: ProviderClient;
+
+  constructor(provider: ProviderClient) {
+    this.#provider = provider;
+  }
+
+  async evaluateCode(
+    question: CodeQuestion,
+    studentAnswer: string
+  ): Promise<CodeEvaluation> {
+    const prompt = buildCodeEvaluationPrompt({ question, studentAnswer });
+    let lastError = new Error(
+      `Failed to evaluate code answer for question "${question.id}" after retry`
+    );
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await this.#provider.sendMessage({
+        ...prompt,
+        maxTokens: CODE_EVALUATION_MAX_TOKENS,
+      });
+
+      const toolBlock = response.content.find(
+        (block): block is ToolUseBlock =>
+          block.type === 'tool_use' && block.name === 'evaluate_code_submission'
+      );
+
+      if (!toolBlock) {
+        lastError = new Error('Provider response did not include code evaluation');
+        continue;
+      }
+
+      try {
+        return this.#parseEvaluation(toolBlock);
+      } catch (error) {
+        lastError = this.#toError(error);
+      }
+    }
+
+    throw lastError;
+  }
+
+  #parseEvaluation(block: ToolUseBlock): CodeEvaluation {
+    const input = block.input as Record<string, unknown>;
+    const verdict = input.verdict;
+    const feedback = input.feedback;
+
+    if (!isCodeEvaluationVerdict(verdict)) {
+      throw new Error('Code evaluation response has an invalid verdict');
+    }
+
+    if (typeof feedback !== 'string' || feedback.trim().length === 0) {
+      throw new Error('Code evaluation response is missing feedback');
+    }
+
+    return {
+      verdict,
+      correct: verdict === 'correct',
+      feedback: feedback.trim(),
+    };
+  }
+
+  #toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -80,6 +80,23 @@ export type CodeQuestion = {
   initialCode?: string;
 };
 
+export type CodeEvaluationVerdict = 'correct' | 'partial' | 'incorrect';
+
+export type CodeEvaluation = {
+  verdict: CodeEvaluationVerdict;
+  correct: boolean;
+  feedback: string;
+};
+
+export type CodeEvaluationClient = {
+  evaluateCode(question: CodeQuestion, studentAnswer: string): Promise<CodeEvaluation>;
+};
+
+export type AnswerEvaluation = {
+  verdict: CodeEvaluationVerdict;
+  feedback: string;
+};
+
 export type SelfEvaluationQuestion = {
   type: 'self-evaluation';
   id: string;
@@ -130,4 +147,5 @@ export type AnswerResult = {
   // Additional context the UI needs to render the result
   correctAnswer: string; // human-readable description of the correct answer
   explanation?: string; // optional explanation of why
+  evaluation?: AnswerEvaluation; // AI tutor feedback for open-ended answers
 };

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -13,6 +13,7 @@ import { ContentGenerator } from '../content/ContentGenerator.js';
 import { ContentManager } from '../content/ContentManager.js';
 import { ContentCache } from '../content/ContentCache.js';
 import { copyContentItem } from '../content/copy-utils.js';
+import { CodeEvaluator } from '../content/CodeEvaluator.js';
 import { Prefetcher } from '../content/Prefetcher.js';
 import type {
   CourseEngineConfig,
@@ -24,7 +25,13 @@ import type {
   StudentState,
   SessionProgress,
 } from './types.js';
-import type { StudentAnswer, Question } from '../content/types.js';
+import type {
+  CodeEvaluation,
+  CodeEvaluationClient,
+  CodeQuestion,
+  StudentAnswer,
+  Question,
+} from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
 function copySection(section: Section): Section {
@@ -63,10 +70,16 @@ function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {
 }
 
 function copyAnswerResult(result: AnswerResult): AnswerResult {
-  return {
+  const copy: AnswerResult = {
     ...result,
     userAnswer: copyStudentAnswer(result.userAnswer),
   };
+
+  if (result.evaluation) {
+    copy.evaluation = { ...result.evaluation };
+  }
+
+  return copy;
 }
 
 function isValidGeneratedContentRecord(
@@ -102,6 +115,8 @@ export class CourseEngine extends EventEmitter {
   #contentManager: ContentManager;
   #contentCache: ContentCache | null = null;
   #prefetcher: Prefetcher | null = null;
+  #codeEvaluator: CodeEvaluationClient;
+  #apiCallSequence = 0;
 
   constructor(config: CourseEngineConfig) {
     super();
@@ -115,6 +130,7 @@ export class CourseEngine extends EventEmitter {
       });
 
     const generator = config.generator || new ContentGenerator(provider);
+    this.#codeEvaluator = config.codeEvaluator || new CodeEvaluator(provider);
 
     this.#contentManager = new ContentManager(generator, (payload) => {
       if (payload.status === 'start') {
@@ -326,6 +342,26 @@ export class CourseEngine extends EventEmitter {
     }
 
     const result = this.#gradeAnswer(item, answer);
+    return this.#completeAnswerSubmission(result);
+  }
+
+  async submitAnswerAsync(answer: StudentAnswer): Promise<AnswerResult> {
+    this.#requireState('submitAnswer', 'practicing');
+
+    const item = this.currentItem;
+    if (!item || item.type === 'explanation') {
+      throw new InvalidTransitionError('submitAnswer', 'current item is not a question');
+    }
+
+    if (item.type !== 'code' || answer.type !== 'code') {
+      return this.#completeAnswerSubmission(this.#gradeAnswer(item, answer));
+    }
+
+    const result = await this.#gradeCodeAnswer(item, answer);
+    return this.#completeAnswerSubmission(result);
+  }
+
+  #completeAnswerSubmission(result: AnswerResult): AnswerResult {
     this.#lastAnswerResult = copyAnswerResult(result);
 
     // Update mastery
@@ -463,6 +499,70 @@ export class CourseEngine extends EventEmitter {
       userAnswer: copyStudentAnswer(answer),
       correctAnswer: this.#describeCorrectAnswer(question),
     };
+  }
+
+  async #gradeCodeAnswer(
+    question: CodeQuestion,
+    answer: { type: 'code'; code: string }
+  ): Promise<AnswerResult> {
+    try {
+      const evaluation = await this.#withApiCall(
+        `Code evaluation for ${question.id}`,
+        () => this.#codeEvaluator.evaluateCode(question, answer.code)
+      );
+      return this.#resultFromCodeEvaluation(question, answer, evaluation);
+    } catch {
+      return {
+        ...this.#gradeAnswer(question, answer),
+        explanation:
+          'Tutor feedback is unavailable, so this code answer was marked complete for self-assessment.',
+      };
+    }
+  }
+
+  #resultFromCodeEvaluation(
+    question: CodeQuestion,
+    answer: { type: 'code'; code: string },
+    evaluation: CodeEvaluation
+  ): AnswerResult {
+    return {
+      correct: evaluation.correct,
+      questionId: question.id,
+      topicId: question.topicId,
+      userAnswer: copyStudentAnswer(answer),
+      correctAnswer: this.#describeCodeEvaluation(evaluation),
+      explanation: evaluation.feedback,
+      evaluation: {
+        verdict: evaluation.verdict,
+        feedback: evaluation.feedback,
+      },
+    };
+  }
+
+  #describeCodeEvaluation(evaluation: CodeEvaluation): string {
+    switch (evaluation.verdict) {
+      case 'correct':
+        return 'Tutor marked this submission correct';
+      case 'partial':
+        return 'Tutor marked this submission partially correct';
+      case 'incorrect':
+        return 'Tutor marked this submission incorrect';
+    }
+  }
+
+  async #withApiCall<T>(purpose: string, call: () => Promise<T>): Promise<T> {
+    const id = this.#nextApiCallId();
+    this.emit('apiCallStart', { id, purpose });
+    try {
+      return await call();
+    } finally {
+      this.emit('apiCallComplete', { id, purpose });
+    }
+  }
+
+  #nextApiCallId(): string {
+    this.#apiCallSequence += 1;
+    return `engine-api-call-${this.#apiCallSequence}`;
   }
 
   #checkCorrectness(question: Question, answer: StudentAnswer): boolean {

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -360,12 +360,14 @@ export class CourseEngine extends EventEmitter {
       throw new InvalidTransitionError('submitAnswer', 'current item is not a question');
     }
 
-    if (item.type !== 'code' || answer.type !== 'code') {
+    if (item.type !== 'code') {
       return this.#completeAnswerSubmission(this.#gradeAnswer(item, answer));
     }
 
-    if (this.#codeSubmissionInFlight) {
-      throw new EngineError('Code answer evaluation is already in progress.');
+    this.#requireNoCodeSubmissionInFlight();
+
+    if (answer.type !== 'code') {
+      return this.#completeAnswerSubmission(this.#gradeAnswer(item, answer));
     }
 
     this.#codeSubmissionInFlight = true;
@@ -422,6 +424,7 @@ export class CourseEngine extends EventEmitter {
 
   skipQuestion(): void {
     this.#requireState('skipQuestion', 'practicing');
+    this.#requireNoCodeSubmissionInFlight();
 
     const item = this.currentItem;
     if (!item || item.type === 'explanation') {
@@ -483,6 +486,12 @@ export class CourseEngine extends EventEmitter {
       studentState: this.studentState,
       progress: this.sessionProgress,
     });
+  }
+
+  #requireNoCodeSubmissionInFlight(): void {
+    if (this.#codeSubmissionInFlight) {
+      throw new EngineError('Code answer evaluation is already in progress.');
+    }
   }
 
   #updateMastery(result: AnswerResult): void {

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -5,7 +5,7 @@
 // the UI consumes these events and never reaches back into the engine.
 
 import { EventEmitter } from './events.js';
-import { InvalidTransitionError } from './errors.js';
+import { EngineError, InvalidTransitionError } from './errors.js';
 import { SNAPSHOT_VERSION } from './constants.js';
 import { StudentModel } from '../student/StudentModel.js';
 import { createDefaultProvider } from '../provider/factory.js';
@@ -116,6 +116,7 @@ export class CourseEngine extends EventEmitter {
   #contentCache: ContentCache | null = null;
   #prefetcher: Prefetcher | null = null;
   #codeEvaluator: CodeEvaluationClient;
+  #codeSubmissionInFlight = false;
   #apiCallSequence = 0;
 
   constructor(config: CourseEngineConfig) {
@@ -341,6 +342,12 @@ export class CourseEngine extends EventEmitter {
       throw new InvalidTransitionError('submitAnswer', 'current item is not a question');
     }
 
+    if (item.type === 'code') {
+      throw new EngineError(
+        'Code questions require submitAnswerAsync() so AI tutor grading can run.'
+      );
+    }
+
     const result = this.#gradeAnswer(item, answer);
     return this.#completeAnswerSubmission(result);
   }
@@ -357,8 +364,17 @@ export class CourseEngine extends EventEmitter {
       return this.#completeAnswerSubmission(this.#gradeAnswer(item, answer));
     }
 
-    const result = await this.#gradeCodeAnswer(item, answer);
-    return this.#completeAnswerSubmission(result);
+    if (this.#codeSubmissionInFlight) {
+      throw new EngineError('Code answer evaluation is already in progress.');
+    }
+
+    this.#codeSubmissionInFlight = true;
+    try {
+      const result = await this.#gradeCodeAnswer(item, answer);
+      return this.#completeAnswerSubmission(result);
+    } finally {
+      this.#codeSubmissionInFlight = false;
+    }
   }
 
   #completeAnswerSubmission(result: AnswerResult): AnswerResult {

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -3,6 +3,7 @@
 import type { CurriculumPlan, Section } from '../curriculum/types.js';
 import type {
   AnswerResult,
+  CodeEvaluationClient,
   ContentItem,
   Question,
   Explanation,
@@ -35,6 +36,7 @@ export type CourseEngineConfig = {
   model?: string;
   provider?: ProviderClient;
   generator?: TopicContentGenerator;
+  codeEvaluator?: CodeEvaluationClient;
   prefetch?: {
     enabled: boolean;
     generator?: TopicContentGenerator;

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -1,8 +1,20 @@
 import { validateCurriculumPlan } from '../curriculum/SyllabusParser.js';
 import { SNAPSHOT_VERSION } from '../engine/constants.js';
 import type { CurriculumPlan, EngineSnapshot } from '../engine/types.js';
-import type { AnswerResult, ContentItem, StudentAnswer } from '../content/types.js';
+import type {
+  AnswerEvaluation,
+  AnswerResult,
+  CodeEvaluationVerdict,
+  ContentItem,
+  StudentAnswer,
+} from '../content/types.js';
 import type { StudentState } from '../student/types.js';
+
+const VALID_CODE_EVALUATION_VERDICTS = new Set<CodeEvaluationVerdict>([
+  'correct',
+  'partial',
+  'incorrect',
+]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -124,7 +136,17 @@ function isValidAnswerResult(value: unknown): value is AnswerResult {
     typeof value.topicId === 'string' &&
     typeof value.correctAnswer === 'string' &&
     (value.explanation === undefined || typeof value.explanation === 'string') &&
+    (value.evaluation === undefined || isValidAnswerEvaluation(value.evaluation)) &&
     isValidStudentAnswer(value.userAnswer)
+  );
+}
+
+function isValidAnswerEvaluation(value: unknown): value is AnswerEvaluation {
+  return (
+    isPlainObject(value) &&
+    typeof value.verdict === 'string' &&
+    VALID_CODE_EVALUATION_VERDICTS.has(value.verdict as CodeEvaluationVerdict) &&
+    typeof value.feedback === 'string'
   );
 }
 
@@ -330,6 +352,13 @@ function copyAnswerResult(result: AnswerResult): AnswerResult {
 
   if (result.explanation !== undefined) {
     copy.explanation = result.explanation;
+  }
+
+  if (result.evaluation !== undefined) {
+    copy.evaluation = {
+      verdict: result.evaluation.verdict,
+      feedback: result.evaluation.feedback,
+    };
   }
 
   return copy;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -12,6 +12,7 @@ export { SyllabusParser, validateCurriculumPlan } from './curriculum/SyllabusPar
 export { CurriculumManager } from './curriculum/CurriculumManager.js';
 export { ContentGenerator } from './content/ContentGenerator.js';
 export { ContentManager } from './content/ContentManager.js';
+export { CodeEvaluator } from './content/CodeEvaluator.js';
 export { checkQuestionQuality } from './content/quality-filters.js';
 export { Exporter } from './export/Exporter.js';
 export { Importer } from './export/Importer.js';
@@ -55,6 +56,10 @@ export {
   buildQuizGenerationPrompt,
   QUIZ_GENERATION_VERSION,
 } from './prompts/quiz-generation.js';
+export {
+  buildCodeEvaluationPrompt,
+  CODE_EVALUATION_VERSION,
+} from './prompts/code-evaluation.js';
 export type { PromptMessages } from './prompts/types.js';
 export type { MasteryUpdate } from './student/StudentModel.js';
 
@@ -66,6 +71,13 @@ export type {
   OrderingQuestion,
   MultiSelectQuestion,
   TwoStageQuestion,
+  ChecklistQuestion,
+  CodeQuestion,
+  SelfEvaluationQuestion,
+  CodeEvaluationVerdict,
+  CodeEvaluation,
+  CodeEvaluationClient,
+  AnswerEvaluation,
 } from './content/types.js';
 
 export type {

--- a/packages/engine/src/prompts/code-evaluation.ts
+++ b/packages/engine/src/prompts/code-evaluation.ts
@@ -1,0 +1,96 @@
+// --- Code Evaluation Prompt ---
+// Grades a student-submitted code answer with the AI tutor.
+// The engine never executes student code; this is text-in, text-out feedback.
+
+import type { CodeQuestion } from '../content/types.js';
+import type { PromptMessages } from './types.js';
+
+export const CODE_EVALUATION_VERSION = '1.0';
+
+// --- Tool Schema ---
+
+const CODE_EVALUATION_TOOL = {
+  name: 'evaluate_code_submission',
+  description:
+    'Evaluate a student code submission against a programming question. ' +
+    'Return a correctness verdict and concise tutor feedback.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      verdict: {
+        type: 'string',
+        enum: ['correct', 'partial', 'incorrect'],
+        description:
+          'correct if the submission satisfies the prompt, partial if the core idea is present but incomplete, incorrect otherwise.',
+      },
+      feedback: {
+        type: 'string',
+        description:
+          'One to three short sentences explaining the verdict and the next improvement.',
+      },
+    },
+    required: ['verdict', 'feedback'],
+  },
+};
+
+// --- Prompt Builders ---
+
+function requireNonEmptyString(value: string, fieldName: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`Code evaluation ${fieldName} is required`);
+  }
+}
+
+function buildSystemPrompt(): string {
+  return `You are an expert programming tutor evaluating a student's code answer.
+
+Guidelines:
+- Do not execute code, simulate execution, call tools, or claim that tests were run
+- Evaluate only from the question, language, starter code, and student submission
+- Mark "correct" only when the submission satisfies the requested behavior
+- Mark "partial" when the main approach is present but incomplete or slightly wrong
+- Mark "incorrect" when the submission solves a different task or misses the core requirement
+- Give brief tutor-style feedback that helps the student improve
+- Do not include hidden tests, executable code, or security-sensitive advice`;
+}
+
+function buildUserPrompt(question: CodeQuestion, studentAnswer: string): string {
+  const starterCode = question.initialCode ?? '(none)';
+
+  return `Evaluate this code submission.
+
+<question>
+Language: ${question.language}
+Prompt: ${question.question}
+Starter code:
+${starterCode}
+</question>
+
+<student_submission>
+${studentAnswer}
+</student_submission>`;
+}
+
+// --- Public API ---
+
+export function buildCodeEvaluationPrompt(params: {
+  question: CodeQuestion;
+  studentAnswer: string;
+}): PromptMessages {
+  requireNonEmptyString(params.question.id, 'question id');
+  requireNonEmptyString(params.question.topicId, 'topic id');
+  requireNonEmptyString(params.question.question, 'question');
+  requireNonEmptyString(params.question.language, 'language');
+
+  return {
+    system: buildSystemPrompt(),
+    messages: [
+      {
+        role: 'user',
+        content: buildUserPrompt(params.question, params.studentAnswer),
+      },
+    ],
+    tools: [CODE_EVALUATION_TOOL],
+    toolChoice: { type: 'tool', name: 'evaluate_code_submission' },
+  };
+}

--- a/packages/engine/tests/code-evaluation.test.ts
+++ b/packages/engine/tests/code-evaluation.test.ts
@@ -1,0 +1,224 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { CodeEvaluator } from '../src/content/CodeEvaluator.js';
+import { CourseEngine } from '../src/index.js';
+import {
+  buildCodeEvaluationPrompt,
+  CODE_EVALUATION_VERSION,
+} from '../src/prompts/code-evaluation.js';
+import type {
+  CodeEvaluation,
+  CodeEvaluationClient,
+  CodeQuestion,
+} from '../src/content/types.js';
+import type { CurriculumPlan } from '../src/index.js';
+import type { ProviderClient, ProviderResponse } from '../src/provider/types.js';
+
+type RecordedCodeEvaluationCase = {
+  label: string;
+  question: CodeQuestion;
+  studentAnswer: string;
+  expectedVerdict: CodeEvaluation['verdict'];
+  response: ProviderResponse;
+};
+
+function loadRecordedCase(fileName: string): RecordedCodeEvaluationCase {
+  const fixtureUrl = new URL(`./fixtures/recorded/${fileName}`, import.meta.url);
+  return JSON.parse(
+    readFileSync(fileURLToPath(fixtureUrl), 'utf8')
+  ) as RecordedCodeEvaluationCase;
+}
+
+function mockProvider(...responses: ProviderResponse[]): ProviderClient {
+  const sendMessage = vi.fn();
+  for (const response of responses) {
+    sendMessage.mockResolvedValueOnce(response);
+  }
+  return { sendMessage };
+}
+
+function textOnlyResponse(): ProviderResponse {
+  return {
+    id: 'msg_text_only',
+    content: [{ type: 'text', text: 'I think this is correct.' }],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'end_turn',
+    usage: { inputTokens: 10, outputTokens: 8 },
+  };
+}
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Programming Practice',
+    description: 'A course about practical programming exercises.',
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Code Practice',
+        order: 0,
+        topics: [
+          {
+            id: 'array-filtering',
+            title: 'Array Filtering',
+            description: 'Filtering array values with a predicate.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const mockGenerator = {
+  generateTopicExplanation: () => new Promise<never>(() => {}),
+  generateTopicQuizBurst: () => new Promise<never>(() => {}),
+};
+
+const codeQuestion: CodeQuestion = {
+  type: 'code',
+  id: 'q-code',
+  topicId: 'array-filtering',
+  question: 'Write a JavaScript function that keeps scores greater than 70.',
+  language: 'javascript',
+  initialCode: 'function passingScores(scores) {\n  return [];\n}',
+};
+
+function engineWithCodeQuestion(codeEvaluator: CodeEvaluationClient): CourseEngine {
+  const engine = new CourseEngine({
+    apiKey: 'test-key',
+    generator: mockGenerator,
+    codeEvaluator,
+  });
+  engine.loadCurriculum(mockCurriculum());
+  engine.startSection('section-1');
+  engine.setSectionContent([codeQuestion]);
+  return engine;
+}
+
+describe('code evaluation prompt', () => {
+  it('exports a versioned tool-use prompt with untrusted input in the user message', () => {
+    const prompt = buildCodeEvaluationPrompt({
+      question: codeQuestion,
+      studentAnswer: '<img src=x onerror=alert(1)>',
+    });
+
+    expect(CODE_EVALUATION_VERSION).toBe('1.0');
+    expect(prompt.system).toContain('Do not execute');
+    expect(prompt.system).not.toContain(codeQuestion.question);
+    expect(prompt.messages[0].content).toContain(codeQuestion.question);
+    expect(prompt.messages[0].content).toContain('<img src=x onerror=alert(1)>');
+    expect(prompt.tools?.[0].name).toBe('evaluate_code_submission');
+    expect(prompt.toolChoice).toEqual({
+      type: 'tool',
+      name: 'evaluate_code_submission',
+    });
+  });
+
+  it('rejects malformed prompt inputs before sending them to the provider', () => {
+    expect(() =>
+      buildCodeEvaluationPrompt({
+        question: { ...codeQuestion, question: ' ' },
+        studentAnswer: '',
+      })
+    ).toThrow(/question/);
+  });
+});
+
+describe('CodeEvaluator', () => {
+  const recordedCases = [
+    loadRecordedCase('code-evaluation-correct.json'),
+    loadRecordedCase('code-evaluation-partial.json'),
+    loadRecordedCase('code-evaluation-incorrect.json'),
+  ];
+
+  it.each(recordedCases)(
+    'parses recorded Claude response for $label',
+    async (fixture) => {
+      const evaluator = new CodeEvaluator(mockProvider(fixture.response));
+
+      const result = await evaluator.evaluateCode(
+        fixture.question,
+        fixture.studentAnswer
+      );
+
+      expect(result.verdict).toBe(fixture.expectedVerdict);
+      expect(result.correct).toBe(fixture.expectedVerdict === 'correct');
+      expect(result.feedback.length).toBeGreaterThan(20);
+    }
+  );
+
+  it('retries once when Claude does not return the evaluation tool call', async () => {
+    const fixture = recordedCases[0];
+    const provider = mockProvider(textOnlyResponse(), fixture.response);
+    const evaluator = new CodeEvaluator(provider);
+
+    const result = await evaluator.evaluateCode(fixture.question, fixture.studentAnswer);
+
+    expect(result.verdict).toBe('correct');
+    expect(provider.sendMessage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CourseEngine code answer evaluation', () => {
+  it('routes code submissions through the async evaluator and emits tutor feedback', async () => {
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockResolvedValue({
+        verdict: 'partial',
+        correct: false,
+        feedback: 'The predicate is close, but the function returns booleans.',
+      }),
+    };
+    const engine = engineWithCodeQuestion(codeEvaluator);
+    const answerResults: unknown[] = [];
+    const apiEvents: string[] = [];
+
+    engine.on('answerResult', (payload) => answerResults.push(payload.result));
+    engine.on('apiCallStart', (payload) => apiEvents.push(`start:${payload.purpose}`));
+    engine.on('apiCallComplete', (payload) =>
+      apiEvents.push(`complete:${payload.purpose}`)
+    );
+
+    const result = await engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores.map(s => s >= 70); }',
+    });
+
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledWith(
+      codeQuestion,
+      'function passingScores(scores) { return scores.map(s => s >= 70); }'
+    );
+    expect(result.correct).toBe(false);
+    expect(result.evaluation).toEqual({
+      verdict: 'partial',
+      feedback: 'The predicate is close, but the function returns booleans.',
+    });
+    expect(result.explanation).toBe(
+      'The predicate is close, but the function returns booleans.'
+    );
+    expect(engine.state).toBe('answered');
+    expect(answerResults).toHaveLength(1);
+    expect(apiEvents).toEqual([
+      'start:Code evaluation for q-code',
+      'complete:Code evaluation for q-code',
+    ]);
+  });
+
+  it('falls back to the self-evaluation path when AI grading fails', async () => {
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockRejectedValue(new Error('provider unavailable')),
+    };
+    const engine = engineWithCodeQuestion(codeEvaluator);
+
+    const result = await engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores; }',
+    });
+
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Self-assessment submitted');
+    expect(result.explanation).toBe(
+      'Tutor feedback is unavailable, so this code answer was marked complete for self-assessment.'
+    );
+    expect(engine.state).toBe('answered');
+  });
+});

--- a/packages/engine/tests/code-evaluation.test.ts
+++ b/packages/engine/tests/code-evaluation.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { CodeEvaluator } from '../src/content/CodeEvaluator.js';
-import { CourseEngine } from '../src/index.js';
+import { CourseEngine, EngineError } from '../src/index.js';
 import {
   buildCodeEvaluationPrompt,
   CODE_EVALUATION_VERSION,
@@ -160,6 +160,26 @@ describe('CodeEvaluator', () => {
 });
 
 describe('CourseEngine code answer evaluation', () => {
+  it('rejects sync code submissions so callers cannot bypass tutor grading', () => {
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockResolvedValue({
+        verdict: 'correct',
+        correct: true,
+        feedback: 'The solution is correct.',
+      }),
+    };
+    const engine = engineWithCodeQuestion(codeEvaluator);
+
+    expect(() =>
+      engine.submitAnswer({
+        type: 'code',
+        code: 'function passingScores(scores) { return scores; }',
+      })
+    ).toThrow(EngineError);
+    expect(codeEvaluator.evaluateCode).not.toHaveBeenCalled();
+    expect(engine.state).toBe('practicing');
+  });
+
   it('routes code submissions through the async evaluator and emits tutor feedback', async () => {
     const codeEvaluator: CodeEvaluationClient = {
       evaluateCode: vi.fn().mockResolvedValue({
@@ -204,10 +224,28 @@ describe('CourseEngine code answer evaluation', () => {
   });
 
   it('falls back to the self-evaluation path when AI grading fails', async () => {
-    const codeEvaluator: CodeEvaluationClient = {
-      evaluateCode: vi.fn().mockRejectedValue(new Error('provider unavailable')),
+    const nextCodeQuestion: CodeQuestion = {
+      ...codeQuestion,
+      id: 'q-code-next',
     };
-    const engine = engineWithCodeQuestion(codeEvaluator);
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('provider unavailable'))
+        .mockResolvedValueOnce({
+          verdict: 'correct',
+          correct: true,
+          feedback: 'The next submission is correct.',
+        }),
+    };
+    const engine = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+      codeEvaluator,
+    });
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    engine.setSectionContent([codeQuestion, nextCodeQuestion]);
 
     const result = await engine.submitAnswerAsync({
       type: 'code',
@@ -220,5 +258,50 @@ describe('CourseEngine code answer evaluation', () => {
       'Tutor feedback is unavailable, so this code answer was marked complete for self-assessment.'
     );
     expect(engine.state).toBe('answered');
+
+    engine.nextItem();
+    const nextResult = await engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores.filter(s => s > 70); }',
+    });
+
+    expect(nextResult.correct).toBe(true);
+    expect(nextResult.evaluation?.feedback).toBe('The next submission is correct.');
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects concurrent code submissions while tutor grading is in flight', async () => {
+    let resolveEvaluation!: (evaluation: CodeEvaluation) => void;
+    const pendingEvaluation = new Promise<CodeEvaluation>((resolve) => {
+      resolveEvaluation = resolve;
+    });
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockReturnValue(pendingEvaluation),
+    };
+    const engine = engineWithCodeQuestion(codeEvaluator);
+
+    const firstSubmission = engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores; }',
+    });
+    const secondSubmission = engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores.filter(Boolean); }',
+    });
+
+    await expect(secondSubmission).rejects.toThrow(EngineError);
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(1);
+    expect(engine.state).toBe('practicing');
+
+    resolveEvaluation({
+      verdict: 'correct',
+      correct: true,
+      feedback: 'The submission filters the scores correctly.',
+    });
+
+    const result = await firstSubmission;
+    expect(result.correct).toBe(true);
+    expect(engine.state).toBe('answered');
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/engine/tests/code-evaluation.test.ts
+++ b/packages/engine/tests/code-evaluation.test.ts
@@ -304,4 +304,55 @@ describe('CourseEngine code answer evaluation', () => {
     expect(engine.state).toBe('answered');
     expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects public mutations while tutor grading is in flight', async () => {
+    let resolveEvaluation!: (evaluation: CodeEvaluation) => void;
+    const pendingEvaluation = new Promise<CodeEvaluation>((resolve) => {
+      resolveEvaluation = resolve;
+    });
+    const codeEvaluator: CodeEvaluationClient = {
+      evaluateCode: vi.fn().mockReturnValue(pendingEvaluation),
+    };
+    const nextCodeQuestion: CodeQuestion = {
+      ...codeQuestion,
+      id: 'q-code-next',
+    };
+    const engine = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+      codeEvaluator,
+    });
+    const answerResults: unknown[] = [];
+    engine.on('answerResult', (payload) => answerResults.push(payload.result));
+    engine.loadCurriculum(mockCurriculum());
+    engine.startSection('section-1');
+    engine.setSectionContent([codeQuestion, nextCodeQuestion]);
+
+    const firstSubmission = engine.submitAnswerAsync({
+      type: 'code',
+      code: 'function passingScores(scores) { return scores; }',
+    });
+
+    await expect(
+      engine.submitAnswerAsync({ type: 'multiple-choice', selectedIndex: 0 })
+    ).rejects.toThrow(EngineError);
+    expect(() => engine.skipQuestion()).toThrow(EngineError);
+    expect(engine.currentItem?.id).toBe('q-code');
+    expect(engine.state).toBe('practicing');
+    expect(answerResults).toHaveLength(0);
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(1);
+
+    resolveEvaluation({
+      verdict: 'correct',
+      correct: true,
+      feedback: 'The submission filters the scores correctly.',
+    });
+
+    const result = await firstSubmission;
+    expect(result.correct).toBe(true);
+    expect(engine.currentItem?.id).toBe('q-code');
+    expect(engine.state).toBe('answered');
+    expect(answerResults).toHaveLength(1);
+    expect(codeEvaluator.evaluateCode).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/engine/tests/content-roundtrip.test.ts
+++ b/packages/engine/tests/content-roundtrip.test.ts
@@ -497,6 +497,45 @@ describe('validateEngineSnapshot — student answers', () => {
     }
   );
 
+  it('round-trips AI tutor evaluation feedback in lastAnswerResult', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    snapshot.lastAnswerResult = {
+      correct: false,
+      questionId: 'q-test',
+      topicId: 'topic-1',
+      userAnswer: ANSWER_FIXTURES.code,
+      correctAnswer: 'Tutor marked this submission partially correct',
+      evaluation: {
+        verdict: 'partial',
+        feedback: 'The approach is close, but the return value needs work.',
+      },
+    };
+
+    const restored = validateEngineSnapshot(snapshot);
+
+    expect(restored?.lastAnswerResult?.evaluation).toEqual({
+      verdict: 'partial',
+      feedback: 'The approach is close, but the return value needs work.',
+    });
+  });
+
+  it('rejects a snapshot with malformed AI tutor evaluation feedback', () => {
+    const snapshot = baseSnapshot([EXPLANATION]);
+    snapshot.lastAnswerResult = {
+      correct: false,
+      questionId: 'q-test',
+      topicId: 'topic-1',
+      userAnswer: ANSWER_FIXTURES.code,
+      correctAnswer: 'Tutor marked this submission partially correct',
+      evaluation: {
+        verdict: 'almost' as never,
+        feedback: 'Close.',
+      },
+    };
+
+    expect(validateEngineSnapshot(snapshot)).toBeNull();
+  });
+
   it('rejects a snapshot with a malformed checklist answer (checkedIndices not numbers)', () => {
     const snapshot = baseSnapshot([EXPLANATION]);
     snapshot.lastAnswerResult = {

--- a/packages/engine/tests/fixtures/recorded/code-evaluation-correct.json
+++ b/packages/engine/tests/fixtures/recorded/code-evaluation-correct.json
@@ -1,0 +1,33 @@
+{
+  "label": "typescript array first helper correct",
+  "question": {
+    "type": "code",
+    "id": "q-code-correct",
+    "topicId": "typescript-arrays",
+    "question": "Write a TypeScript helper that returns the first item in an array, or undefined for an empty array.",
+    "language": "typescript",
+    "initialCode": "function first<T>(items: T[]): T | undefined {\n  return undefined;\n}"
+  },
+  "studentAnswer": "function first<T>(items: T[]): T | undefined {\n  return items[0];\n}",
+  "expectedVerdict": "correct",
+  "response": {
+    "id": "msg_code_eval_correct_01",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "toolu_code_eval_correct_01",
+        "name": "evaluate_code_submission",
+        "input": {
+          "verdict": "correct",
+          "feedback": "This satisfies the prompt: indexing returns the first element and naturally returns undefined when the array is empty."
+        }
+      }
+    ],
+    "model": "claude-sonnet-4-20250514",
+    "stopReason": "tool_use",
+    "usage": {
+      "inputTokens": 610,
+      "outputTokens": 72
+    }
+  }
+}

--- a/packages/engine/tests/fixtures/recorded/code-evaluation-incorrect.json
+++ b/packages/engine/tests/fixtures/recorded/code-evaluation-incorrect.json
@@ -1,0 +1,33 @@
+{
+  "label": "javascript filter incorrect",
+  "question": {
+    "type": "code",
+    "id": "q-code-incorrect",
+    "topicId": "array-filtering",
+    "question": "Write a JavaScript function that returns only scores greater than or equal to 70.",
+    "language": "javascript",
+    "initialCode": "function passingScores(scores) {\n  // return a filtered array\n}"
+  },
+  "studentAnswer": "function passingScores(scores) {\n  return scores.map(score => score >= 70);\n}",
+  "expectedVerdict": "incorrect",
+  "response": {
+    "id": "msg_code_eval_incorrect_01",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "toolu_code_eval_incorrect_01",
+        "name": "evaluate_code_submission",
+        "input": {
+          "verdict": "incorrect",
+          "feedback": "This returns booleans for every score instead of the passing score values. Use filter with a predicate so the output array contains only scores at least 70."
+        }
+      }
+    ],
+    "model": "claude-sonnet-4-20250514",
+    "stopReason": "tool_use",
+    "usage": {
+      "inputTokens": 620,
+      "outputTokens": 86
+    }
+  }
+}

--- a/packages/engine/tests/fixtures/recorded/code-evaluation-partial.json
+++ b/packages/engine/tests/fixtures/recorded/code-evaluation-partial.json
@@ -1,0 +1,33 @@
+{
+  "label": "python normalize score partial",
+  "question": {
+    "type": "code",
+    "id": "q-code-partial",
+    "topicId": "normalization",
+    "question": "Write a Python function that converts a raw score and maximum score into a percentage from 0 to 100.",
+    "language": "python",
+    "initialCode": "def percent_score(raw, maximum):\n    pass"
+  },
+  "studentAnswer": "def percent_score(raw, maximum):\n    return raw / maximum",
+  "expectedVerdict": "partial",
+  "response": {
+    "id": "msg_code_eval_partial_01",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "toolu_code_eval_partial_01",
+        "name": "evaluate_code_submission",
+        "input": {
+          "verdict": "partial",
+          "feedback": "The division is the right core idea, but the result is a 0-1 ratio. Multiply by 100 to return the requested percentage scale."
+        }
+      }
+    ],
+    "model": "claude-sonnet-4-20250514",
+    "stopReason": "tool_use",
+    "usage": {
+      "inputTokens": 590,
+      "outputTokens": 78
+    }
+  }
+}

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { CourseEngine } from '../src/index.js';
-import type { CurriculumPlan, ContentItem } from '../src/index.js';
+import { CourseEngine, EngineError } from '../src/index.js';
+import type { CodeEvaluationClient, CurriculumPlan, ContentItem } from '../src/index.js';
 
 function mockCurriculum(): CurriculumPlan {
   return {
@@ -22,6 +22,14 @@ function mockCurriculum(): CurriculumPlan {
 const mockGenerator = {
   generateTopicExplanation: () => new Promise(() => {}),
   generateTopicQuizBurst: () => new Promise(() => {}),
+};
+
+const mockCodeEvaluator: CodeEvaluationClient = {
+  evaluateCode: async () => ({
+    verdict: 'correct',
+    correct: true,
+    feedback: 'This submission satisfies the prompt.',
+  }),
 };
 
 describe('New Question Types', () => {
@@ -98,7 +106,7 @@ describe('New Question Types', () => {
     expect(outOfRangeResult.correct).toBe(false);
   });
 
-  it('grades code as self-evaluation and ignores legacy expectedPattern', () => {
+  it('requires async tutor grading for code answers and ignores legacy expectedPattern', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
@@ -114,15 +122,15 @@ describe('New Question Types', () => {
 
     engine.setSectionContent([codeItem]);
 
-    const result = engine.submitAnswer({
-      type: 'code',
-      code: 'function test() { return false; }',
-    });
-    expect(result.correct).toBe(true);
-    expect(result.correctAnswer).toBe('Self-assessment submitted');
+    expect(() =>
+      engine.submitAnswer({
+        type: 'code',
+        code: 'function test() { return false; }',
+      })
+    ).toThrow(EngineError);
   });
 
-  it('grades code submissions as complete', () => {
+  it('rejects sync code submissions so the AI tutor cannot be bypassed', () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
@@ -137,11 +145,12 @@ describe('New Question Types', () => {
 
     engine.setSectionContent([codeItem]);
 
-    const result = engine.submitAnswer({
-      type: 'code',
-      code: 'any code',
-    });
-    expect(result.correct).toBe(true);
+    expect(() =>
+      engine.submitAnswer({
+        type: 'code',
+        code: 'any code',
+      })
+    ).toThrow(/submitAnswerAsync/);
   });
 
   it('grades self-evaluation correctly when a valid option is selected', () => {
@@ -204,7 +213,7 @@ describe('New Question Types', () => {
     expect(fractionalResult.correct).toBe(false);
   });
 
-  it('round-trips new question types via serialization', () => {
+  it('round-trips new question types via serialization', async () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
@@ -236,13 +245,16 @@ describe('New Question Types', () => {
     engine.setSectionContent(items);
 
     const snapshot = engine.serialize();
-    const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
+    const restored = CourseEngine.restore(snapshot, {
+      apiKey: 'test-key',
+      codeEvaluator: mockCodeEvaluator,
+    });
 
     expect(restored.currentItem?.type).toBe('checklist');
     restored.submitAnswer({ type: 'checklist', checkedIndices: [0, 1] });
     restored.nextItem();
     expect(restored.currentItem?.type).toBe('code');
-    restored.submitAnswer({ type: 'code', code: 'test' });
+    await restored.submitAnswerAsync({ type: 'code', code: 'test' });
     restored.nextItem();
     expect(restored.currentItem?.type).toBe('self-evaluation');
   });


### PR DESCRIPTION
## Summary
- Add a versioned code-evaluation prompt and provider-backed CodeEvaluator with recorded correct/partial/incorrect fixtures.
- Route code-question submissions through async engine grading, preserving the self-evaluation fallback when tutor grading fails.
- Render the tutor verdict and feedback in the Svelte learn flow as escaped text.

## Cross-package reason
This touches both packages because the engine owns grading, mastery updates, and answer-result payloads, while the app needs to call the async code path and display the emitted tutor feedback.

## Verification
- corepack pnpm -r test
- corepack pnpm -r build
- corepack pnpm format
- corepack pnpm format:check
- rg security scan for {@html}, eval/new Function, new RegExp, expectedPattern, and fetch usage

Closes #107