### PR TITLE
refactor: enforce provider-agnostic boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 - **Engine/App:** Add correlation ids to `apiCallStart` and `apiCallComplete` events, and keep app loading state tied to active API call ids
 - **Engine:** Add `AdaptiveSelector` boundary and integration tests covering gap, default, and proficient quiz burst counts
 - **Scripts:** Guard author-agent `gh pr merge` calls so approved PRs cannot merge while GitHub status checks are failing, pending, cancelled, or absent
-- **Engine:** Type content generation orchestration against provider-agnostic interfaces, with default Claude construction isolated inside the provider layer
+- **Engine/App:** Complete the provider-agnostic refactor by removing concrete `ClaudeProvider` exports from the engine index and updating the app to use the provider factory
+- **App:** Refactor syllabus analysis flow to use `SyllabusParser` from the engine, centralizing parsing and retry logic
+- **Engine:** Update `SyllabusParser` to throw `ProviderError` with `malformed_response` type for better error categorization in the UI
+- **Engine:** Tighten provider boundary tests to ensure no concrete provider leaks through the main engine index
 - **Engine/App:** Move topic status, review flags, and course progress summary calculations behind engine-owned progress helpers so the app only formats and renders emitted progress data
 - **Engine:** Tighten imported snapshot validation for mastery ranges, question counts, answer-key bounds, and state-aware section/item indices
 - **Engine:** Add import coverage for recoverable error-state snapshots so exports from generation failures restore back to `ready`

--- a/apps/coursequizzer/src/lib/stores/new-course.ts
+++ b/apps/coursequizzer/src/lib/stores/new-course.ts
@@ -4,7 +4,7 @@
 // This module is pure logic — no Svelte, no browser APIs at import time.
 
 import {
-  validateCurriculumPlan,
+  SyllabusParser,
   type CurriculumPlan,
   type ProviderRequest,
   type ProviderResponse,
@@ -22,7 +22,7 @@ export type AnalysisResult =
   | { ok: true; plan: CurriculumPlan }
   | { ok: false; error: string; errorType?: string };
 
-// A sendMessage function matching ClaudeProvider.sendMessage signature.
+// A sendMessage function matching ProviderClient.sendMessage signature.
 // Accepting this as a parameter makes the module testable without real API calls.
 type SendMessageFn = (request: ProviderRequest) => Promise<ProviderResponse>;
 
@@ -44,10 +44,6 @@ export function validateSyllabusInput(text: string): string | null {
   return null;
 }
 
-// --- Error Sanitization ---
-// Delegates to the centralized normalizeError utility, which maps provider,
-// engine, storage, and unknown errors to user-safe messages.
-
 // --- Analysis ---
 
 export async function analyzeSyllabus(
@@ -55,58 +51,17 @@ export async function analyzeSyllabus(
 ): Promise<AnalysisResult> {
   const { syllabusText, sendMessage } = params;
 
-  // Build the prompt using the engine's prompt builder and wire in the
-  // sendMessage function directly (no ClaudeProvider instance needed).
-  const { buildSyllabusAnalysisPrompt } = await import('quizzer-engine');
-
-  const prompt = buildSyllabusAnalysisPrompt(syllabusText);
-  const MAX_TOKENS = 4096;
+  // Use the engine's SyllabusParser, which handles prompt building,
+  // response parsing, and retries.
+  const parser = new SyllabusParser({ sendMessage });
 
   try {
-    let response = await sendMessage({ ...prompt, maxTokens: MAX_TOKENS });
-
-    // Try to extract and validate the plan
-    try {
-      const plan = extractPlan(response);
-      return { ok: true, plan };
-    } catch {
-      // Retry once on malformed response
-      response = await sendMessage({ ...prompt, maxTokens: MAX_TOKENS });
-      try {
-        const plan = extractPlan(response);
-        return { ok: true, plan };
-      } catch {
-        return {
-          ok: false,
-          error: 'The API returned an unexpected response. Please try again.',
-          errorType: 'malformed_response',
-        };
-      }
-    }
+    const plan = await parser.parse(syllabusText);
+    return { ok: true, plan };
   } catch (err) {
     const normalized = normalizeError(err);
     return { ok: false, error: normalized.message, errorType: normalized.category };
   }
-}
-
-// --- Response Extraction ---
-// Extracts and validates the curriculum plan from a provider response.
-
-function extractPlan(response: ProviderResponse): CurriculumPlan {
-  const toolBlock = response.content.find(
-    (block): block is Extract<(typeof response.content)[number], { type: 'tool_use' }> =>
-      block.type === 'tool_use' &&
-      'name' in block &&
-      block.name === 'create_curriculum_plan'
-  );
-
-  if (!toolBlock) {
-    throw new Error(
-      'Syllabus analysis response did not contain a create_curriculum_plan tool use'
-    );
-  }
-
-  return validateCurriculumPlan(toolBlock.input);
 }
 
 // --- Persistence ---

--- a/apps/coursequizzer/src/routes/course/new/+page.svelte
+++ b/apps/coursequizzer/src/routes/course/new/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { ClaudeProvider, type CurriculumPlan } from 'quizzer-engine';
+  import { createDefaultProvider, type CurriculumPlan } from 'quizzer-engine';
   import { getApiKey } from '$lib/stores/api-key.js';
   import {
     analyzeSyllabus,
@@ -51,7 +51,7 @@
     step = 'analyzing';
     analysisError = '';
 
-    const provider = new ClaudeProvider({ apiKey });
+    const provider = createDefaultProvider({ apiKey });
     const result = await analyzeSyllabus({
       syllabusText: syllabusText.trim(),
       sendMessage: (req) => provider.sendMessage(req),

--- a/packages/engine/src/curriculum/SyllabusParser.ts
+++ b/packages/engine/src/curriculum/SyllabusParser.ts
@@ -53,15 +53,12 @@ export class SyllabusParser {
         });
         return this.#extractPlan(response);
       } catch (secondError) {
-        // If it's still failing, throw the error. If it's a ProviderError, keep it.
-        // Otherwise wrap it as malformed_response.
-        if (firstError instanceof ProviderError) {
-          throw firstError;
+        // Prioritize the second error if it's a ProviderError (e.g., rate limit or network during retry)
+        if (secondError instanceof ProviderError) {
+          throw secondError;
         }
-        throw new ProviderError(
-          'malformed_response',
-          firstError instanceof Error ? firstError.message : String(firstError)
-        );
+        // Fall back to the first error (guaranteed to be ProviderError from #extractPlan)
+        throw firstError as ProviderError;
       }
     }
   }

--- a/packages/engine/src/curriculum/SyllabusParser.ts
+++ b/packages/engine/src/curriculum/SyllabusParser.ts
@@ -10,10 +10,11 @@
 // ProviderRequest/ProviderResponse types.
 
 import { buildSyllabusAnalysisPrompt } from '../prompts/syllabus-analysis.js';
-import type {
-  ProviderClient,
-  ProviderResponse,
-  ToolUseBlock,
+import {
+  ProviderError,
+  type ProviderClient,
+  type ProviderResponse,
+  type ToolUseBlock,
 } from '../provider/types.js';
 import type { CurriculumPlan, Section, Topic } from './types.js';
 
@@ -51,9 +52,16 @@ export class SyllabusParser {
           maxTokens: MAX_TOKENS,
         });
         return this.#extractPlan(response);
-      } catch {
-        // Throw the original error — it's more informative
-        throw firstError;
+      } catch (secondError) {
+        // If it's still failing, throw the error. If it's a ProviderError, keep it.
+        // Otherwise wrap it as malformed_response.
+        if (firstError instanceof ProviderError) {
+          throw firstError;
+        }
+        throw new ProviderError(
+          'malformed_response',
+          firstError instanceof Error ? firstError.message : String(firstError)
+        );
       }
     }
   }
