### PR TITLE
feat(scripts): add Claude as last-resort fallback after Codex and Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Scripts:** Add Claude as a last-resort fallback after Codex and Gemini in `author.sh` and `reviewer.sh`. Claude fires only when both free tiers are in cooldown, preserving Pro-plan budget for the planner role.
+
 ## 0.9.2 — 2026-06-07
 
 ### Fixes

--- a/scripts/author.sh
+++ b/scripts/author.sh
@@ -2,8 +2,9 @@
 # Author agent loop.
 # Each invocation does one thing (revise a PR or implement an issue), then exits.
 # If work was done, immediately checks for more. Only sleeps when idle.
-# Falls back through Codex → Gemini if a model runs out of credits.
-# Claude is intentionally excluded — it's reserved for the planner role.
+# Falls back through Codex → Gemini → Claude if a model runs out of credits.
+# Claude is last-resort only — the planner reserves Pro-plan budget, so it
+# fires only when both free tiers are in cooldown.
 # Retries on transient errors (network, GitHub). Logs errors for later review.
 #
 # Usage: ./scripts/author.sh
@@ -194,9 +195,32 @@ run_agent() {
         if is_out_of_credits "$output"; then
             set_cooldown "gemini"
             echo "$(date): Gemini out of credits, set 1h cooldown." | tee -a "$logfile"
-            log_error "All models exhausted (Gemini hit limit)."
         else
             log_error "Gemini failed with exit code $status."
+            return 1
+        fi
+    fi
+
+    # Try Claude (last resort — burns Pro-plan budget reserved for the planner)
+    if check_cooldown "claude"; then
+        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
+    else
+        echo "$(date): Trying Claude (last-resort fallback)..." | tee -a "$logfile"
+        if output=$(claude -p "$prompt" --dangerously-skip-permissions 2>&1); then
+            status=0
+        else
+            status=$?
+        fi
+        echo "$output" | tee -a "$logfile"
+        if [ "$status" -eq 0 ]; then
+            return 0
+        fi
+        if is_out_of_credits "$output"; then
+            set_cooldown "claude"
+            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
+            log_error "All models exhausted (Claude hit limit)."
+        else
+            log_error "Claude failed with exit code $status."
         fi
     fi
     return 1

--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -2,8 +2,9 @@
 # Reviewer agent loop.
 # Each invocation reviews one PR (or exits if nothing to review).
 # If work was done, immediately checks for more. Only sleeps when idle.
-# Falls back through Codex → Gemini if a model runs out of credits.
-# Claude is intentionally excluded — it's reserved for the planner role.
+# Falls back through Codex → Gemini → Claude if a model runs out of credits.
+# Claude is last-resort only — the planner reserves Pro-plan budget, so it
+# fires only when both free tiers are in cooldown.
 # Retries on transient errors (network, GitHub). Logs errors for later review.
 #
 # Usage: ./scripts/reviewer.sh
@@ -154,9 +155,32 @@ run_agent() {
         if is_out_of_credits "$output"; then
             set_cooldown "gemini"
             echo "$(date): Gemini out of credits, set 1h cooldown." | tee -a "$logfile"
-            log_error "All models exhausted (Gemini hit limit)."
         else
             log_error "Gemini failed with exit code $status."
+            return 1
+        fi
+    fi
+
+    # Try Claude (last resort — burns Pro-plan budget reserved for the planner)
+    if check_cooldown "claude"; then
+        echo "$(date): Skipping Claude (cooldown active)..." | tee -a "$logfile"
+    else
+        echo "$(date): Trying Claude (last-resort fallback)..." | tee -a "$logfile"
+        if output=$(claude -p "$prompt" --dangerously-skip-permissions 2>&1); then
+            status=0
+        else
+            status=$?
+        fi
+        echo "$output" | tee -a "$logfile"
+        if [ "$status" -eq 0 ]; then
+            return 0
+        fi
+        if is_out_of_credits "$output"; then
+            set_cooldown "claude"
+            echo "$(date): Claude out of credits, set 1h cooldown." | tee -a "$logfile"
+            log_error "All models exhausted (Claude hit limit)."
+        else
+            log_error "Claude failed with exit code $status."
         fi
     fi
     return 1


### PR DESCRIPTION
## Summary

- Author and reviewer scripts cascaded **Codex → Gemini** only (PR #76 removed Claude to protect Pro-plan budget). With Codex's 10x promo expired and both free tiers exhausted this morning at 01:18 PDT, the factory dead-ends.
- Add **Claude as a third tier** with the same `is_out_of_credits` + 1h cooldown plumbing. Order preserves the "don't burn Pro plan unless we have to" principle — Claude only fires when both free tiers are in cooldown.
- Also: a non-credit Gemini failure now returns 1 instead of falling through to Claude, matching Codex's pattern. The "All models exhausted" log moves to the Claude block.

Planner-direct PR (no issue) — scripts/* change, precedent: PRs #75, #76, #77, #81, #92, #93, #112.

## Test plan

- [x] `bash -n scripts/author.sh && bash -n scripts/reviewer.sh` clean
- [ ] After merge: restart agents on both machines so they pick up the new cascade
- [ ] Watch the next idle Codex-exhausted run — should see `Trying Claude (last-resort fallback)...` in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)