### PR TITLE
feat: add AI tutor code grading to engine + app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **Engine:** Reuse in-flight prefetch generation when starting a prefetched section so the engine does not make duplicate foreground and background API calls for the same section
 - **Engine:** Reject duplicate, fractional, and out-of-range practical-question answer indices during checklist and self-evaluation grading
 - **Engine/App:** Convert code questions to v1 self-evaluation grading, remove regex-based expected-pattern grading, and bump `QUIZ_GENERATION_VERSION` to `1.4`
+- **Engine/App:** Add AI-tutor grading for code questions, including tutor feedback rendering, self-evaluation fallback on provider failure, and `QUIZ_GENERATION_VERSION` `1.5`
 - **App:** Add route-level DOM coverage for checklist, code, and self-evaluation question rendering and submitted answer payloads
 - **Engine:** Add recorded quiz-generation v1.4 fixtures for diverse topics, including checklist, code, and self-evaluation schema coverage
 - **Engine:** Clean up stale Phase 3 question-type comments so source comments match the current eight-format v1 set

--- a/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
+++ b/apps/coursequizzer/src/lib/stores/engine-session.svelte.ts
@@ -12,7 +12,9 @@ import {
   type EngineSnapshot,
   type ContentItem,
   type AnswerResult,
-  type StudentAnswer,
+  type CodeAnswerEvaluator,
+  type CodeStudentAnswer,
+  type NonCodeStudentAnswer,
   type StudentState,
   type SessionProgress,
   type Section,
@@ -51,6 +53,7 @@ export type EngineSessionConfig = {
   snapshot?: EngineSnapshot;
   courseId?: string;
   storage?: Storage;
+  codeEvaluator?: CodeAnswerEvaluator;
 };
 
 export type EngineSession = ReturnType<typeof createEngineSession>;
@@ -60,6 +63,7 @@ export type EngineSession = ReturnType<typeof createEngineSession>;
 export function createEngineSession(config: EngineSessionConfig) {
   const engineConfig: CourseEngineConfig = {
     apiKey: config.apiKey,
+    codeEvaluator: config.codeEvaluator,
     prefetch: {
       enabled: true,
     },
@@ -283,9 +287,14 @@ export function createEngineSession(config: EngineSessionConfig) {
       engine.setSectionContent(items);
     },
 
-    submitAnswer(answer: StudentAnswer): AnswerResult {
+    submitAnswer(answer: NonCodeStudentAnswer): AnswerResult {
       if (!engine) throw new Error('Session is disposed');
       return engine.submitAnswer(answer);
+    },
+
+    submitCodeAnswer(answer: CodeStudentAnswer): Promise<AnswerResult> {
+      if (!engine) throw new Error('Session is disposed');
+      return engine.submitCodeAnswer(answer);
     },
 
     nextItem(): void {

--- a/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/[courseId]/learn/+page.svelte
@@ -89,9 +89,9 @@
     session.submitAnswer({ type: 'checklist', checkedIndices: indices });
   }
 
-  function handleCode(code: string) {
+  async function handleCode(code: string) {
     if (!session) return;
-    session.submitAnswer({ type: 'code', code });
+    await session.submitCodeAnswer({ type: 'code', code });
   }
 
   function handleSelfEvaluation(selectedIndex: number) {
@@ -231,6 +231,22 @@
   // --- Derived helpers ---
 
   const hasApiKey = $derived(getApiKey(localStorage) !== null);
+
+  function resultHeading(result: NonNullable<EngineSession['lastResult']>['result']) {
+    if (result.codeEvaluation?.verdict === 'partial') {
+      return 'Partially correct';
+    }
+    if (result.codeEvaluation?.verdict === 'incorrect') {
+      return 'Needs work';
+    }
+    return result.correct ? 'Correct!' : 'Incorrect';
+  }
+
+  function shouldShowCorrectAnswer(
+    result: NonNullable<EngineSession['lastResult']>['result']
+  ) {
+    return !result.correct && !result.codeEvaluation;
+  }
 </script>
 
 <svelte:head>
@@ -274,14 +290,20 @@
       </ol>
       <p><a href={`/course/${courseId}`}>← Back to course</a></p>
 
-    {:else if session.engineState === 'loading' || session.apiLoading}
+    {:else if session.engineState === 'loading' || session.engineState === 'grading' || session.apiLoading}
       <!-- Generating content -->
       <h1>{course.title}</h1>
       {#if session.currentSection}
         <h2>{session.currentSection.section.title}</h2>
       {/if}
-      <p class="loading">Generating learning content...</p>
-      <p>This may take a minute as content is generated for each topic.</p>
+      <p class="loading">
+        {session.engineState === 'loading'
+          ? 'Generating learning content...'
+          : 'Evaluating answer...'}
+      </p>
+      {#if session.engineState === 'loading'}
+        <p>This may take a minute as content is generated for each topic.</p>
+      {/if}
       {#if session.error}
         <p role="alert" class="error">{session.error.message}</p>
         <button type="button" onclick={handleBackToOverview}>Back to Course</button>
@@ -573,8 +595,8 @@
       {/if}
 
       <article class="result" class:correct={session.lastResult.result.correct} class:incorrect={!session.lastResult.result.correct}>
-        <h2>{session.lastResult.result.correct ? 'Correct!' : 'Incorrect'}</h2>
-        {#if !session.lastResult.result.correct}
+        <h2>{resultHeading(session.lastResult.result)}</h2>
+        {#if shouldShowCorrectAnswer(session.lastResult.result)}
           <p><strong>Correct answer:</strong> {session.lastResult.result.correctAnswer}</p>
         {/if}
         {#if session.lastResult.result.explanation}

--- a/apps/coursequizzer/tests/unit/learn-flow.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-flow.test.ts
@@ -4,7 +4,12 @@ import {
   type EngineSession,
 } from '../../src/lib/stores/engine-session.svelte.js';
 import { createCourse, getCourse } from '../../src/lib/storage/course-storage.js';
-import type { CurriculumPlan, ContentItem, StudentAnswer } from 'quizzer-engine';
+import type {
+  CodeAnswerEvaluator,
+  CurriculumPlan,
+  ContentItem,
+  StudentAnswer,
+} from 'quizzer-engine';
 
 // --- Test fixtures ---
 
@@ -196,8 +201,14 @@ describe('learn page flow', () => {
     expect(session.lastResult!.result.correct).toBe(false);
   });
 
-  it('handles code questions through the self-evaluation grading path', () => {
-    const session = createEngineSession({ apiKey: 'test-key' });
+  it('handles code questions through AI tutor grading', async () => {
+    const codeEvaluator: CodeAnswerEvaluator = {
+      evaluateCodeAnswer: vi.fn(async () => ({
+        verdict: 'partial',
+        feedback: 'The function returns false, but the prompt asks for true.',
+      })),
+    };
+    const session = createEngineSession({ apiKey: 'test-key', codeEvaluator });
     session.loadCurriculum(mockCurriculumPlan());
     session.startSection('s1');
     session.setSectionContent([
@@ -214,14 +225,18 @@ describe('learn page flow', () => {
 
     expect(session.currentItem!.item.type).toBe('code');
 
-    const result = session.submitAnswer({
+    const result = await session.submitCodeAnswer({
       type: 'code',
       code: 'function answer() { return false; }',
     });
 
-    expect(result.correct).toBe(true);
-    expect(result.correctAnswer).toBe('Self-assessment submitted');
-    expect(session.lastResult!.result.correct).toBe(true);
+    expect(codeEvaluator.evaluateCodeAnswer).toHaveBeenCalled();
+    expect(result.correct).toBe(false);
+    expect(result.codeEvaluation).toEqual({
+      verdict: 'partial',
+      feedback: 'The function returns false, but the prompt asks for true.',
+    });
+    expect(session.lastResult!.result.correct).toBe(false);
   });
 
   it('can skip a question and continue', () => {

--- a/apps/coursequizzer/tests/unit/learn-route-question-types.test.ts
+++ b/apps/coursequizzer/tests/unit/learn-route-question-types.test.ts
@@ -7,7 +7,9 @@ import type {
   ContentItem,
   CurriculumPlan,
   EngineSnapshot,
+  SessionProgress,
   StudentAnswer,
+  StudentState,
 } from 'quizzer-engine';
 import LearnPage from '../../src/routes/course/[courseId]/learn/+page.svelte';
 import { COURSES_STORAGE_KEY } from '../../src/lib/storage/course-storage.js';
@@ -79,6 +81,9 @@ function answerResult(answer: StudentAnswer, item: ContentItem): AnswerResult {
 function createPracticingSession(item: ContentItem) {
   const curriculum = mockCurriculumPlan();
   const submitAnswer = vi.fn((answer: StudentAnswer) => answerResult(answer, item));
+  const submitCodeAnswer = vi.fn(async (answer: { type: 'code'; code: string }) =>
+    answerResult(answer, item)
+  );
   const session: EngineSession = {
     engineState: 'practicing',
     curriculum,
@@ -102,6 +107,7 @@ function createPracticingSession(item: ContentItem) {
     startSection: vi.fn(),
     setSectionContent: vi.fn(),
     submitAnswer,
+    submitCodeAnswer,
     nextItem: vi.fn(),
     skipQuestion: vi.fn(),
     nextSection: vi.fn(),
@@ -109,14 +115,14 @@ function createPracticingSession(item: ContentItem) {
     dispose: vi.fn(),
   };
 
-  return { session, submitAnswer };
+  return { session, submitAnswer, submitCodeAnswer };
 }
 
 async function renderLearnPageWithItem(item: ContentItem) {
   const curriculum = mockCurriculumPlan();
   storeCourse(curriculum);
 
-  const { session, submitAnswer } = createPracticingSession(item);
+  const { session, submitAnswer, submitCodeAnswer } = createPracticingSession(item);
   createEngineSessionMock.mockReturnValue(session);
 
   render(LearnPage);
@@ -124,7 +130,68 @@ async function renderLearnPageWithItem(item: ContentItem) {
     name: item.type === 'explanation' ? item.title : item.question,
   });
 
-  return { session, submitAnswer };
+  return { session, submitAnswer, submitCodeAnswer };
+}
+
+function mockStudentState(): StudentState {
+  return { masteryByTopic: {}, gaps: [] };
+}
+
+function mockSessionProgress(): SessionProgress {
+  return {
+    currentSectionIndex: 0,
+    totalSections: 1,
+    currentItemIndex: 0,
+    totalItemsInSection: 1,
+    overallMastery: 0,
+    overallMasteryPercent: 0,
+    totalQuestionsAnswered: 1,
+    sections: [],
+    currentSectionTopicProgress: [],
+    hasProgress: true,
+  };
+}
+
+async function renderLearnPageWithResult(result: AnswerResult) {
+  const curriculum = mockCurriculumPlan();
+  storeCourse(curriculum);
+
+  const session: EngineSession = {
+    engineState: 'answered',
+    curriculum,
+    currentSection: {
+      section: curriculum.sections[0],
+      sectionIndex: 0,
+      totalSections: curriculum.sections.length,
+    },
+    currentItem: null,
+    lastResult: {
+      result,
+      studentState: mockStudentState(),
+      progress: mockSessionProgress(),
+    },
+    studentState: mockStudentState(),
+    progress: mockSessionProgress(),
+    apiLoading: false,
+    error: null,
+    restoreFailed: false,
+    loadCurriculum: vi.fn(),
+    startSection: vi.fn(),
+    setSectionContent: vi.fn(),
+    submitAnswer: vi.fn(),
+    submitCodeAnswer: vi.fn(),
+    nextItem: vi.fn(),
+    skipQuestion: vi.fn(),
+    nextSection: vi.fn(),
+    serialize: vi.fn((): EngineSnapshot | null => null),
+    dispose: vi.fn(),
+  };
+
+  createEngineSessionMock.mockReturnValue(session);
+  render(LearnPage);
+  await screen.findByRole('heading', { name: 'Partially correct' });
+
+  return { session };
 }
 
 // --- Tests ---
@@ -170,8 +237,8 @@ describe('learn route new question types', () => {
     });
   });
 
-  it('renders a code prompt with starter code and submits edited code', async () => {
-    const { submitAnswer } = await renderLearnPageWithItem({
+  it('renders a code prompt with starter code and submits edited code for tutor grading', async () => {
+    const { submitCodeAnswer } = await renderLearnPageWithItem({
       type: 'code',
       id: 'code-1',
       topicId: 't1',
@@ -195,7 +262,7 @@ describe('learn route new question types', () => {
     });
     await fireEvent.click(screen.getByRole('button', { name: 'Submit Code' }));
 
-    expect(submitAnswer).toHaveBeenCalledWith({
+    expect(submitCodeAnswer).toHaveBeenCalledWith({
       type: 'code',
       code: 'function first<T>(items: T[]): T | undefined {\n  return items[0];\n}',
     });
@@ -216,5 +283,33 @@ describe('learn route new question types', () => {
       type: 'self-evaluation',
       selectedIndex: 2,
     });
+  });
+
+  it('renders AI tutor feedback as escaped text', async () => {
+    const feedback = 'Use items[0], not <script>alert("x")</script>.';
+
+    await renderLearnPageWithResult({
+      correct: false,
+      questionId: 'code-1',
+      topicId: 't1',
+      userAnswer: {
+        type: 'code',
+        code: 'function first<T>(items: T[]): T | undefined { return undefined; }',
+      },
+      correctAnswer: 'Review the AI tutor feedback',
+      explanation: feedback,
+      codeEvaluation: {
+        verdict: 'partial',
+        feedback,
+      },
+    });
+
+    expect(screen.getByText(feedback)).toBeTruthy();
+    const resultElement = document.querySelector('.result')!;
+    expect(resultElement.innerHTML).toContain(
+      'Use items[0], not &lt;script&gt;alert("x")&lt;/script&gt;.'
+    );
+    expect(resultElement.querySelector('script')).toBeNull();
+    expect(screen.queryByText(/Correct answer:/)).toBeNull();
   });
 });

--- a/packages/engine/src/content/CodeEvaluator.ts
+++ b/packages/engine/src/content/CodeEvaluator.ts
@@ -1,0 +1,80 @@
+// --- Code Evaluator ---
+// Provider-backed AI tutor grading for code questions.
+// Student code is sent as text and is never executed.
+
+import { buildCodeEvaluationPrompt } from '../prompts/code-evaluation.js';
+import type { ProviderClient, ToolUseBlock } from '../provider/types.js';
+import type { CodeEvaluation, CodeEvaluationVerdict, CodeQuestion } from './types.js';
+
+const CODE_EVALUATION_MAX_TOKENS = 1024;
+
+export type { CodeEvaluation, CodeEvaluationVerdict } from './types.js';
+
+export type CodeAnswerEvaluator = {
+  evaluateCodeAnswer(
+    question: CodeQuestion,
+    studentCode: string
+  ): Promise<CodeEvaluation>;
+};
+
+export class CodeEvaluator implements CodeAnswerEvaluator {
+  #provider: ProviderClient;
+
+  constructor(provider: ProviderClient) {
+    this.#provider = provider;
+  }
+
+  async evaluateCodeAnswer(
+    question: CodeQuestion,
+    studentCode: string
+  ): Promise<CodeEvaluation> {
+    const prompt = buildCodeEvaluationPrompt({ question, studentCode });
+    let lastError = new Error(
+      `Failed to evaluate code answer for question "${question.id}" after retry`
+    );
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await this.#provider.sendMessage({
+        ...prompt,
+        maxTokens: CODE_EVALUATION_MAX_TOKENS,
+      });
+
+      const toolBlock = response.content.find(
+        (block): block is ToolUseBlock =>
+          block.type === 'tool_use' && block.name === 'evaluate_code_answer'
+      );
+
+      if (!toolBlock) {
+        continue;
+      }
+
+      try {
+        return this.#parseEvaluation(toolBlock);
+      } catch (error) {
+        lastError = this.#toError(error);
+      }
+    }
+
+    throw lastError;
+  }
+
+  #parseEvaluation(block: ToolUseBlock): CodeEvaluation {
+    const input = block.input as Record<string, unknown>;
+    const verdict = input.verdict;
+    const feedback = input.feedback;
+
+    if (verdict !== 'correct' && verdict !== 'partial' && verdict !== 'incorrect') {
+      throw new Error('Code evaluation verdict is invalid');
+    }
+
+    if (typeof feedback !== 'string' || feedback.length === 0) {
+      throw new Error('Code evaluation feedback is missing');
+    }
+
+    return { verdict, feedback };
+  }
+
+  #toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/packages/engine/src/content/types.ts
+++ b/packages/engine/src/content/types.ts
@@ -122,6 +122,16 @@ export type StudentAnswer =
   | { type: 'code'; code: string }
   | { type: 'self-evaluation'; selectedIndex: number };
 
+export type CodeStudentAnswer = Extract<StudentAnswer, { type: 'code' }>;
+export type NonCodeStudentAnswer = Exclude<StudentAnswer, CodeStudentAnswer>;
+
+export type CodeEvaluationVerdict = 'correct' | 'partial' | 'incorrect';
+
+export type CodeEvaluation = {
+  verdict: CodeEvaluationVerdict;
+  feedback: string;
+};
+
 export type AnswerResult = {
   correct: boolean;
   questionId: string;
@@ -130,4 +140,5 @@ export type AnswerResult = {
   // Additional context the UI needs to render the result
   correctAnswer: string; // human-readable description of the correct answer
   explanation?: string; // optional explanation of why
+  codeEvaluation?: CodeEvaluation; // AI tutor verdict and feedback for code answers
 };

--- a/packages/engine/src/engine/CourseEngine.ts
+++ b/packages/engine/src/engine/CourseEngine.ts
@@ -11,9 +11,11 @@ import { StudentModel } from '../student/StudentModel.js';
 import { createDefaultProvider } from '../provider/factory.js';
 import { ContentGenerator } from '../content/ContentGenerator.js';
 import { ContentManager } from '../content/ContentManager.js';
+import { CodeEvaluator } from '../content/CodeEvaluator.js';
 import { ContentCache } from '../content/ContentCache.js';
 import { copyContentItem } from '../content/copy-utils.js';
 import { Prefetcher } from '../content/Prefetcher.js';
+import type { CodeAnswerEvaluator } from '../content/CodeEvaluator.js';
 import type {
   CourseEngineConfig,
   EngineSnapshot,
@@ -24,7 +26,13 @@ import type {
   StudentState,
   SessionProgress,
 } from './types.js';
-import type { StudentAnswer, Question } from '../content/types.js';
+import type {
+  CodeQuestion,
+  CodeStudentAnswer,
+  NonCodeStudentAnswer,
+  Question,
+  StudentAnswer,
+} from '../content/types.js';
 import type { Section } from '../curriculum/types.js';
 
 function copySection(section: Section): Section {
@@ -63,10 +71,16 @@ function copyStudentAnswer(answer: StudentAnswer): StudentAnswer {
 }
 
 function copyAnswerResult(result: AnswerResult): AnswerResult {
-  return {
+  const copy: AnswerResult = {
     ...result,
     userAnswer: copyStudentAnswer(result.userAnswer),
   };
+
+  if (result.codeEvaluation) {
+    copy.codeEvaluation = { ...result.codeEvaluation };
+  }
+
+  return copy;
 }
 
 function isValidGeneratedContentRecord(
@@ -100,8 +114,10 @@ export class CourseEngine extends EventEmitter {
   #studentModel: StudentModel = new StudentModel();
   #lastAnswerResult: AnswerResult | null = null;
   #contentManager: ContentManager;
+  #codeEvaluator: CodeAnswerEvaluator;
   #contentCache: ContentCache | null = null;
   #prefetcher: Prefetcher | null = null;
+  #codeEvaluationCallSequence = 0;
 
   constructor(config: CourseEngineConfig) {
     super();
@@ -115,6 +131,7 @@ export class CourseEngine extends EventEmitter {
       });
 
     const generator = config.generator || new ContentGenerator(provider);
+    this.#codeEvaluator = config.codeEvaluator || new CodeEvaluator(provider);
 
     this.#contentManager = new ContentManager(generator, (payload) => {
       if (payload.status === 'start') {
@@ -317,7 +334,7 @@ export class CourseEngine extends EventEmitter {
 
   // --- Student Interaction ---
 
-  submitAnswer(answer: StudentAnswer): AnswerResult {
+  submitAnswer(answer: NonCodeStudentAnswer): AnswerResult {
     this.#requireState('submitAnswer', 'practicing');
 
     const item = this.currentItem;
@@ -326,19 +343,35 @@ export class CourseEngine extends EventEmitter {
     }
 
     const result = this.#gradeAnswer(item, answer);
-    this.#lastAnswerResult = copyAnswerResult(result);
+    return this.#applyAnswerResult(result);
+  }
 
-    // Update mastery
-    this.#updateMastery(result);
+  async submitCodeAnswer(answer: CodeStudentAnswer): Promise<AnswerResult> {
+    this.#requireState('submitCodeAnswer', 'practicing');
 
-    this.#setState('answered');
-    this.emit('answerResult', {
-      result: copyAnswerResult(result),
-      studentState: this.studentState,
-      progress: this.sessionProgress,
-    });
+    const item = this.currentItem;
+    if (!item || item.type === 'explanation') {
+      throw new InvalidTransitionError(
+        'submitCodeAnswer',
+        'current item is not a question'
+      );
+    }
 
-    return copyAnswerResult(result);
+    if (item.type !== 'code') {
+      const result: AnswerResult = {
+        correct: false,
+        questionId: item.id,
+        topicId: item.topicId,
+        userAnswer: copyStudentAnswer(answer),
+        correctAnswer: this.#describeCorrectAnswer(item),
+        explanation: 'Answer type does not match question type.',
+      };
+      return this.#applyAnswerResult(result);
+    }
+
+    this.#setState('grading');
+    const result = await this.#gradeCodeAnswer(item, answer);
+    return this.#applyAnswerResult(result);
   }
 
   nextItem(): void {
@@ -442,7 +475,22 @@ export class CourseEngine extends EventEmitter {
 
   // --- Grading ---
 
-  #gradeAnswer(question: Question, answer: StudentAnswer): AnswerResult {
+  #applyAnswerResult(result: AnswerResult): AnswerResult {
+    this.#lastAnswerResult = copyAnswerResult(result);
+
+    this.#updateMastery(result);
+
+    this.#setState('answered');
+    this.emit('answerResult', {
+      result: copyAnswerResult(result),
+      studentState: this.studentState,
+      progress: this.sessionProgress,
+    });
+
+    return copyAnswerResult(result);
+  }
+
+  #gradeAnswer(question: Question, answer: NonCodeStudentAnswer): AnswerResult {
     if (question.type !== answer.type) {
       return {
         correct: false,
@@ -462,6 +510,66 @@ export class CourseEngine extends EventEmitter {
       topicId: question.topicId,
       userAnswer: copyStudentAnswer(answer),
       correctAnswer: this.#describeCorrectAnswer(question),
+    };
+  }
+
+  async #gradeCodeAnswer(
+    question: CodeQuestion,
+    answer: CodeStudentAnswer
+  ): Promise<AnswerResult> {
+    try {
+      const evaluation = await this.#withCodeEvaluationApiCall(question.id, () =>
+        this.#codeEvaluator.evaluateCodeAnswer(question, answer.code)
+      );
+
+      return {
+        correct: evaluation.verdict === 'correct',
+        questionId: question.id,
+        topicId: question.topicId,
+        userAnswer: copyStudentAnswer(answer),
+        correctAnswer: 'Review the AI tutor feedback',
+        explanation: evaluation.feedback,
+        codeEvaluation: { ...evaluation },
+      };
+    } catch {
+      return this.#fallbackCodeAnswerResult(question, answer);
+    }
+  }
+
+  async #withCodeEvaluationApiCall<T>(
+    questionId: string,
+    evaluate: () => Promise<T>
+  ): Promise<T> {
+    this.#codeEvaluationCallSequence += 1;
+    const id = `code-evaluation-${this.#codeEvaluationCallSequence}`;
+    const purpose = `Code evaluation: ${questionId}`;
+
+    this.emit('apiCallStart', { id, purpose });
+    try {
+      return await evaluate();
+    } finally {
+      this.emit('apiCallComplete', { id, purpose });
+    }
+  }
+
+  #fallbackCodeAnswerResult(
+    question: CodeQuestion,
+    answer: CodeStudentAnswer
+  ): AnswerResult {
+    const feedback =
+      'The AI tutor could not evaluate this code, so CourseQuizzer recorded the submission as completed without executing it.';
+
+    return {
+      correct: true,
+      questionId: question.id,
+      topicId: question.topicId,
+      userAnswer: copyStudentAnswer(answer),
+      correctAnswer: 'Self-assessment submitted',
+      explanation: feedback,
+      codeEvaluation: {
+        verdict: 'correct',
+        feedback,
+      },
     };
   }
 
@@ -517,7 +625,7 @@ export class CourseEngine extends EventEmitter {
         );
       }
       case 'code':
-        return true;
+        throw new Error('Code questions require AI tutor grading');
       case 'self-evaluation': {
         const a = answer as { type: 'self-evaluation'; selectedIndex: number };
         return (
@@ -546,6 +654,7 @@ export class CourseEngine extends EventEmitter {
       case 'checklist':
         return 'Completion of all steps';
       case 'code':
+        return 'Review the AI tutor feedback';
       case 'self-evaluation':
         return 'Self-assessment submitted';
     }
@@ -602,6 +711,9 @@ export class CourseEngine extends EventEmitter {
     // (or without an error message for 'error'). Revert to 'ready'.
     if (engine.#state === 'loading' || engine.#state === 'error') {
       engine.#state = 'ready';
+    }
+    if (engine.#state === 'grading') {
+      engine.#state = 'practicing';
     }
 
     engine.#curriculum = snapshot.curriculum

--- a/packages/engine/src/engine/types.ts
+++ b/packages/engine/src/engine/types.ts
@@ -18,6 +18,7 @@ import type {
 } from '../student/types.js';
 import type { ProviderClient } from '../provider/types.js';
 import type { TopicContentGenerator } from '../content/ContentGenerator.js';
+import type { CodeAnswerEvaluator } from '../content/CodeEvaluator.js';
 
 export type EngineState =
   | 'idle' // no syllabus loaded
@@ -25,6 +26,7 @@ export type EngineState =
   | 'ready' // curriculum plan available, no section started
   | 'loading' // generating content for a section
   | 'practicing' // student is viewing content or answering a question
+  | 'grading' // evaluating an async answer submission
   | 'answered' // student submitted an answer, viewing result
   | 'sectionComplete' // all items in the current section are done
   | 'complete' // all sections done
@@ -35,6 +37,7 @@ export type CourseEngineConfig = {
   model?: string;
   provider?: ProviderClient;
   generator?: TopicContentGenerator;
+  codeEvaluator?: CodeAnswerEvaluator;
   prefetch?: {
     enabled: boolean;
     generator?: TopicContentGenerator;

--- a/packages/engine/src/export/snapshot-validation.ts
+++ b/packages/engine/src/export/snapshot-validation.ts
@@ -63,6 +63,7 @@ function isValidEngineState(value: unknown): boolean {
     value === 'ready' ||
     value === 'loading' ||
     value === 'practicing' ||
+    value === 'grading' ||
     value === 'answered' ||
     value === 'sectionComplete' ||
     value === 'complete' ||
@@ -118,12 +119,22 @@ function isValidStudentAnswer(value: unknown): value is StudentAnswer {
 
 function isValidAnswerResult(value: unknown): value is AnswerResult {
   if (!isPlainObject(value)) return false;
+
+  const hasValidCodeEvaluation =
+    value.codeEvaluation === undefined ||
+    (isPlainObject(value.codeEvaluation) &&
+      (value.codeEvaluation.verdict === 'correct' ||
+        value.codeEvaluation.verdict === 'partial' ||
+        value.codeEvaluation.verdict === 'incorrect') &&
+      typeof value.codeEvaluation.feedback === 'string');
+
   return (
     typeof value.correct === 'boolean' &&
     typeof value.questionId === 'string' &&
     typeof value.topicId === 'string' &&
     typeof value.correctAnswer === 'string' &&
     (value.explanation === undefined || typeof value.explanation === 'string') &&
+    hasValidCodeEvaluation &&
     isValidStudentAnswer(value.userAnswer)
   );
 }
@@ -261,6 +272,7 @@ function isValidSnapshotPosition(snapshot: EngineSnapshot): boolean {
     case 'error':
       return snapshot.currentItemIndex === -1 && snapshot.sectionItems.length === 0;
     case 'practicing':
+    case 'grading':
     case 'answered':
       return (
         snapshot.sectionItems.length > 0 &&
@@ -330,6 +342,13 @@ function copyAnswerResult(result: AnswerResult): AnswerResult {
 
   if (result.explanation !== undefined) {
     copy.explanation = result.explanation;
+  }
+
+  if (result.codeEvaluation !== undefined) {
+    copy.codeEvaluation = {
+      verdict: result.codeEvaluation.verdict,
+      feedback: result.codeEvaluation.feedback,
+    };
   }
 
   return copy;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -12,6 +12,7 @@ export { SyllabusParser, validateCurriculumPlan } from './curriculum/SyllabusPar
 export { CurriculumManager } from './curriculum/CurriculumManager.js';
 export { ContentGenerator } from './content/ContentGenerator.js';
 export { ContentManager } from './content/ContentManager.js';
+export { CodeEvaluator } from './content/CodeEvaluator.js';
 export { checkQuestionQuality } from './content/quality-filters.js';
 export { Exporter } from './export/Exporter.js';
 export { Importer } from './export/Importer.js';
@@ -55,11 +56,20 @@ export {
   buildQuizGenerationPrompt,
   QUIZ_GENERATION_VERSION,
 } from './prompts/quiz-generation.js';
+export {
+  buildCodeEvaluationPrompt,
+  CODE_EVALUATION_VERSION,
+} from './prompts/code-evaluation.js';
 export type { PromptMessages } from './prompts/types.js';
 export type { MasteryUpdate } from './student/StudentModel.js';
 
 export type {
+  CodeEvaluation,
+  CodeEvaluationVerdict,
+  CodeQuestion,
+  CodeStudentAnswer,
   StudentAnswer,
+  NonCodeStudentAnswer,
   QuestionType,
   MultipleChoiceQuestion,
   NumericInputQuestion,
@@ -67,6 +77,8 @@ export type {
   MultiSelectQuestion,
   TwoStageQuestion,
 } from './content/types.js';
+
+export type { CodeAnswerEvaluator } from './content/CodeEvaluator.js';
 
 export type {
   ProviderConfig,

--- a/packages/engine/src/prompts/code-evaluation.ts
+++ b/packages/engine/src/prompts/code-evaluation.ts
@@ -1,0 +1,88 @@
+// --- Code Evaluation Prompt ---
+// Evaluates a student-submitted code answer by reading it as text.
+// The engine never executes student code.
+
+import type { CodeQuestion } from '../content/types.js';
+import type { PromptMessages } from './types.js';
+
+export const CODE_EVALUATION_VERSION = '1.0';
+
+// --- Tool Schema ---
+
+function buildCodeEvaluationTool() {
+  return {
+    name: 'evaluate_code_answer',
+    description:
+      'Evaluate a student code submission against the requested task without executing it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        verdict: {
+          type: 'string',
+          enum: ['correct', 'partial', 'incorrect'],
+          description:
+            'correct if the submission satisfies the prompt, partial if it is meaningfully close but incomplete, incorrect otherwise',
+        },
+        feedback: {
+          type: 'string',
+          description:
+            'Short tutor-style feedback explaining the verdict and the most important next step',
+        },
+      },
+      required: ['verdict', 'feedback'],
+    },
+  };
+}
+
+// --- Prompt Builders ---
+
+function buildSystemPrompt(): string {
+  return `You are an AI tutor evaluating a student's code answer.
+
+Do not execute, simulate execution of, or request execution of the code. Read the code as text and judge whether it satisfies the task.
+
+Return:
+- correct: the answer satisfies the task
+- partial: the answer shows meaningful understanding but misses an important requirement or edge case
+- incorrect: the answer does not solve the task
+
+Feedback should be concise, specific, and helpful. Do not mention hidden tests, metadata, or internal grading rules.`;
+}
+
+function buildUserPrompt(question: CodeQuestion, studentCode: string): string {
+  const starterCode =
+    question.initialCode === undefined
+      ? ''
+      : `\nStarter code:\n<starter_code>\n${question.initialCode}\n</starter_code>\n`;
+
+  return `Evaluate this student code answer.
+
+Question:
+${question.question}
+
+Language:
+${question.language}${starterCode}
+Student submission:
+<student_code>
+${studentCode}
+</student_code>`;
+}
+
+// --- Public API ---
+
+export function buildCodeEvaluationPrompt(params: {
+  question: CodeQuestion;
+  studentCode: string;
+}): PromptMessages {
+  return {
+    system: buildSystemPrompt(),
+    messages: [
+      {
+        role: 'user',
+        content: buildUserPrompt(params.question, params.studentCode),
+      },
+    ],
+    tools: [buildCodeEvaluationTool()],
+    toolChoice: { type: 'tool', name: 'evaluate_code_answer' },
+  };
+}

--- a/packages/engine/src/prompts/quiz-generation.ts
+++ b/packages/engine/src/prompts/quiz-generation.ts
@@ -4,7 +4,7 @@
 
 import type { PromptMessages } from './types.js';
 
-export const QUIZ_GENERATION_VERSION = '1.4';
+export const QUIZ_GENERATION_VERSION = '1.5';
 
 // --- Tool Schema ---
 
@@ -133,7 +133,7 @@ Question type guidelines:
 - **multi-select**: 4-6 options, 2-3 correct. Clearly ask "select ALL that apply."
 - **two-stage**: First question + follow-up. Both are multiple-choice. The follow-up probes deeper understanding.
 - **checklist**: Used for practical tasks or procedures. List 3-5 specific steps the student should perform or verify.
-- **code**: Ask the student to write a short code snippet. Provide the programming language and optionally some initial code. Do not provide automatic grading fields; code questions are self-evaluated in this version.
+- **code**: Ask the student to write a short code snippet. Provide the programming language and optionally some initial code. Do not provide automatic grading fields; code answers are evaluated later by an AI tutor.
 - **self-evaluation**: Used for open-ended or subjective practical mastery. Provide 2-4 levels of mastery as options (e.g., "I can do this reliably", "I need more practice").
 
 Quality rules:

--- a/packages/engine/tests/code-evaluator.test.ts
+++ b/packages/engine/tests/code-evaluator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildCodeEvaluationPrompt,
+  CODE_EVALUATION_VERSION,
+} from '../src/prompts/code-evaluation.js';
+import { CodeEvaluator } from '../src/content/CodeEvaluator.js';
+import type { ProviderClient, ProviderResponse } from '../src/provider/types.js';
+import {
+  RECORDED_CODE_EVALUATION_CASES,
+  type RecordedCodeEvaluationCase,
+} from './fixtures/recorded/code-evaluation.js';
+
+function mockProvider(...responses: ProviderResponse[]): ProviderClient {
+  const sendMessage = vi.fn();
+  for (const response of responses) {
+    sendMessage.mockResolvedValueOnce(response);
+  }
+  return { sendMessage };
+}
+
+function textOnlyResponse(): ProviderResponse {
+  return {
+    id: 'msg_text_only',
+    content: [{ type: 'text', text: 'I cannot evaluate that.' }],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'end_turn',
+    usage: { inputTokens: 100, outputTokens: 20 },
+  };
+}
+
+describe('code evaluation prompt', () => {
+  const recordedCase = RECORDED_CODE_EVALUATION_CASES[0];
+
+  it('exports version constant', () => {
+    expect(CODE_EVALUATION_VERSION).toBe('1.0');
+  });
+
+  it('builds a tool-backed grading prompt', () => {
+    const prompt = buildCodeEvaluationPrompt({
+      question: recordedCase.question,
+      studentCode: recordedCase.studentCode,
+    });
+
+    expect(prompt.system).toContain('AI tutor');
+    expect(prompt.system).toContain('Do not execute');
+    expect(prompt.messages[0].content).toContain(recordedCase.question.question);
+    expect(prompt.messages[0].content).toContain(recordedCase.studentCode);
+    expect(prompt.tools![0].name).toBe('evaluate_code_answer');
+    expect(prompt.toolChoice).toEqual({
+      type: 'tool',
+      name: 'evaluate_code_answer',
+    });
+  });
+
+  it('keeps student-controlled prompt data out of the system prompt', () => {
+    const prompt = buildCodeEvaluationPrompt({
+      question: {
+        ...recordedCase.question,
+        question: 'SECRET_QUESTION',
+        language: 'SECRET_LANGUAGE',
+      },
+      studentCode: 'SECRET_CODE',
+    });
+
+    expect(prompt.messages[0].content).toContain('SECRET_QUESTION');
+    expect(prompt.messages[0].content).toContain('SECRET_LANGUAGE');
+    expect(prompt.messages[0].content).toContain('SECRET_CODE');
+    expect(prompt.system).not.toContain('SECRET_QUESTION');
+    expect(prompt.system).not.toContain('SECRET_LANGUAGE');
+    expect(prompt.system).not.toContain('SECRET_CODE');
+  });
+});
+
+describe('CodeEvaluator', () => {
+  it.each(RECORDED_CODE_EVALUATION_CASES)(
+    'parses recorded Claude response: $label',
+    async (recordedCase: RecordedCodeEvaluationCase) => {
+      const evaluator = new CodeEvaluator(mockProvider(recordedCase.response));
+
+      const result = await evaluator.evaluateCodeAnswer(
+        recordedCase.question,
+        recordedCase.studentCode
+      );
+
+      expect(result).toEqual({
+        verdict: recordedCase.expectedVerdict,
+        feedback: recordedCase.expectedFeedback,
+      });
+    }
+  );
+
+  it('retries once when the first response is missing the tool payload', async () => {
+    const recordedCase = RECORDED_CODE_EVALUATION_CASES[0];
+    const provider = mockProvider(textOnlyResponse(), recordedCase.response);
+    const evaluator = new CodeEvaluator(provider);
+
+    const result = await evaluator.evaluateCodeAnswer(
+      recordedCase.question,
+      recordedCase.studentCode
+    );
+
+    expect(result.verdict).toBe('correct');
+    expect(provider.sendMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/engine/tests/code-grading.test.ts
+++ b/packages/engine/tests/code-grading.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CourseEngine } from '../src/index.js';
+import type {
+  CodeAnswerEvaluator,
+  CodeEvaluation,
+} from '../src/content/CodeEvaluator.js';
+import type {
+  CodeQuestion,
+  ContentItem,
+  CurriculumPlan,
+  EngineEventMap,
+} from '../src/index.js';
+
+function mockCurriculum(): CurriculumPlan {
+  return {
+    title: 'Programming Basics',
+    description: 'A course about programming tasks.',
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Functions',
+        order: 0,
+        topics: [
+          {
+            id: 'topic-1',
+            title: 'Return Values',
+            description: 'Writing functions that return values.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const mockGenerator = {
+  generateTopicExplanation: () => new Promise<never>(() => {}),
+  generateTopicQuizBurst: () => new Promise<never>(() => {}),
+};
+
+function codeQuestion(): CodeQuestion {
+  return {
+    type: 'code',
+    id: 'q-code',
+    topicId: 'topic-1',
+    question: 'Write a function that returns true.',
+    language: 'TypeScript',
+    initialCode: 'function answer(): boolean {\n}',
+  };
+}
+
+function engineWithCodeQuestion(evaluator: CodeAnswerEvaluator): CourseEngine {
+  const engine = new CourseEngine({
+    apiKey: 'test-key',
+    generator: mockGenerator,
+    codeEvaluator: evaluator,
+  });
+  engine.loadCurriculum(mockCurriculum());
+  engine.startSection('section-1');
+  engine.setSectionContent([codeQuestion() as ContentItem]);
+  return engine;
+}
+
+function evaluatorReturning(evaluation: CodeEvaluation): CodeAnswerEvaluator {
+  return {
+    evaluateCodeAnswer: vi.fn(async () => evaluation),
+  };
+}
+
+describe('AI tutor code grading', () => {
+  it('uses the code evaluator verdict and feedback for code answers', async () => {
+    const evaluator = evaluatorReturning({
+      verdict: 'partial',
+      feedback: 'You returned a boolean, but it is false instead of true.',
+    });
+    const engine = engineWithCodeQuestion(evaluator);
+    const answerResultEvents: EngineEventMap['answerResult'][] = [];
+    const stateChanges: EngineEventMap['stateChange'][] = [];
+    engine.on('answerResult', (payload) => answerResultEvents.push(payload));
+    engine.on('stateChange', (payload) => stateChanges.push(payload));
+
+    const result = await engine.submitCodeAnswer({
+      type: 'code',
+      code: 'function answer(): boolean {\n  return false;\n}',
+    });
+
+    expect(evaluator.evaluateCodeAnswer).toHaveBeenCalledWith(
+      codeQuestion(),
+      'function answer(): boolean {\n  return false;\n}'
+    );
+    expect(result.correct).toBe(false);
+    expect(result.codeEvaluation).toEqual({
+      verdict: 'partial',
+      feedback: 'You returned a boolean, but it is false instead of true.',
+    });
+    expect(result.explanation).toBe(
+      'You returned a boolean, but it is false instead of true.'
+    );
+    expect(engine.studentState.masteryByTopic['topic-1'].questionsAnswered).toBe(1);
+    expect(engine.studentState.masteryByTopic['topic-1'].questionsCorrect).toBe(0);
+    expect(answerResultEvents).toHaveLength(1);
+    expect(stateChanges).toEqual([
+      { from: 'practicing', to: 'grading' },
+      { from: 'grading', to: 'answered' },
+    ]);
+  });
+
+  it('marks correct code evaluations as correct for mastery', async () => {
+    const engine = engineWithCodeQuestion(
+      evaluatorReturning({
+        verdict: 'correct',
+        feedback: 'This returns true as requested.',
+      })
+    );
+
+    const result = await engine.submitCodeAnswer({
+      type: 'code',
+      code: 'function answer(): boolean {\n  return true;\n}',
+    });
+
+    expect(result.correct).toBe(true);
+    expect(engine.studentState.masteryByTopic['topic-1'].questionsCorrect).toBe(1);
+  });
+
+  it('falls back to self-evaluation when code evaluation fails', async () => {
+    const evaluator: CodeAnswerEvaluator = {
+      evaluateCodeAnswer: vi.fn(async () => {
+        throw new Error('provider failed');
+      }),
+    };
+    const engine = engineWithCodeQuestion(evaluator);
+
+    const result = await engine.submitCodeAnswer({
+      type: 'code',
+      code: 'function answer(): boolean {\n  return false;\n}',
+    });
+
+    expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Self-assessment submitted');
+    expect(result.codeEvaluation).toEqual({
+      verdict: 'correct',
+      feedback:
+        'The AI tutor could not evaluate this code, so CourseQuizzer recorded the submission as completed without executing it.',
+    });
+    expect(engine.studentState.masteryByTopic['topic-1'].questionsCorrect).toBe(1);
+  });
+
+  it('emits API loading events around tutor grading', async () => {
+    const engine = engineWithCodeQuestion(
+      evaluatorReturning({
+        verdict: 'correct',
+        feedback: 'This returns true.',
+      })
+    );
+    const starts: EngineEventMap['apiCallStart'][] = [];
+    const completes: EngineEventMap['apiCallComplete'][] = [];
+    engine.on('apiCallStart', (payload) => starts.push(payload));
+    engine.on('apiCallComplete', (payload) => completes.push(payload));
+
+    await engine.submitCodeAnswer({
+      type: 'code',
+      code: 'function answer(): boolean {\n  return true;\n}',
+    });
+
+    expect(starts).toEqual([
+      { id: 'code-evaluation-1', purpose: 'Code evaluation: q-code' },
+    ]);
+    expect(completes).toEqual(starts);
+  });
+});

--- a/packages/engine/tests/content-generator.test.ts
+++ b/packages/engine/tests/content-generator.test.ts
@@ -80,7 +80,7 @@ describe('explanation prompt', () => {
 
 describe('quiz generation prompt', () => {
   it('exports version constant', () => {
-    expect(QUIZ_GENERATION_VERSION).toBe('1.4');
+    expect(QUIZ_GENERATION_VERSION).toBe('1.5');
   });
 
   it('builds prompt with topic and explanation context', () => {
@@ -127,6 +127,7 @@ describe('quiz generation prompt', () => {
     expect(questionProperties).not.toHaveProperty('expectedPattern');
     expect(prompt.system).not.toContain('expectedPattern');
     expect(prompt.system).not.toContain('regex');
+    expect(prompt.system).toContain('AI tutor');
   });
 });
 

--- a/packages/engine/tests/fixtures/recorded/code-evaluation.ts
+++ b/packages/engine/tests/fixtures/recorded/code-evaluation.ts
@@ -1,0 +1,101 @@
+// --- Recorded Fixture: Code Evaluation v1.0 ---
+// Captured-format Claude responses for AI tutor grading of code answers.
+
+import type { CodeEvaluationVerdict } from '../../../src/content/CodeEvaluator.js';
+import type { CodeQuestion } from '../../../src/content/types.js';
+import type { ProviderResponse } from '../../../src/provider/types.js';
+
+export type RecordedCodeEvaluationCase = {
+  label: string;
+  question: CodeQuestion;
+  studentCode: string;
+  expectedVerdict: CodeEvaluationVerdict;
+  expectedFeedback: string;
+  response: ProviderResponse;
+};
+
+function codeEvaluationResponse(
+  id: string,
+  verdict: CodeEvaluationVerdict,
+  feedback: string
+): ProviderResponse {
+  return {
+    id: `msg_code_eval_${id}`,
+    content: [
+      {
+        type: 'tool_use',
+        id: `toolu_code_eval_${id}`,
+        name: 'evaluate_code_answer',
+        input: { verdict, feedback },
+      },
+    ],
+    model: 'claude-sonnet-4-20250514',
+    stopReason: 'tool_use',
+    usage: { inputTokens: 640, outputTokens: 120 },
+  };
+}
+
+export const RECORDED_CODE_EVALUATION_CASES: RecordedCodeEvaluationCase[] = [
+  {
+    label: 'correct TypeScript array helper',
+    question: {
+      type: 'code',
+      id: 'code-arrays-1',
+      topicId: 'arrays',
+      question:
+        'Write a TypeScript function firstItem that returns the first item in an array, or undefined for an empty array.',
+      language: 'TypeScript',
+    },
+    studentCode:
+      'function firstItem<T>(items: T[]): T | undefined {\n  return items[0];\n}',
+    expectedVerdict: 'correct',
+    expectedFeedback:
+      'This satisfies the prompt: indexing at 0 returns the first item and naturally returns undefined for an empty array.',
+    response: codeEvaluationResponse(
+      'arrays_correct',
+      'correct',
+      'This satisfies the prompt: indexing at 0 returns the first item and naturally returns undefined for an empty array.'
+    ),
+  },
+  {
+    label: 'partial Python validation helper',
+    question: {
+      type: 'code',
+      id: 'code-validation-1',
+      topicId: 'validation',
+      question:
+        'Write a Python function is_positive_even that returns True only when n is both positive and even.',
+      language: 'Python',
+    },
+    studentCode: 'def is_positive_even(n):\n    return n % 2 == 0',
+    expectedVerdict: 'partial',
+    expectedFeedback:
+      'The even-number check is present, but the answer does not reject zero or negative even numbers.',
+    response: codeEvaluationResponse(
+      'validation_partial',
+      'partial',
+      'The even-number check is present, but the answer does not reject zero or negative even numbers.'
+    ),
+  },
+  {
+    label: 'incorrect JavaScript reduce implementation',
+    question: {
+      type: 'code',
+      id: 'code-reduce-1',
+      topicId: 'reducers',
+      question:
+        'Write a JavaScript function sum that returns the sum of every number in an array.',
+      language: 'JavaScript',
+      initialCode: 'function sum(numbers) {\n  // your code here\n}',
+    },
+    studentCode: 'function sum(numbers) {\n  return numbers.length;\n}',
+    expectedVerdict: 'incorrect',
+    expectedFeedback:
+      'This returns the number of elements, not the sum of their values. Accumulate the values instead.',
+    response: codeEvaluationResponse(
+      'reduce_incorrect',
+      'incorrect',
+      'This returns the number of elements, not the sum of their values. Accumulate the values instead.'
+    ),
+  },
+];

--- a/packages/engine/tests/new-question-types.test.ts
+++ b/packages/engine/tests/new-question-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CourseEngine } from '../src/index.js';
+import type { CodeAnswerEvaluator } from '../src/content/CodeEvaluator.js';
 import type { CurriculumPlan, ContentItem } from '../src/index.js';
 
 function mockCurriculum(): CurriculumPlan {
@@ -22,6 +23,13 @@ function mockCurriculum(): CurriculumPlan {
 const mockGenerator = {
   generateTopicExplanation: () => new Promise(() => {}),
   generateTopicQuizBurst: () => new Promise(() => {}),
+};
+
+const correctCodeEvaluator: CodeAnswerEvaluator = {
+  evaluateCodeAnswer: async () => ({
+    verdict: 'correct',
+    feedback: 'The submission satisfies the prompt.',
+  }),
 };
 
 describe('New Question Types', () => {
@@ -98,8 +106,17 @@ describe('New Question Types', () => {
     expect(outOfRangeResult.correct).toBe(false);
   });
 
-  it('grades code as self-evaluation and ignores legacy expectedPattern', () => {
-    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+  it('grades code with the tutor evaluator and ignores legacy expectedPattern', async () => {
+    const engine = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+      codeEvaluator: {
+        evaluateCodeAnswer: async () => ({
+          verdict: 'incorrect',
+          feedback: 'The function returns false, but the prompt asks for true.',
+        }),
+      },
+    });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
 
@@ -114,16 +131,27 @@ describe('New Question Types', () => {
 
     engine.setSectionContent([codeItem]);
 
-    const result = engine.submitAnswer({
+    const result = await engine.submitCodeAnswer({
       type: 'code',
       code: 'function test() { return false; }',
     });
-    expect(result.correct).toBe(true);
-    expect(result.correctAnswer).toBe('Self-assessment submitted');
+    expect(result.correct).toBe(false);
+    expect(result.correctAnswer).toBe('Review the AI tutor feedback');
+    expect(result.explanation).toBe(
+      'The function returns false, but the prompt asks for true.'
+    );
   });
 
-  it('grades code submissions as complete', () => {
-    const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
+  it('falls back to self-evaluation when tutor code grading fails', async () => {
+    const engine = new CourseEngine({
+      apiKey: 'test-key',
+      generator: mockGenerator,
+      codeEvaluator: {
+        evaluateCodeAnswer: async () => {
+          throw new Error('provider failed');
+        },
+      },
+    });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
 
@@ -137,11 +165,12 @@ describe('New Question Types', () => {
 
     engine.setSectionContent([codeItem]);
 
-    const result = engine.submitAnswer({
+    const result = await engine.submitCodeAnswer({
       type: 'code',
       code: 'any code',
     });
     expect(result.correct).toBe(true);
+    expect(result.correctAnswer).toBe('Self-assessment submitted');
   });
 
   it('grades self-evaluation correctly when a valid option is selected', () => {
@@ -204,7 +233,7 @@ describe('New Question Types', () => {
     expect(fractionalResult.correct).toBe(false);
   });
 
-  it('round-trips new question types via serialization', () => {
+  it('round-trips new question types via serialization', async () => {
     const engine = new CourseEngine({ apiKey: 'test-key', generator: mockGenerator });
     engine.loadCurriculum(mockCurriculum());
     engine.startSection('section-1');
@@ -236,13 +265,16 @@ describe('New Question Types', () => {
     engine.setSectionContent(items);
 
     const snapshot = engine.serialize();
-    const restored = CourseEngine.restore(snapshot, { apiKey: 'test-key' });
+    const restored = CourseEngine.restore(snapshot, {
+      apiKey: 'test-key',
+      codeEvaluator: correctCodeEvaluator,
+    });
 
     expect(restored.currentItem?.type).toBe('checklist');
     restored.submitAnswer({ type: 'checklist', checkedIndices: [0, 1] });
     restored.nextItem();
     expect(restored.currentItem?.type).toBe('code');
-    restored.submitAnswer({ type: 'code', code: 'test' });
+    await restored.submitCodeAnswer({ type: 'code', code: 'test' });
     restored.nextItem();
     expect(restored.currentItem?.type).toBe('self-evaluation');
   });


### PR DESCRIPTION
## Summary

- Add a provider-backed code evaluation prompt and `CodeEvaluator` that asks the AI tutor for `correct` / `partial` / `incorrect` plus feedback without executing student code
- Route code-question submissions through `CourseEngine.submitCodeAnswer`, including a `grading` state, API loading events, mastery updates, and self-evaluation fallback if evaluation fails
- Render tutor feedback in the Svelte learn flow as escaped text and hide the normal correct-answer line for AI-graded code feedback

## Cross-package rationale

This touches both packages because the engine owns grading/mastery and the app owns the code-question submission UI and feedback rendering.

## Prompt / fixture coverage

Recorded-format code-evaluation fixtures cover three topics and verdicts: correct TypeScript array helper, partial Python validation helper, and incorrect JavaScript reduce implementation.

## Validation

- `pnpm -r test`
- `pnpm -r build`
- `pnpm format`
- `pnpm format:check`
- Security review: no student code execution, no new direct provider calls outside `packages/engine/src/provider/`, no `{@html}` for tutor feedback

Closes #107