@@ -67,12 +75,20 @@ export class SyllabusParser {
     );
 
     if (!toolBlock) {
-      throw new Error(
+      throw new ProviderError(
+        'malformed_response',
         'Syllabus analysis response did not contain a create_curriculum_plan tool use'
       );
     }
 
-    return validateCurriculumPlan(toolBlock.input);
+    try {
+      return validateCurriculumPlan(toolBlock.input);
+    } catch (err) {
+      throw new ProviderError(
+        'malformed_response',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
   }
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,7 +1,6 @@
 export { CourseEngine } from './engine/CourseEngine.js';
 export { SNAPSHOT_VERSION } from './engine/constants.js';
 export { InvalidTransitionError, EngineError } from './engine/errors.js';
-export { ClaudeProvider } from './provider/ClaudeProvider.js';
 export { createDefaultProvider } from './provider/factory.js';
 export { RateLimiter } from './provider/rate-limiter.js';
 export { ProviderError } from './provider/types.js';
@@ -97,5 +96,4 @@ export type {
 
 export type { QualityIssue } from './content/quality-filters.js';
 export type { TopicContentGenerator } from './content/ContentGenerator.js';
-export type { ClaudeProviderConfig } from './provider/ClaudeProvider.js';
 export type { RateLimiterConfig } from './provider/rate-limiter.js';

--- a/packages/engine/tests/provider-boundary.test.ts
+++ b/packages/engine/tests/provider-boundary.test.ts
@@ -35,7 +35,7 @@ describe('provider boundary', () => {
     const violations = collectSourceFiles(sourceRoot)
       .filter((filePath) => {
         const path = sourcePath(filePath);
-        return !path.startsWith('provider/') && path !== 'index.ts';
+        return !path.startsWith('provider/');
       })
       .filter((filePath) => {
         const contents = readFileSync(filePath, 'utf8');

--- a/packages/engine/tests/provider.test.ts
+++ b/packages/engine/tests/provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ClaudeProvider, ProviderError, RateLimiter } from '../src/index.js';
+import { ClaudeProvider } from '../src/provider/ClaudeProvider.js';
+import { ProviderError, RateLimiter } from '../src/index.js';
 import type { ProviderRequest } from '../src/index.js';
 
 // --- Mock Fetch ---


### PR DESCRIPTION
## Summary

This PR completes the provider-agnostic refactor initiated in Phase 3 by enforcing the boundary between the provider layer and the rest of the engine/app.

- **Engine:** Removed concrete `ClaudeProvider` and `ClaudeProviderConfig` exports from the main engine index. Consumers must now use `createDefaultProvider` or provide their own `ProviderClient` implementation.
- **Engine:** Updated `SyllabusParser` to throw `ProviderError` with `malformed_response` type instead of generic errors, allowing the app to show categorized user-friendly messages.
- **Engine:** Tightened `provider-boundary.test.ts` to also check `index.ts`, ensuring no concrete provider leaks through the public API.
- **App:** Updated the new course flow to use `createDefaultProvider` instead of `new ClaudeProvider`.
- **App:** Refactored `analyzeSyllabus` to use the engine's `SyllabusParser` instead of re-implementing parsing and retry logic locally.
- **Tests:** Updated engine tests to import `ClaudeProvider` directly from the provider layer.

## Verification

- `pnpm -r test` passes
- `pnpm -r build` passes
- `pnpm format` run
- Verified boundary test checks `index.ts`

Closes #95